### PR TITLE
Fix sourcehunt trajectory growth and verifier evidence merging

### DIFF
--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -219,6 +219,7 @@ class HunterTrajectoryLogger:
         *,
         prompt: str,
         initial_messages: list[ChatMessage],
+        tools: list[NativeToolSpec],
     ) -> HunterTrajectoryLogger:
         path = _trajectory_path(ctx)
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -230,10 +231,18 @@ class HunterTrajectoryLogger:
                 "file_path": ctx.file_path,
                 "specialist": ctx.specialist,
                 "prompt": prompt,
-                "initial_messages": [_serialize_message(msg) for msg in initial_messages],
+                "tools": [tool.name for tool in tools],
                 "seeded_crash": ctx.seeded_crash,
             },
         )
+        for message in initial_messages:
+            logger_obj.log(
+                "message",
+                {
+                    "step": 0,
+                    "message": _serialize_message(message),
+                },
+            )
         return logger_obj
 
     def log(self, event: str, payload: dict[str, Any]) -> None:
@@ -812,6 +821,7 @@ class NativeHunter:
             self.ctx,
             prompt=self.prompt,
             initial_messages=messages,
+            tools=self.tools,
         )
         total_input_tokens = 0
         total_output_tokens = 0
@@ -820,26 +830,22 @@ class NativeHunter:
         tools_by_name = {tool.name: tool for tool in self.tools}
 
         for step in range(1, self.max_steps + 1):
-            trajectory.log(
-                "request",
-                {
-                    "step": step,
-                    "system": self.prompt,
-                    "messages": [_serialize_message(message) for message in messages],
-                    "tools": [tool.name for tool in self.tools],
-                },
-            )
             response = await self.llm.achat(
                 messages=messages,
                 system=self.prompt,
                 tools=self.tools,
             )
             trajectory.log(
-                "assistant_response",
+                "message",
                 {
                     "step": step,
-                    "text": response.text,
-                    "tool_calls": [_serialize_tool_call(tc) for tc in response.tool_calls],
+                    "message": _serialize_message(
+                        ChatMessage(
+                            "assistant",
+                            response.text or "",
+                            tool_calls=response.tool_calls,
+                        )
+                    ),
                     "usage": {
                         "input_tokens": response.usage.prompt_tokens or 0,
                         "output_tokens": response.usage.completion_tokens or 0,
@@ -918,6 +924,13 @@ class NativeHunter:
                             tool_summary,
                             tool_response_call_id=tool_call.call_id,
                         )
+                    )
+                    trajectory.log(
+                        "message",
+                        {
+                            "step": step,
+                            "message": _serialize_message(messages[-1]),
+                        },
                     )
                 continue
 

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -16,6 +16,7 @@ import subprocess
 import time
 import uuid
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from clearwing.llm.native import AsyncLLMClient
@@ -172,6 +173,7 @@ class SourceHuntRunner:
 
     def run(self) -> SourceHuntResult:
         start_time = time.monotonic()
+        self._ensure_output_dir_layout()
         logger.info("Sourcehunt session %s starting on %s", self._session_id, self.repo_url)
         try:
             # 1. Preprocess
@@ -571,6 +573,11 @@ class SourceHuntRunner:
         return self._session_id
 
     # --- Pipeline helpers ---------------------------------------------------
+
+    def _ensure_output_dir_layout(self) -> Path:
+        session_dir = Path(self.output_dir) / self._session_id
+        session_dir.mkdir(parents=True, exist_ok=True)
+        return session_dir
 
     def _export_disclosure_bundle(
         self,

--- a/clearwing/sourcehunt/verifier.py
+++ b/clearwing/sourcehunt/verifier.py
@@ -485,7 +485,11 @@ def apply_verifier_result(
     finding["verifier_session_id"] = session_id
     # Bump evidence_level if the verifier confirms a stronger one
     current = finding.get("evidence_level", "suspicion")
+    if current not in EVIDENCE_LEVELS:
+        current = "suspicion"
     new = result.evidence_level
+    if new not in EVIDENCE_LEVELS:
+        new = "suspicion"
     if EVIDENCE_LEVELS.index(new) > EVIDENCE_LEVELS.index(current):
         finding["evidence_level"] = new
     # v0.3: patch-oracle outcome
@@ -495,6 +499,8 @@ def apply_verifier_result(
         # validated — the fix actually killed the crash).
         if result.patch_oracle_passed:
             level = finding.get("evidence_level", "suspicion")
+            if level not in EVIDENCE_LEVELS:
+                level = "suspicion"
             if EVIDENCE_LEVELS.index("root_cause_explained") > EVIDENCE_LEVELS.index(level):
                 finding["evidence_level"] = "root_cause_explained"
     return finding

--- a/tests/test_sourcehunt_hunter.py
+++ b/tests/test_sourcehunt_hunter.py
@@ -12,7 +12,11 @@ These tests verify:
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -26,6 +30,7 @@ from clearwing.agent.tools.hunt import (
 )
 from clearwing.sandbox.container import ExecResult
 from clearwing.sourcehunt.hunter import (
+    NativeHunter,
     _build_hunter_prompt,
     _build_propagation_prompt,
     _choose_specialist,
@@ -433,6 +438,72 @@ class TestBuildHunterAgent:
             variant_seed={"original": "ignored in v0.1"},
         )
         assert ctx.seeded_crash is not None
+
+
+class TestHunterTrajectoryLogging:
+    def test_trajectory_is_append_log_of_turns(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLEARWING_HOME", str(tmp_path))
+
+        class _StubLLM:
+            model_name = "stub-model"
+
+            async def achat(self, *, messages, system, tools):
+                assert system == "system prompt"
+                assert len(messages) == 1
+                return SimpleNamespace(
+                    text="No findings.",
+                    tool_calls=[],
+                    usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7, total_tokens=18),
+                    provider_model_name="stub-provider",
+                )
+
+        ctx = HunterContext(
+            repo_path=str(FIXTURE_C_PROPAGATION),
+            findings=[],
+            file_path="src/codec_a.c",
+            session_id="traj-test",
+            specialist="general",
+        )
+        hunter = NativeHunter(
+            llm=_StubLLM(),
+            prompt="system prompt",
+            tools=[],
+            ctx=ctx,
+            max_steps=1,
+        )
+
+        findings, _, _ = asyncio.run(hunter.arun())
+
+        assert findings == []
+
+        trajectory_path = (
+            Path(os.environ["CLEARWING_HOME"])
+            / "sourcehunt"
+            / "trajectories"
+            / "traj-test"
+            / "src__codec_a.c.jsonl"
+        )
+        records = [
+            json.loads(line) for line in trajectory_path.read_text(encoding="utf-8").splitlines()
+        ]
+        start = next(record for record in records if record["event"] == "start")
+        messages = [record for record in records if record["event"] == "message"]
+
+        assert start["prompt"] == "system prompt"
+        assert start["tools"] == []
+        assert len(messages) == 2
+        assert messages[0]["step"] == 0
+        assert messages[0]["message"]["role"] == "user"
+        assert messages[0]["message"]["content"] == "Hunt for vulnerabilities in src/codec_a.c."
+        assert messages[1]["step"] == 1
+        assert messages[1]["message"]["role"] == "assistant"
+        assert messages[1]["message"]["content"] == "No findings."
+        assert messages[1]["usage"] == {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "total_tokens": 18,
+        }
+        assert all(record["event"] != "request" for record in records)
 
 
 # --- Hunter tools (host fallback paths) -------------------------------------

--- a/tests/test_sourcehunt_runner.py
+++ b/tests/test_sourcehunt_runner.py
@@ -107,6 +107,22 @@ def _make_verifier_llm() -> MagicMock:
 
 
 class TestQuickDepth:
+    def test_session_dir_exists_even_if_run_fails_early(self, tmp_path, monkeypatch):
+        runner = SourceHuntRunner(
+            repo_url=str(FIXTURE_C_PROPAGATION),
+            local_path=str(FIXTURE_C_PROPAGATION),
+            depth="quick",
+            output_dir=str(tmp_path),
+        )
+        monkeypatch.setattr(
+            runner, "_preprocess", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            runner.run()
+
+        assert (tmp_path / runner.session_id).is_dir()
+
     def test_quick_runs_without_hunter_llm(self, tmp_path):
         runner = SourceHuntRunner(
             repo_url=str(FIXTURE_C_PROPAGATION),

--- a/tests/test_sourcehunt_verifier.py
+++ b/tests/test_sourcehunt_verifier.py
@@ -648,3 +648,18 @@ class TestApplyVerifierResult:
         apply_verifier_result(finding, result)
         assert finding["verified"] is False
         assert finding["severity_verified"] is None
+
+    def test_invalid_existing_evidence_level_falls_back_to_suspicion(self):
+        finding = _make_finding(evidence_level="made_up_level")
+        result = VerifierResult(
+            finding_id="x",
+            is_real=True,
+            severity_verified="high",
+            evidence_level="crash_reproduced",
+            pro_argument="",
+            counter_argument="",
+            tie_breaker="",
+            duplicate_cve=None,
+        )
+        apply_verifier_result(finding, result)
+        assert finding["evidence_level"] == "crash_reproduced"


### PR DESCRIPTION
## Summary
- make sourcehunt hunter trajectories append-only turn logs instead of replaying full prompt/history each step
- create sourcehunt output session directories eagerly at run start
- normalize unknown evidence levels during verifier result merge instead of crashing

## Validation
- uv run python -m pytest -q --strict-markers --strict-config tests/test_sourcehunt_verifier.py tests/test_sourcehunt_runner.py tests/test_sourcehunt_hunter.py
- 111 passed

## Notes
- this is a follow-up PR on top of the already-merged native sourcehunt work
- untracked local repos and run artifacts were intentionally left out of the commit