### PR TITLE
Add streaming via genai-pyo3 astream_chat and web frontend

### DIFF
--- a/clearwing/agent/runtime.py
+++ b/clearwing/agent/runtime.py
@@ -6,6 +6,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
+from collections.abc import Callable
 from typing import Any, TypedDict
 
 import networkx as nx
@@ -119,7 +120,7 @@ class NativeAgentGraph:
         self.knowledge_graph_populator_fn = knowledge_graph_populator_fn
         self.input_guardrail_tool_names = set(input_guardrail_tool_names)
         self.output_guardrail_tool_names = set(output_guardrail_tool_names)
-        self.on_text_delta: Any = None  # optional streaming callback
+        self.on_text_delta: Callable[[str], None] | None = None
         self._state: dict[str, dict[str, Any]] = {}
         self._pending: dict[str, _PendingToolResume | None] = {}
 

--- a/clearwing/agent/runtime.py
+++ b/clearwing/agent/runtime.py
@@ -119,6 +119,7 @@ class NativeAgentGraph:
         self.knowledge_graph_populator_fn = knowledge_graph_populator_fn
         self.input_guardrail_tool_names = set(input_guardrail_tool_names)
         self.output_guardrail_tool_names = set(output_guardrail_tool_names)
+        self.on_text_delta: Any = None  # optional streaming callback
         self._state: dict[str, dict[str, Any]] = {}
         self._pending: dict[str, _PendingToolResume | None] = {}
 
@@ -237,7 +238,9 @@ class NativeAgentGraph:
 
         sys_prompt = self.system_prompt_fn(state)
         full_messages: list[BaseMessage] = [SystemMessage(content=sys_prompt), *messages]
-        response = await self.llm_with_tools.ainvoke(full_messages)
+        response = await self.llm_with_tools.ainvoke(
+            full_messages, on_text_delta=self.on_text_delta
+        )
         state.setdefault("messages", []).append(response)
 
         usage = getattr(response, "response_metadata", {}).get("usage", {})

--- a/clearwing/llm/chat.py
+++ b/clearwing/llm/chat.py
@@ -234,13 +234,21 @@ class ChatModel:
             },
         )
 
-    async def ainvoke(self, messages: Any) -> AIMessage:
+    async def ainvoke(self, messages: Any, on_text_delta: Any = None) -> AIMessage:
         system, chat_messages = _coerce_chat_messages(messages)
-        response = await self._client.achat(
-            messages=chat_messages,
-            system=system or self.default_system,
-            tools=self.bound_tools or None,
-        )
+        if on_text_delta is not None:
+            response = await self._client.achat_stream(
+                messages=chat_messages,
+                system=system or self.default_system,
+                tools=self.bound_tools or None,
+                on_text_delta=on_text_delta,
+            )
+        else:
+            response = await self._client.achat(
+                messages=chat_messages,
+                system=system or self.default_system,
+                tools=self.bound_tools or None,
+            )
         return AIMessage(
             content=response.first_text() or "",
             tool_calls=[

--- a/clearwing/llm/chat.py
+++ b/clearwing/llm/chat.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -234,7 +234,7 @@ class ChatModel:
             },
         )
 
-    async def ainvoke(self, messages: Any, on_text_delta: Any = None) -> AIMessage:
+    async def ainvoke(self, messages: Any, on_text_delta: Callable[[str], None] | None = None) -> AIMessage:
         system, chat_messages = _coerce_chat_messages(messages)
         if on_text_delta is not None:
             response = await self._client.achat_stream(

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -189,6 +189,60 @@ class AsyncLLMClient:
             )
         return response
 
+    async def achat_stream(
+        self,
+        *,
+        messages: list[ChatMessage],
+        system: str | None = None,
+        tools: list[NativeToolSpec] | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        on_text_delta: Any = None,
+    ) -> ChatResponse:
+        """Like ``achat`` but streams text deltas via *on_text_delta*.
+
+        Uses genai-pyo3's native ``astream_chat``. Falls back to
+        non-streaming ``achat`` when no callback is given.
+        """
+        if on_text_delta is None:
+            return await self.achat(
+                messages=messages, system=system, tools=tools,
+                temperature=temperature, max_tokens=max_tokens,
+            )
+
+        request_tools = None
+        if tools:
+            request_tools = [
+                Tool(tool.name, tool.description, json.dumps(tool.schema))
+                for tool in tools
+            ]
+        request = ChatRequest(
+            messages=list(messages),
+            system=system or self.default_system,
+            tools=request_tools,
+        )
+        options = ChatOptions(
+            temperature=temperature,
+            max_tokens=max_tokens,
+            capture_content=True,
+            capture_usage=True,
+            capture_tool_calls=True,
+        )
+
+        async with self._semaphore:
+            client = self._build_client(Client)
+            stream = await client.astream_chat(self.model_name, request, options)
+            async for event in stream:
+                if event.content and on_text_delta is not None:
+                    on_text_delta(event.content)
+                if event.end is not None:
+                    return event.end
+        # Fallback if stream ends without an end event
+        return await self.achat(
+            messages=messages, system=system, tools=tools,
+            temperature=temperature, max_tokens=max_tokens,
+        )
+
     def chat(self, **kwargs: Any) -> ChatResponse:
         return _run_coro_sync(self.achat(**kwargs))
 

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -5,6 +5,7 @@ import json
 import logging
 import random
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -197,7 +198,7 @@ class AsyncLLMClient:
         tools: list[NativeToolSpec] | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
-        on_text_delta: Any = None,
+        on_text_delta: Callable[[str], None] | None = None,
     ) -> ChatResponse:
         """Like ``achat`` but streams text deltas via *on_text_delta*.
 
@@ -233,7 +234,7 @@ class AsyncLLMClient:
             client = self._build_client(Client)
             stream = await client.astream_chat(self.model_name, request, options)
             async for event in stream:
-                if event.content and on_text_delta is not None:
+                if event.content:
                     on_text_delta(event.content)
                 if event.end is not None:
                     return event.end

--- a/clearwing/ui/commands/interactive.py
+++ b/clearwing/ui/commands/interactive.py
@@ -193,6 +193,66 @@ def _run_interactive_legacy(cli, args, session=None):
     if args.target:
         cli.console.print(f"[blue]Target set to: {args.target}[/blue]")
 
+    class _StreamPrinter:
+        def __init__(self, console):
+            self._console = console
+            self._in_think = False
+            self._buf = ""
+            self._started = False
+
+        def reset(self):
+            self._in_think = False
+            self._buf = ""
+            self._started = False
+
+        def __call__(self, delta: str):
+            self._buf += delta
+            while True:
+                if self._in_think:
+                    end = self._buf.find("</think>")
+                    if end == -1:
+                        self._buf = self._buf[-8:]
+                        return
+                    self._buf = self._buf[end + 8:]
+                    self._in_think = False
+                    continue
+                start = self._buf.find("<think>")
+                if start == -1:
+                    safe = len(self._buf)
+                    for i in range(1, min(7, len(self._buf) + 1)):
+                        if self._buf.endswith("<think>"[:i]):
+                            safe = len(self._buf) - i
+                            break
+                    if safe > 0:
+                        text = self._buf[:safe]
+                        self._buf = self._buf[safe:]
+                        if text:
+                            if not self._started:
+                                self._console.print("\n[bold cyan]Agent:[/bold cyan] ", end="")
+                                self._started = True
+                            self._console.print(text, end="", highlight=False)
+                    return
+                if start > 0:
+                    if not self._started:
+                        self._console.print("\n[bold cyan]Agent:[/bold cyan] ", end="")
+                        self._started = True
+                    self._console.print(self._buf[:start], end="", highlight=False)
+                self._buf = self._buf[start + 7:]
+                self._in_think = True
+
+        def finish(self):
+            if self._buf and not self._in_think:
+                if not self._started:
+                    self._console.print("\n[bold cyan]Agent:[/bold cyan] ", end="")
+                    self._started = True
+                self._console.print(self._buf, end="", highlight=False)
+                self._buf = ""
+            if self._started:
+                self._console.print()
+
+    stream_printer = _StreamPrinter(cli.console)
+    graph.on_text_delta = stream_printer
+
     known_custom_tools = set()
 
     while True:
@@ -207,6 +267,8 @@ def _run_interactive_legacy(cli, args, session=None):
         if not user_input.strip():
             continue
 
+        stream_printer.reset()
+
         input_msg = {"messages": [{"role": "user", "content": user_input}]}
         input_msg.update(initial_state)
         initial_state = {}
@@ -219,31 +281,9 @@ def _run_interactive_legacy(cli, args, session=None):
                 events = asyncio.run(_collect_events(graph, input_msg))
                 interrupted = False
 
-                last_msg_count = 0
-                for event in events:
-                    msgs = event.get("messages", [])
-                    if len(msgs) <= last_msg_count:
-                        continue
-                    last_msg_count = len(msgs)
-                    last = msgs[-1]
-                    if hasattr(last, "content") and last.content and last.type == "ai":
-                        content = last.content
-                        if isinstance(content, list):
-                            text_parts = [
-                                c["text"]
-                                for c in content
-                                if isinstance(c, dict) and c.get("type") == "text"
-                            ]
-                            content = "\n".join(text_parts)
-                        content = strip_think_tags(content)
-                        if content:
-                            cli.console.print(
-                                Panel(
-                                    content,
-                                    title="[bold cyan]Agent[/bold cyan]",
-                                    border_style="cyan",
-                                )
-                            )
+                stream_printer.finish()
+                for _event in events:
+                    pass  # streaming callback already printed text
 
                 # Check for interrupt
                 state = graph.get_state(config)

--- a/clearwing/ui/web/app.py
+++ b/clearwing/ui/web/app.py
@@ -6,9 +6,12 @@ import logging
 import uuid
 from typing import Any
 
+from pathlib import Path
+
 from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 import clearwing.data.memory as memory_data
 import clearwing.observability.telemetry as telemetry
@@ -16,6 +19,7 @@ from clearwing.agent.graph import create_agent
 from clearwing.agent.operator import OperatorAgent, OperatorConfig
 from clearwing.agent.runtime import Command
 from clearwing.core.events import EventBus, EventType
+from clearwing.llm.native import strip_think_tags
 from clearwing.observability import MetricsCollector
 
 logger = logging.getLogger(__name__)
@@ -44,6 +48,15 @@ def create_app():
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Serve the single-page frontend
+    _static_dir = Path(__file__).parent / "static"
+
+    @app.get("/")
+    async def index():
+        return FileResponse(_static_dir / "index.html")
+
+    app.mount("/static", StaticFiles(directory=str(_static_dir)), name="static")
 
     # In-memory session registry
     _sessions: dict[str, dict[str, Any]] = {}
@@ -323,12 +336,14 @@ def create_app():
                                     if c:
                                         last_content = c
                         if last_content:
-                            await websocket.send_json(
-                                {
-                                    "type": "agent_message",
-                                    "data": {"content": last_content},
-                                }
-                            )
+                            cleaned = strip_think_tags(last_content)
+                            if cleaned:
+                                await websocket.send_json(
+                                    {
+                                        "type": "agent_message",
+                                        "data": {"content": cleaned},
+                                    }
+                                )
                     except Exception as e:
                         await websocket.send_json(
                             {

--- a/clearwing/ui/web/static/index.html
+++ b/clearwing/ui/web/static/index.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Clearwing</title>
+<style>
+  :root {
+    --bg: #0d1117; --surface: #161b22; --border: #30363d;
+    --text: #c9d1d9; --dim: #8b949e; --accent: #58a6ff;
+    --green: #3fb950; --red: #f85149; --yellow: #d29922; --purple: #bc8cff;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', monospace;
+         background: var(--bg); color: var(--text); height: 100vh;
+         display: flex; flex-direction: column; }
+  header { background: var(--surface); border-bottom: 1px solid var(--border);
+           padding: 12px 20px; display: flex; align-items: center; gap: 16px; }
+  header h1 { font-size: 16px; color: var(--accent); font-weight: 600; }
+  header .status { font-size: 12px; color: var(--dim); }
+  header .status.connected { color: var(--green); }
+
+  #setup { padding: 20px; max-width: 500px; margin: 40px auto; }
+  #setup label { display: block; color: var(--dim); font-size: 12px;
+                 margin-top: 12px; margin-bottom: 4px; }
+  #setup input { width: 100%; padding: 8px 12px; background: var(--surface);
+                 border: 1px solid var(--border); border-radius: 6px;
+                 color: var(--text); font-size: 14px; }
+  #setup button { margin-top: 20px; width: 100%; padding: 10px;
+                  background: var(--accent); color: #fff; border: none;
+                  border-radius: 6px; font-size: 14px; cursor: pointer; }
+  #setup button:hover { opacity: 0.9; }
+
+  #chat { flex: 1; display: none; flex-direction: column; overflow: hidden; }
+  #messages { flex: 1; overflow-y: auto; padding: 16px 20px; }
+  .msg { margin-bottom: 12px; padding: 10px 14px; border-radius: 8px;
+         max-width: 85%; white-space: pre-wrap; word-wrap: break-word;
+         font-size: 13px; line-height: 1.5; }
+  .msg.user { background: #1f3a5f; margin-left: auto; }
+  .msg.agent { background: var(--surface); border: 1px solid var(--border); }
+  .msg.tool { background: #1a1e24; border-left: 3px solid var(--accent);
+              font-size: 12px; color: var(--dim); }
+  .msg.error { background: #2d1215; border: 1px solid var(--red); color: var(--red); }
+  .msg.flag { background: #2a1a2e; border: 1px solid var(--purple);
+              color: var(--purple); font-weight: bold; }
+  .msg.approval { background: #2a2000; border: 1px solid var(--yellow); }
+  .msg.approval button { margin: 8px 8px 0 0; padding: 4px 16px;
+                         border-radius: 4px; border: 1px solid; cursor: pointer;
+                         font-size: 12px; background: transparent; }
+  .msg.approval .approve { color: var(--green); border-color: var(--green); }
+  .msg.approval .deny { color: var(--red); border-color: var(--red); }
+  .msg .label { font-size: 11px; color: var(--dim); margin-bottom: 4px; }
+
+  #input-bar { border-top: 1px solid var(--border); padding: 12px 20px;
+               display: flex; gap: 10px; background: var(--surface); }
+  #input-bar input { flex: 1; padding: 10px 14px; background: var(--bg);
+                     border: 1px solid var(--border); border-radius: 6px;
+                     color: var(--text); font-size: 14px; }
+  #input-bar button { padding: 10px 20px; background: var(--accent); color: #fff;
+                      border: none; border-radius: 6px; cursor: pointer; }
+
+  footer { background: var(--surface); border-top: 1px solid var(--border);
+           padding: 6px 20px; font-size: 11px; color: var(--dim);
+           display: flex; gap: 20px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>Clearwing</h1>
+  <span id="conn-status" class="status">Disconnected</span>
+  <span id="session-info" class="status"></span>
+</header>
+
+<div id="setup">
+  <h2 style="color:var(--text);margin-bottom:8px;">Start Session</h2>
+  <label>Target (IP / hostname / CIDR)</label>
+  <input id="target" placeholder="e.g. 192.168.1.0/24">
+  <label>Model</label>
+  <input id="model" value="MiniMax-M2.7">
+  <label>Base URL</label>
+  <input id="base-url" placeholder="https://api.minimax.io/v1">
+  <label>API Key</label>
+  <input id="api-key" type="password" placeholder="sk-...">
+  <button onclick="startSession()">Connect</button>
+</div>
+
+<div id="chat">
+  <div id="messages"></div>
+  <div id="input-bar">
+    <input id="msg-input" placeholder="Type a message..." autofocus
+           onkeydown="if(event.key==='Enter')sendMessage()">
+    <button onclick="sendMessage()">Send</button>
+  </div>
+</div>
+
+<footer>
+  <span id="cost">Cost: $0.00</span>
+  <span id="tokens">Tokens: 0</span>
+</footer>
+
+<script>
+const THINK_RE = /<think>[\s\S]*?<\/think>\s*/g;
+let ws = null;
+
+function addMessage(text, cls) {
+  const el = document.createElement('div');
+  el.className = 'msg ' + cls;
+  el.textContent = text;
+  document.getElementById('messages').appendChild(el);
+  el.scrollIntoView({behavior: 'smooth'});
+  return el;
+}
+
+function addHtml(html, cls) {
+  const el = document.createElement('div');
+  el.className = 'msg ' + cls;
+  el.innerHTML = html;
+  document.getElementById('messages').appendChild(el);
+  el.scrollIntoView({behavior: 'smooth'});
+  return el;
+}
+
+function startSession() {
+  const target = document.getElementById('target').value;
+  const model = document.getElementById('model').value;
+  const baseUrl = document.getElementById('base-url').value;
+  const apiKey = document.getElementById('api-key').value;
+
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  ws = new WebSocket(`${proto}://${location.host}/ws/agent`);
+
+  ws.onopen = () => {
+    document.getElementById('conn-status').textContent = 'Connected';
+    document.getElementById('conn-status').className = 'status connected';
+    document.getElementById('setup').style.display = 'none';
+    document.getElementById('chat').style.display = 'flex';
+
+    ws.send(JSON.stringify({
+      type: 'start', target, model,
+      base_url: baseUrl || undefined,
+      api_key: apiKey || undefined,
+    }));
+  };
+
+  ws.onclose = () => {
+    document.getElementById('conn-status').textContent = 'Disconnected';
+    document.getElementById('conn-status').className = 'status';
+    addMessage('Connection closed.', 'error');
+  };
+
+  ws.onmessage = (event) => {
+    const msg = JSON.parse(event.data);
+    const data = msg.data || {};
+    switch (msg.type) {
+      case 'started':
+        document.getElementById('session-info').textContent =
+          `Session: ${msg.session_id} | Model: ${msg.model}`;
+        addMessage(`Session started. Target: ${msg.target || '(none)'}`, 'tool');
+        break;
+      case 'agent_message': {
+        let content = typeof data === 'string' ? data :
+                      (data.content || data.text || JSON.stringify(data));
+        content = content.replace(THINK_RE, '');
+        if (content.trim()) addMessage(content.trim(), 'agent');
+        break;
+      }
+      case 'tool_start':
+        addMessage(`>>> ${data.tool || data.name || 'tool'} ${JSON.stringify(data.args || {}).slice(0, 100)}`, 'tool');
+        break;
+      case 'tool_result':
+        addMessage(`<<< ${data.tool || data.name || 'tool'} (${data.content_length || '?'} bytes)`, 'tool');
+        break;
+      case 'flag_found':
+        addMessage(`FLAG: ${data.flag || JSON.stringify(data)}`, 'flag');
+        break;
+      case 'cost_update':
+        document.getElementById('cost').textContent = `Cost: $${(data.cost_usd || 0).toFixed(4)}`;
+        document.getElementById('tokens').textContent = `Tokens: ${data.tokens || 0}`;
+        break;
+      case 'approval_needed': {
+        const prompt = data.prompt || JSON.stringify(data);
+        const el = addHtml(
+          `<div class="label">APPROVAL NEEDED</div>${prompt}<br>` +
+          `<button class="approve" onclick="approve(true,this)">Approve</button>` +
+          `<button class="deny" onclick="approve(false,this)">Deny</button>`,
+          'approval'
+        );
+        break;
+      }
+      case 'error':
+        addMessage(`Error: ${data.message || JSON.stringify(data)}`, 'error');
+        break;
+      case 'complete':
+        addMessage('Agent completed.', 'tool');
+        break;
+    }
+  };
+}
+
+function sendMessage() {
+  const input = document.getElementById('msg-input');
+  const text = input.value.trim();
+  if (!text || !ws) return;
+  addMessage(text, 'user');
+  ws.send(JSON.stringify({type: 'message', content: text}));
+  input.value = '';
+}
+
+function approve(approved, btn) {
+  if (!ws) return;
+  ws.send(JSON.stringify({type: 'approve', approved}));
+  const parent = btn.parentElement;
+  parent.querySelectorAll('button').forEach(b => b.disabled = true);
+  addMessage(approved ? 'Approved.' : 'Denied.', 'tool');
+}
+</script>
+</body>
+</html>

--- a/clearwing/ui/web/static/index.html
+++ b/clearwing/ui/web/static/index.html
@@ -77,7 +77,7 @@
   <label>Target (IP / hostname / CIDR)</label>
   <input id="target" placeholder="e.g. 192.168.1.0/24">
   <label>Model</label>
-  <input id="model" value="MiniMax-M2.7">
+  <input id="model" placeholder="e.g. claude-sonnet-4-6">
   <label>Base URL</label>
   <input id="base-url" placeholder="https://api.minimax.io/v1">
   <label>API Key</label>
@@ -112,10 +112,27 @@ function addMessage(text, cls) {
   return el;
 }
 
-function addHtml(html, cls) {
+function addApproval(prompt) {
   const el = document.createElement('div');
-  el.className = 'msg ' + cls;
-  el.innerHTML = html;
+  el.className = 'msg approval';
+  const label = document.createElement('div');
+  label.className = 'label';
+  label.textContent = 'APPROVAL NEEDED';
+  el.appendChild(label);
+  const text = document.createElement('span');
+  text.textContent = prompt;
+  el.appendChild(text);
+  el.appendChild(document.createElement('br'));
+  const btnApprove = document.createElement('button');
+  btnApprove.className = 'approve';
+  btnApprove.textContent = 'Approve';
+  btnApprove.onclick = () => approve(true, btnApprove);
+  el.appendChild(btnApprove);
+  const btnDeny = document.createElement('button');
+  btnDeny.className = 'deny';
+  btnDeny.textContent = 'Deny';
+  btnDeny.onclick = () => approve(false, btnDeny);
+  el.appendChild(btnDeny);
   document.getElementById('messages').appendChild(el);
   el.scrollIntoView({behavior: 'smooth'});
   return el;
@@ -180,12 +197,7 @@ function startSession() {
         break;
       case 'approval_needed': {
         const prompt = data.prompt || JSON.stringify(data);
-        const el = addHtml(
-          `<div class="label">APPROVAL NEEDED</div>${prompt}<br>` +
-          `<button class="approve" onclick="approve(true,this)">Approve</button>` +
-          `<button class="deny" onclick="approve(false,this)">Deny</button>`,
-          'approval'
-        );
+        addApproval(prompt);
         break;
       }
       case 'error':


### PR DESCRIPTION
## Summary

Two features that improve the interactive experience. Builds on #11.

### Streaming
Uses genai-pyo3's native \`Client.astream_chat()\` for token-by-token output instead of waiting for complete responses.
- \`AsyncLLMClient.achat_stream(on_text_delta=...)\` wraps genai-pyo3's streaming API
- \`ChatModel.ainvoke(on_text_delta=...)\` passes the callback through
- Legacy interactive loop (\`--no-tui\`) prints tokens in real time with a \`_StreamPrinter\` that filters \`<think>\` blocks on the fly

### Web frontend
The FastAPI backend had a WebSocket protocol at \`/ws/agent\` but no frontend. Adds a single-page HTML+JS+CSS app served at \`/\` with:
- Session setup form (target, model, base URL, API key)
- Real-time chat pane with think-tag stripping
- Tool start/result indicators, approval prompts, flag banners
- Cost and token counters, dark theme

## Test plan
- [x] All existing tests pass (1584 passed, 0 failed)
- [x] Smoke test: \`GET /\` returns HTML frontend, \`GET /api/health\` returns ok
- [ ] Manual: streaming output in \`--no-tui\` mode
- [ ] Manual: \`clearwing webui\` and interact via browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)