### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/clearwing/providers/catalog.py
+++ b/clearwing/providers/catalog.py
@@ -188,6 +188,16 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         alt_models=("deepseek-coder",),
     ),
     ProviderPreset(
+        key="minimax",
+        display_name="MiniMax",
+        description="MiniMax-M2.7 — peak performance and value via api.minimax.io.",
+        docs_url="https://platform.minimax.io/",
+        default_base_url="https://api.minimax.io/v1",
+        default_model="MiniMax-M2.7",
+        api_key_env_var="MINIMAX_API_KEY",
+        alt_models=("MiniMax-M2.7-highspeed",),
+    ),
+    ProviderPreset(
         key="custom",
         display_name="Custom OpenAI-compatible endpoint",
         description="Any service that speaks /v1/chat/completions — vLLM, SGLang, "

--- a/clearwing/providers/env.py
+++ b/clearwing/providers/env.py
@@ -340,6 +340,8 @@ def _default_openai_compat_model(base_url: str) -> str:
         return "gpt-4o"
     if "api.deepseek.com" in host:
         return "deepseek-chat"
+    if "api.minimax.io" in host:
+        return "MiniMax-M2.7"
     # Catch-all
     return "default"
 

--- a/clearwing/providers/manager.py
+++ b/clearwing/providers/manager.py
@@ -52,6 +52,11 @@ PROVIDER_PRESETS = {
         "models": [],  # dynamic
         "default_base_url": "http://localhost:11434",
     },
+    "minimax": {
+        "env_key": "MINIMAX_API_KEY",
+        "models": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"],
+        "default_base_url": "https://api.minimax.io/v1",
+    },
 }
 
 DEFAULT_ROUTES = [
@@ -388,6 +393,19 @@ class ProviderManager:
                 provider_name="ollama",
             )
 
+        elif provider == "minimax":
+            base_url = (
+                config.base_url
+                if config and config.base_url
+                else "https://api.minimax.io/v1"
+            )
+            return ChatModel(
+                model_name=model,
+                base_url=base_url,
+                api_key=config.api_key if config else os.environ.get("MINIMAX_API_KEY", ""),
+                provider_name="openai",
+            )
+
         else:
             if config and config.base_url:
                 return ChatModel(
@@ -440,6 +458,20 @@ class ProviderManager:
                 api_key=config.api_key if config else "",
                 provider_name="ollama",
                 max_concurrency=_native_concurrency_for_task(task, "ollama"),
+            )
+
+        if provider == "minimax":
+            base_url = (
+                config.base_url
+                if config and config.base_url
+                else "https://api.minimax.io/v1"
+            )
+            return AsyncLLMClient(
+                model_name=model,
+                base_url=base_url,
+                api_key=config.api_key if config else os.environ.get("MINIMAX_API_KEY", ""),
+                provider_name="openai",
+                max_concurrency=_native_concurrency_for_task(task, "openai"),
             )
 
         if config and config.base_url:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -85,6 +85,14 @@ class TestProviderPresets:
         preset = PROVIDER_PRESETS["ollama"]
         assert preset["default_base_url"] == "http://localhost:11434"
 
+    def test_minimax_preset(self):
+        assert "minimax" in PROVIDER_PRESETS
+        preset = PROVIDER_PRESETS["minimax"]
+        assert preset["env_key"] == "MINIMAX_API_KEY"
+        assert "MiniMax-M2.7" in preset["models"]
+        assert "MiniMax-M2.7-highspeed" in preset["models"]
+        assert preset["default_base_url"] == "https://api.minimax.io/v1"
+
 
 # --- DEFAULT_ROUTES ---
 
@@ -239,3 +247,19 @@ class TestCreateLlmErrors:
         assert isinstance(llm, ChatModel)
         assert llm.provider_name == "ollama"
         assert llm.base_url == "http://localhost:11434"
+
+    def test_minimax_provider_uses_openai_compat(self):
+        mgr = ProviderManager()
+        llm = mgr._create_llm("minimax", "MiniMax-M2.7")
+        assert isinstance(llm, ChatModel)
+        assert llm.provider_name == "openai"
+        assert llm.model_name == "MiniMax-M2.7"
+        assert llm.base_url == "https://api.minimax.io/v1"
+
+    def test_minimax_highspeed_model(self):
+        mgr = ProviderManager()
+        llm = mgr._create_llm("minimax", "MiniMax-M2.7-highspeed")
+        assert isinstance(llm, ChatModel)
+        assert llm.provider_name == "openai"
+        assert llm.model_name == "MiniMax-M2.7-highspeed"
+        assert llm.base_url == "https://api.minimax.io/v1"

--- a/tests/test_providers_env.py
+++ b/tests/test_providers_env.py
@@ -235,6 +235,7 @@ class TestDefaultModelGuessing:
             ("https://api.groq.com/openai/v1", "llama"),
             ("https://api.openai.com/v1", "gpt-4o"),
             ("https://api.deepseek.com/v1", "deepseek"),
+            ("https://api.minimax.io/v1", "MiniMax"),
         ],
     )
     def test_known_hosts_get_sensible_defaults(self, clean_env, base_url, expected_substring):
@@ -261,6 +262,19 @@ class TestPlaceholderKey:
     def test_non_ollama_gets_not_needed_placeholder(self, clean_env):
         ep = resolve_llm_endpoint(cli_base_url="http://localhost:1234/v1", config_provider={})
         assert ep.api_key == "not-needed"
+
+    def test_minimax_with_cli_key(self, clean_env):
+        ep = resolve_llm_endpoint(
+            cli_base_url="https://api.minimax.io/v1",
+            cli_api_key="sk-minimax-test",
+            cli_model="MiniMax-M2.7",
+            config_provider={},
+        )
+        assert ep.provider == "openai_compat"
+        assert ep.base_url == "https://api.minimax.io/v1"
+        assert ep.api_key == "sk-minimax-test"
+        assert ep.model == "MiniMax-M2.7"
+        assert ep.source == "cli"
 
 
 # --- LLMEndpoint.describe / is_* helpers ---------------------------------


### PR DESCRIPTION
## Summary

- Add **MiniMax** as a new LLM provider using the OpenAI-compatible API at `https://api.minimax.io/v1`
- Supported models: `MiniMax-M2.7` (default) and `MiniMax-M2.7-highspeed`
- Uses `MINIMAX_API_KEY` environment variable for authentication
- Registered in the provider catalog, `PROVIDER_PRESETS`, and explicit routing in `_create_llm` / `_create_native`
- Added default model guessing from `api.minimax.io` base URL in `resolve_llm_endpoint`
- Added unit tests covering the MiniMax preset, model creation, and endpoint resolution

## API References

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test plan

- [x] `tests/test_providers.py` — MiniMax preset fields, `_create_llm` for both models
- [x] `tests/test_providers_env.py` — default model guessing from `api.minimax.io`, CLI flag flow
- [x] `tests/test_setup_and_doctor.py` — catalog completeness check (all 96 tests pass)