### PR TITLE
Fix sourcehunt path normalization on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   prefixes with `v` only when the value starts with a digit, and
   parenthesises non-version labels (e.g. `HTTP (Vercel)`,
   `HTTP v2.4.41`).
+- **Windows sourcehunt path normalization now stays POSIX-stable**.
+  Repo-relative paths emitted by discovery, preprocessing, callgraph,
+  and variant-search flows now normalize `os.path.relpath(...)`
+  outputs to forward-slash paths and handle leading-slash sandbox
+  inputs safely on Windows, so sourcehunt path matching stays aligned
+  with the existing fixtures and `/workspace/...` expectations.
 - **`clearwing config --set-provider` config.yaml bloat regression**.
   The prior `cli.config.save()` path dumped the full merged default
   config (including the 1024-port scanning defaults) into

--- a/clearwing/agent/tools/hunt/discovery.py
+++ b/clearwing/agent/tools/hunt/discovery.py
@@ -16,6 +16,7 @@ import fnmatch
 import logging
 import os
 import re
+from pathlib import Path
 
 from clearwing.llm import NativeToolSpec
 
@@ -34,19 +35,22 @@ def _normalize_path(repo_path: str, path: str) -> str:
     Returns a repo-relative path (no leading slash). Caller can prepend
     repo_path or '/workspace' depending on context.
     """
-    # Strip leading slash
-    if path.startswith("/"):
-        path = path.lstrip("/")
+    repo_root = os.path.abspath(repo_path)
+    # Strip a leading slash/backslash so POSIX-looking inputs like
+    # "/foo/bar" still resolve inside the repo on Windows.
+    if path.startswith(("/", "\\")):
+        path = path.lstrip("/\\")
     # Resolve and check it's still under repo_path
-    abs_path = os.path.abspath(os.path.join(repo_path, path))
-    common = os.path.commonpath([abs_path, repo_path])
-    if common != os.path.abspath(repo_path):
+    abs_path = os.path.abspath(os.path.join(repo_root, path))
+    common = os.path.commonpath([abs_path, repo_root])
+    if common != repo_root:
         raise ValueError(f"path escapes repo: {path}")
-    return os.path.relpath(abs_path, repo_path)
+    return Path(os.path.relpath(abs_path, repo_root)).as_posix()
 
 
 def _container_path(rel_path: str) -> str:
     """Turn a repo-relative path into the path inside the /workspace mount."""
+    rel_path = rel_path.replace("\\", "/")
     return f"/workspace/{rel_path}".replace("//", "/")
 
 
@@ -69,7 +73,7 @@ def _parse_rg_output(stdout: str, default_file: str = "") -> list[dict]:
             continue
         matches.append(
             {
-                "file": path.replace("/workspace/", "", 1),
+                "file": path.replace("/workspace/", "", 1).replace("\\", "/"),
                 "line_number": ln,
                 "matched_text": text.rstrip(),
             }
@@ -105,7 +109,7 @@ def _grep_python_fallback(
 
     for full in candidate_files:
         fname = os.path.basename(full)
-        rel_file = os.path.relpath(full, repo_path)
+        rel_file = Path(os.path.relpath(full, repo_path)).as_posix()
         if file_glob and not (
             fnmatch.fnmatch(rel_file, file_glob)
             or fnmatch.fnmatch(fname, file_glob)
@@ -193,9 +197,13 @@ def build_discovery_tools(ctx: HunterContext) -> list:
             if depth >= max_depth:
                 dirnames[:] = []
             for d in dirnames:
-                out.append(os.path.relpath(os.path.join(dirpath, d), ctx.repo_path) + "/")
+                out.append(
+                    Path(os.path.relpath(os.path.join(dirpath, d), ctx.repo_path)).as_posix() + "/"
+                )
             for f in filenames:
-                out.append(os.path.relpath(os.path.join(dirpath, f), ctx.repo_path))
+                out.append(
+                    Path(os.path.relpath(os.path.join(dirpath, f), ctx.repo_path)).as_posix()
+                )
             if len(out) > 500:
                 out.append("... (truncated)")
                 return out

--- a/clearwing/sourcehunt/callgraph.py
+++ b/clearwing/sourcehunt/callgraph.py
@@ -128,9 +128,7 @@ class CallGraph:
     functions: dict[str, set[str]] = field(default_factory=lambda: defaultdict(set))
     calls_out: dict[str, set[str]] = field(default_factory=lambda: defaultdict(set))
     defined_in: dict[str, set[str]] = field(default_factory=lambda: defaultdict(set))
-    function_info: dict[str, list[FunctionInfo]] = field(
-        default_factory=lambda: defaultdict(list)
-    )
+    function_info: dict[str, list[FunctionInfo]] = field(default_factory=lambda: defaultdict(list))
 
     def callers_of_file(self, target_file: str) -> set[str]:
         """Return the set of files that call any function defined in target_file."""
@@ -284,7 +282,7 @@ class CallGraphBuilder:
 
         parser = self._get_parser(lang_name)
         tree = parser.parse(source)
-        rel_path = os.path.relpath(abs_path, repo_path)
+        rel_path = Path(os.path.relpath(abs_path, repo_path)).as_posix()
 
         def_types = _FUNCTION_DEF_NODE_TYPES.get(lang_name, set())
         call_types = _FUNCTION_CALL_NODE_TYPES.get(lang_name, set())
@@ -299,11 +297,13 @@ class CallGraphBuilder:
                 if name:
                     graph.functions[rel_path].add(name)
                     graph.defined_in[name].add(rel_path)
-                    graph.function_info[rel_path].append(FunctionInfo(
-                        name=name,
-                        start_line=node.start_point[0] + 1,
-                        end_line=node.end_point[0] + 1,
-                    ))
+                    graph.function_info[rel_path].append(
+                        FunctionInfo(
+                            name=name,
+                            start_line=node.start_point[0] + 1,
+                            end_line=node.end_point[0] + 1,
+                        )
+                    )
 
             elif node.type in call_types:
                 name = self._extract_call_name(node, lang_name, source)

--- a/clearwing/sourcehunt/preprocessor.py
+++ b/clearwing/sourcehunt/preprocessor.py
@@ -302,7 +302,7 @@ class Preprocessor:
             except OSError:
                 continue
 
-            rel_path = os.path.relpath(abs_path, repo_path)
+            rel_path = Path(os.path.relpath(abs_path, repo_path)).as_posix()
 
             tags: list[FileTag] = []
             if self.tag_files:

--- a/clearwing/sourcehunt/variant_loop.py
+++ b/clearwing/sourcehunt/variant_loop.py
@@ -22,6 +22,7 @@ import os
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from clearwing.llm import AsyncLLMClient
@@ -211,7 +212,7 @@ class VariantSearcher:
             dirnames[:] = [d for d in dirnames if d not in self.SKIP_DIRS]
             for fname in filenames:
                 full_path = os.path.join(dirpath, fname)
-                rel = os.path.relpath(full_path, repo_path)
+                rel = Path(os.path.relpath(full_path, repo_path)).as_posix()
                 if rel in exclude_paths:
                     continue
                 try:


### PR DESCRIPTION
## Summary
- normalize sourcehunt repo-relative paths to POSIX form at the path boundaries
- handle leading-slash sandbox inputs safely on Windows when resolving repo-relative targets
- keep /workspace/... path matching aligned across discovery, preprocessing, callgraph, and variant search flows

## Verification
- uv run python -m ruff check clearwing/agent/tools/hunt/discovery.py clearwing/sourcehunt/callgraph.py clearwing/sourcehunt/preprocessor.py clearwing/sourcehunt/variant_loop.py
- uv run python -m pytest -q --strict-markers --strict-config tests/test_sourcehunt_hunter.py tests/test_sourcehunt_callgraph.py tests/test_sourcehunt_variant_loop.py tests/test_sourcehunt_runner.py

## Notes
- this is a narrow Windows path-normalization lane; repo-wide lint/type/test remain noisy on current main, so verification is scoped to the affected sourcehunt slice