### PR TITLE
Add support for dtruss on macos (instead of strace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **`clearwing doctor` external-tool probe is now host-OS aware**: on
+  macOS it checks for `dtruss` (the DTrace-based syscall tracer that
+  ships with the OS) instead of `strace`, which is Linux-only. The
+  Linux sandbox container still ships `strace` unchanged; this only
+  removes the spurious "strace not on PATH" warning on Darwin hosts.
 - **`langchain-openai` is now a runtime dependency**, not a lazy
   `try/except ImportError` import. Every OpenAI-compatible endpoint
   works out of the box after `pip install clearwing` — no extra

--- a/clearwing/ui/commands/doctor.py
+++ b/clearwing/ui/commands/doctor.py
@@ -438,8 +438,22 @@ def _check_external_tools() -> DoctorSection:
     optional = [
         ("gh", "Optional: needed for `sourcehunt --auto-pr` and `--github-checks` modes."),
         ("gdb", "Optional: useful inside the hunter sandbox for debugging."),
-        ("strace", "Optional: syscall tracing inside the hunter sandbox."),
     ]
+    if platform.system() == "Darwin":
+        # strace is Linux-only (uses ptrace); on macOS the equivalent is
+        # dtruss, a DTrace wrapper that ships with the OS but normally
+        # requires sudo and an SIP configuration that allows DTrace.
+        optional.append(
+            (
+                "dtruss",
+                "Optional: macOS syscall tracer (DTrace wrapper); equivalent to strace. "
+                "Usually requires sudo; SIP must allow DTrace.",
+            )
+        )
+    else:
+        optional.append(
+            ("strace", "Optional: syscall tracing inside the hunter sandbox.")
+        )
 
     for tool, required_flag, hint in required:
         path = shutil.which(tool)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -187,7 +187,7 @@ Runs ~25 checks across: Python version, clearwing version, LLM
 provider resolution (with an optional live test-invoke), filesystem
 (`~/.clearwing/` writable, `config.yaml` valid, `clearwing.log`
 writable), Docker daemon reachability, external CLI tools (git, rg,
-gh, gdb, strace), optional Python extras (langchain-ollama,
+gh, gdb, strace — or dtruss on macOS), optional Python extras (langchain-ollama,
 langchain-google-genai, playwright, sentence-transformers, fastapi,
 pymetasploit3, chromadb), and network reachability to the configured
 LLM endpoint. Prints a per-section summary with green-yellow-red


### PR DESCRIPTION
This pull request updates the external tool checks in the `clearwing doctor` command to be aware of the host operating system. On macOS, it now checks for `dtruss` (the native syscall tracer) instead of `strace`, which is Linux-only. This prevents spurious warnings about missing `strace` on macOS and improves the accuracy of the tool check summary. Documentation has also been updated to reflect this behavior.

**External tool checks:**

* The `clearwing doctor` command now checks for `dtruss` on macOS instead of `strace`, and only checks for `strace` on non-macOS systems. This removes unnecessary warnings on macOS and provides accurate recommendations for syscall tracing tools.

**Documentation updates:**

* Updated `docs/cli.md` to clarify that `clearwing doctor` checks for `strace` on Linux and `dtruss` on macOS.
* Updated `CHANGELOG.md` to document the new OS-aware behavior of the external tool probe in `clearwing doctor`.