### PR TITLE
Support non 'root' scanning 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **`clearwing scan` returned 0 open ports for unprivileged users**.
+  `ScanConfig.scan_type` defaulted to `"syn"`, which routed every
+  probe through scapy's raw-socket SYN scan in
+  `clearwing/scanning/port_scanner.py`. Without root (or `CAP_NET_RAW`)
+  scapy silently dropped every packet ("No route found for IPv4
+  destination ...") and the report showed a blank port list in
+  ~80 ms even when the target had ports open. Default is now
+  `"connect"` (TCP connect, equivalent to `nmap -sT`); SYN remains
+  available by explicit opt-in. `PortScanner.scan` also emits a
+  one-shot WARNING when a raw-socket scan type is requested by an
+  unprivileged process so the failure is no longer silent.
+- **`VulnerabilityScanner` NVD timeouts dumped multi-frame
+  tracebacks** to the user terminal. The previous
+  `logger.warning(..., exc_info=True)` in `_query_nvd` rendered the
+  full aiohttp call stack on every routine network timeout. Replaced
+  with a single-line WARNING (`"NVD API query timed out for 'HTTP'"`
+  for `asyncio.TimeoutError`; class + message for other exceptions);
+  full traceback is now emitted at DEBUG only.
+- **`Unclosed client session` aiohttp warning at end of every scan**.
+  `VulnerabilityScanner` lazily allocated an `aiohttp.ClientSession`
+  but `CoreEngine._vulnerability_scan` never called the scanner's
+  `close()`. Wrapped the scanner usage in `try/finally:
+  await scanner.close()` so the session is reliably cleaned up.
+- **Scan report rendered service versions as `vNone` / `vVercel`**.
+  `ReportGenerator._generate_text` formatted versions with a naive
+  `f"{service} v{version}"`, producing `HTTP vNone` when no version
+  was captured and `HTTP vVercel` when the regex pulled a server
+  name out of a `Server:` header instead of a real version. New
+  `_format_service_label` helper omits the version when missing,
+  prefixes with `v` only when the value starts with a digit, and
+  parenthesises non-version labels (e.g. `HTTP (Vercel)`,
+  `HTTP v2.4.41`).
 - **`clearwing config --set-provider` config.yaml bloat regression**.
   The prior `cli.config.save()` path dumped the full merged default
   config (including the 1024-port scanning defaults) into

--- a/clearwing/core/config.py
+++ b/clearwing/core/config.py
@@ -11,7 +11,11 @@ class ScanConfig:
 
     target: str = ""
     ports: list = field(default_factory=lambda: list(range(1, 1025)))
-    scan_type: str = "syn"
+    # Default to "connect" (TCP connect / nmap -sT): works without root on
+    # every OS. "syn" (raw-socket SYN scan via scapy) needs root + a route
+    # to a usable IP source; without it scapy silently drops every probe
+    # and the report looks empty. Users can opt back into SYN explicitly.
+    scan_type: str = "connect"
     threads: int = 100
     timeout: int = 1
     os_detection: bool = True

--- a/clearwing/core/engine.py
+++ b/clearwing/core/engine.py
@@ -142,10 +142,13 @@ class CoreEngine:
     async def _vulnerability_scan(self, target: str, config: ScanConfig) -> None:
         """Perform vulnerability scanning."""
         scanner = VulnerabilityScanner()
-        vulnerabilities = await scanner.scan(target, self.scan_result.services)
-        self.scan_result.vulnerabilities = vulnerabilities
-        for vuln in vulnerabilities:
-            self._trigger_callback("on_vulnerability_found", target, vuln)
+        try:
+            vulnerabilities = await scanner.scan(target, self.scan_result.services)
+            self.scan_result.vulnerabilities = vulnerabilities
+            for vuln in vulnerabilities:
+                self._trigger_callback("on_vulnerability_found", target, vuln)
+        finally:
+            await scanner.close()
 
     async def _exploit(self, target: str, config: ScanConfig) -> None:
         """Perform exploitation."""

--- a/clearwing/reporting/report_generator.py
+++ b/clearwing/reporting/report_generator.py
@@ -97,7 +97,8 @@ class ReportGenerator:
         if scan_result.services:
             for service in scan_result.services:
                 lines.append(
-                    f"  Port {service['port']}: {service['service']} v{service.get('version', 'Unknown')}"
+                    f"  Port {service['port']}: "
+                    f"{_format_service_label(service['service'], service.get('version'))}"
                 )
                 if service.get("banner"):
                     lines.append(f"    Banner: {service['banner'][:100]}...")
@@ -253,3 +254,25 @@ class ReportGenerator:
             md += f"| {exploit.get('exploit_name', 'N/A')} | {exploit.get('cve', 'N/A')} | {exploit.get('success', False)} | {exploit.get('message', exploit.get('error', 'N/A'))} |\n"
 
         return md
+
+
+def _format_service_label(service: str, version: Any) -> str:
+    """Render `service` + `version` for the human-readable scan report.
+
+    The previous `f"{service} v{version}"` produced ugly output like
+    `HTTP vNone` (when version was missing) and `HTTP vVercel` (when the
+    version-pattern regex captured a server name from a `Server:` header
+    instead of a real version string). Disambiguate:
+
+      - missing/blank version       -> just the service name
+      - looks like a version (1.x)  -> `service v<version>`
+      - anything else (server name) -> `service (<version>)`
+    """
+    if version is None:
+        return service
+    label = str(version).strip()
+    if not label or label.lower() in ("none", "unknown"):
+        return service
+    if label[0].isdigit():
+        return f"{service} v{label}"
+    return f"{service} ({label})"

--- a/clearwing/scanning/port_scanner.py
+++ b/clearwing/scanning/port_scanner.py
@@ -1,10 +1,27 @@
 import asyncio
 import logging
+import os
 from typing import Any
 
 from scapy.all import IP, TCP, sr1
 
 logger = logging.getLogger(__name__)
+
+
+def _has_raw_socket_privilege() -> bool:
+    """Best-effort check that the current process can open raw sockets / BPF.
+
+    True when running as root on Unix (covers macOS and the common Linux
+    case). On Linux a non-root user with `CAP_NET_RAW` would also work,
+    but we don't try to probe capabilities — a false negative just means
+    the user gets a warning that's actually wrong, which is recoverable.
+    On Windows / platforms without ``os.geteuid`` we return True and let
+    scapy decide; we don't want to false-positive a warning there.
+    """
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:
+        return True
+    return geteuid() == 0
 
 
 COMMON_PORTS = [
@@ -95,6 +112,20 @@ class PortScanner:
         """
         ports = ports or COMMON_PORTS
         open_ports = []
+
+        # Surface the most common silent-failure mode: scan_type='syn'
+        # uses scapy raw sockets, which on macOS/Linux require root
+        # (or CAP_NET_RAW). Without privilege scapy drops every probe
+        # silently and the report looks like "0 open ports". Warn once
+        # per scan so the user can re-run with sudo or scan_type='connect'.
+        if scan_type in ("syn", "fin", "ack", "xmas", "null") and not _has_raw_socket_privilege():
+            logger.warning(
+                "scan_type=%r needs raw-socket privileges; this process is "
+                "not root so probes will likely fail silently and the report "
+                "will show no open ports. Re-run with sudo, or use "
+                "scan_type='connect' (CLI default) for a userland TCP scan.",
+                scan_type,
+            )
 
         # Create semaphore for limiting concurrent connections
         semaphore = asyncio.Semaphore(threads)

--- a/clearwing/scanning/vulnerability_scanner.py
+++ b/clearwing/scanning/vulnerability_scanner.py
@@ -121,8 +121,18 @@ class VulnerabilityScanner:
                                 ],
                             }
                         )
-        except Exception:
-            logger.warning("NVD API query failed for '%s'", service, exc_info=True)
+        except asyncio.TimeoutError:
+            # NVD is frequently slow / rate-limited; a timeout per service
+            # is routine and shouldn't paper the terminal with a traceback.
+            logger.warning("NVD API query timed out for '%s'", service)
+        except Exception as e:
+            logger.warning(
+                "NVD API query failed for '%s': %s: %s",
+                service,
+                type(e).__name__,
+                e,
+            )
+            logger.debug("NVD API failure traceback for '%s'", service, exc_info=True)
 
         return vulns
 


### PR DESCRIPTION
This pull request introduces several improvements to the scanning and reporting functionality, focusing on better user experience, clearer reporting, and more robust error handling. The changes include making the default scan type more user-friendly, adding privilege checks and warnings for raw-socket scans, improving service/version labeling in reports, and enhancing error messages for vulnerability queries.

**Scan type and privilege handling:**
* Changed the default `scan_type` in `ScanConfig` to `"connect"` instead of `"syn"`, as `"connect"` works without root privileges on all operating systems, reducing confusion from empty scan results when insufficient privileges are present.
* Added a `_has_raw_socket_privilege` check and a warning in `port_scanner.py` to inform users when a raw-socket scan type is selected but the process lacks necessary privileges, helping users avoid silent scan failures. [[1]](diffhunk://#diff-bb26349dbe6480691adc9b5853f83d84432ce6925093955c67c0b88ea98d00bbR3-R26) [[2]](diffhunk://#diff-bb26349dbe6480691adc9b5853f83d84432ce6925093955c67c0b88ea98d00bbR116-R129)

**Reporting improvements:**
* Improved the formatting of service/version labels in scan reports by introducing `_format_service_label`, which avoids confusing outputs like `HTTP vNone` or `HTTP vVercel` and presents missing or non-standard versions more clearly. [[1]](diffhunk://#diff-2ae03560d3aae4c8553d9d24d764846c51d677bfa4bc5a2927bb2c8086485d85L100-R101) [[2]](diffhunk://#diff-2ae03560d3aae4c8553d9d24d764846c51d677bfa4bc5a2927bb2c8086485d85R257-R278)

**Error handling and resource management:**
* Enhanced error handling in the NVD vulnerability scanner: timeouts now log a concise warning instead of a traceback, and other exceptions provide both a warning and a debug traceback for better troubleshooting.
* Ensured the `VulnerabilityScanner` is always closed after use by adding a `finally` block in the vulnerability scan coroutine, preventing resource leaks.