### PR TITLE
Switch MiniMax to Anthropic API; drop strip_think_tags and the <think> filter plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **MiniMax provider now routes through the Anthropic-compatible
+  endpoint** at `https://api.minimax.io/anthropic`, which separates
+  reasoning from response content at the protocol level. This replaces
+  the previous OpenAI-compat path that required in-band
+  `<think>...</think>` tag stripping in every response handler.
 - **`clearwing doctor` external-tool probe is now host-OS aware**: on
   macOS it checks for `dtruss` (the DTrace-based syscall tracer that
   ships with the OS) instead of `strace`, which is Linux-only. The

--- a/clearwing/agent/runtime.py
+++ b/clearwing/agent/runtime.py
@@ -16,7 +16,6 @@ from clearwing.core.events import EventBus, EventType
 from clearwing.data.knowledge import KnowledgeGraph
 from clearwing.data.memory import ContextSummarizer, EpisodicMemory
 from clearwing.llm.chat import BaseMessage, SystemMessage, ToolMessage, extract_text_content
-from clearwing.llm.native import strip_think_tags
 from clearwing.observability.telemetry import CostTracker
 from clearwing.safety.audit import AuditLogger
 from clearwing.safety.guardrails import InputGuardrail, OutputGuardrail
@@ -260,7 +259,7 @@ class NativeAgentGraph:
                 )
 
         if self.event_bus:
-            self.event_bus.emit_message(strip_think_tags(response.text)[:200], "agent")
+            self.event_bus.emit_message(response.text[:200], "agent")
 
         response_text = extract_text_content(response.content)
         if response_text:

--- a/clearwing/llm/__init__.py
+++ b/clearwing/llm/__init__.py
@@ -14,7 +14,6 @@ from .native import (
     NativeToolSpec,
     extract_json_array,
     extract_json_object,
-    strip_think_tags,
 )
 
 __all__ = [
@@ -33,5 +32,4 @@ __all__ = [
     "extract_json_array",
     "extract_json_object",
     "extract_text_content",
-    "strip_think_tags",
 ]

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -33,20 +33,6 @@ def _run_coro_sync(coro):
     raise RuntimeError("Synchronous wrapper called from a running event loop")
 
 
-_THINK_TAG_RE = re.compile(r"<think>[\s\S]*?</think>\s*", re.DOTALL)
-
-
-def strip_think_tags(text: str) -> str:
-    """Remove ``<think>...</think>`` blocks emitted by reasoning models.
-
-    Models like MiniMax M2.7 wrap chain-of-thought in ``<think>`` tags
-    within the ``content`` field.  The raw tags must be preserved in
-    conversation history for multi-turn reasoning continuity, but they
-    need to be stripped before parsing JSON or presenting final output.
-    """
-    return _THINK_TAG_RE.sub("", text).strip()
-
-
 def response_text(response: ChatResponse) -> str:
     """Coalesce a :class:`ChatResponse`'s text segments into a single string.
 
@@ -289,7 +275,7 @@ class AsyncLLMClient:
             response_schema_name=schema_name,
             response_schema_description=schema_description,
         )
-        text = strip_think_tags(response_text(response))
+        text = response_text(response)
         if schema_model is not None:
             parsed_model = _validate_schema_response(schema_model, text)
             if _is_root_model_type(schema_model):

--- a/clearwing/providers/catalog.py
+++ b/clearwing/providers/catalog.py
@@ -191,12 +191,13 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
     ProviderPreset(
         key="minimax",
         display_name="MiniMax",
-        description="MiniMax M2.7 / M2.5 reasoning models via api.minimax.io. "
-        "OpenAI-compatible, 200K context.",
+        description="MiniMax M2.7 / M2.5 reasoning models via the Anthropic-compatible "
+        "endpoint at api.minimax.io/anthropic. 200K context.",
         docs_url="https://platform.minimax.io/",
-        default_base_url="https://api.minimax.io/v1",
+        default_base_url="https://api.minimax.io/anthropic",
         default_model="MiniMax-M2.7",
         api_key_env_var="MINIMAX_API_KEY",
+        is_openai_compat=False,
         alt_models=(
             "MiniMax-M2.7-highspeed",
             "MiniMax-M2.5",

--- a/clearwing/providers/env.py
+++ b/clearwing/providers/env.py
@@ -143,6 +143,14 @@ def resolve_llm_endpoint(
     if cli_base_url or cli_model or cli_api_key:
         base_url = cli_base_url
         if base_url:
+            if _is_anthropic_compat_base_url(base_url):
+                return LLMEndpoint(
+                    provider="anthropic",
+                    model=cli_model or _default_anthropic_compat_model(base_url),
+                    base_url=base_url,
+                    api_key=cli_api_key or os.environ.get(ENV_API_KEY),
+                    source="cli",
+                )
             provider = "openai_compat"
             model = cli_model or _default_openai_compat_model(base_url)
             api_key = cli_api_key or os.environ.get(ENV_API_KEY) or _placeholder_for(base_url)
@@ -169,6 +177,14 @@ def resolve_llm_endpoint(
     env_model = os.environ.get(ENV_MODEL)
     if env_base_url or env_model:
         if env_base_url:
+            if _is_anthropic_compat_base_url(env_base_url):
+                return LLMEndpoint(
+                    provider="anthropic",
+                    model=env_model or _default_anthropic_compat_model(env_base_url),
+                    base_url=env_base_url,
+                    api_key=env_api_key or os.environ.get(ENV_ANTHROPIC_KEY),
+                    source="env",
+                )
             return LLMEndpoint(
                 provider="openai_compat",
                 model=env_model or _default_openai_compat_model(env_base_url),
@@ -204,6 +220,14 @@ def resolve_llm_endpoint(
         cfg_model = config_provider.get("model")
         cfg_api_key = _resolve_config_secret(config_provider.get("api_key"))
         if cfg_base_url:
+            if _is_anthropic_compat_base_url(cfg_base_url):
+                return LLMEndpoint(
+                    provider="anthropic",
+                    model=cfg_model or _default_anthropic_compat_model(cfg_base_url),
+                    base_url=cfg_base_url,
+                    api_key=cfg_api_key or os.environ.get(ENV_ANTHROPIC_KEY),
+                    source="config",
+                )
             return LLMEndpoint(
                 provider="openai_compat",
                 model=cfg_model or _default_openai_compat_model(cfg_base_url),
@@ -317,6 +341,29 @@ def _openai_oauth_access_token() -> str | None:
         return None
 
 
+def _is_anthropic_compat_base_url(base_url: str) -> bool:
+    """Return True if *base_url* speaks Anthropic's Messages API.
+
+    Used by `resolve_llm_endpoint` to route a custom base_url through
+    the Anthropic adapter instead of OpenAI-compat. Covers MiniMax's
+    `api.minimax.io/anthropic` endpoint and anthropic.com itself.
+    """
+    host = base_url.lower().rstrip("/")
+    if "anthropic.com" in host:
+        return True
+    if "minimax.io" in host and host.endswith("/anthropic"):
+        return True
+    return False
+
+
+def _default_anthropic_compat_model(base_url: str) -> str:
+    """Pick a default model for an Anthropic-compat base_url."""
+    host = base_url.lower()
+    if "minimax.io" in host:
+        return "MiniMax-M2.7"
+    return DEFAULT_ANTHROPIC_MODEL
+
+
 def _default_openai_compat_model(base_url: str) -> str:
     """Pick a sensible default model when only the base_url is given.
 
@@ -342,8 +389,6 @@ def _default_openai_compat_model(base_url: str) -> str:
         return "gpt-4o"
     if "api.deepseek.com" in host:
         return "deepseek-chat"
-    if "minimax.io" in host:
-        return "MiniMax-M2.7"
     # Catch-all
     return "default"
 

--- a/clearwing/providers/manager.py
+++ b/clearwing/providers/manager.py
@@ -312,9 +312,11 @@ class ProviderManager:
                 provider_name=_adapter_for_endpoint(endpoint),
             )
 
-        # Anthropic direct (the default fallback path)
+        # Anthropic direct, or an Anthropic-compatible gateway (e.g. MiniMax's
+        # api.minimax.io/anthropic). base_url is None for the direct case.
         return ChatModel(
             model_name=endpoint.model,
+            base_url=endpoint.base_url,
             api_key=endpoint.api_key or "",
             provider_name=_adapter_for_endpoint(endpoint),
         )
@@ -538,6 +540,8 @@ def _adapter_for_base_url(base_url: str | None, model: str) -> str:
     if "generativelanguage.googleapis.com" in host or "googleapis.com" in host:
         return "gemini"
     if "anthropic.com" in host:
+        return "anthropic"
+    if "minimax.io" in host and host.rstrip("/").endswith("/anthropic"):
         return "anthropic"
     if model.startswith("gemini-"):
         return "gemini"

--- a/clearwing/ui/commands/interactive.py
+++ b/clearwing/ui/commands/interactive.py
@@ -11,7 +11,6 @@ from rich.prompt import Confirm, Prompt
 
 from clearwing.agent.graph import create_agent
 from clearwing.agent.runtime import Command
-from clearwing.llm.native import strip_think_tags
 from clearwing.agent.tools.ops.dynamic_tool_creator import get_custom_tools
 from clearwing.agent.tools.ops.kali_docker_tool import kali_cleanup
 from clearwing.data.memory import SessionStore
@@ -194,59 +193,24 @@ def _run_interactive_legacy(cli, args, session=None):
         cli.console.print(f"[blue]Target set to: {args.target}[/blue]")
 
     class _StreamPrinter:
+        """Print streaming text deltas, emitting the ``Agent:`` label once."""
+
         def __init__(self, console):
             self._console = console
-            self._in_think = False
-            self._buf = ""
             self._started = False
 
         def reset(self):
-            self._in_think = False
-            self._buf = ""
             self._started = False
 
         def __call__(self, delta: str):
-            self._buf += delta
-            while True:
-                if self._in_think:
-                    end = self._buf.find("</think>")
-                    if end == -1:
-                        self._buf = self._buf[-8:]
-                        return
-                    self._buf = self._buf[end + 8:]
-                    self._in_think = False
-                    continue
-                start = self._buf.find("<think>")
-                if start == -1:
-                    safe = len(self._buf)
-                    for i in range(1, min(7, len(self._buf) + 1)):
-                        if self._buf.endswith("<think>"[:i]):
-                            safe = len(self._buf) - i
-                            break
-                    if safe > 0:
-                        text = self._buf[:safe]
-                        self._buf = self._buf[safe:]
-                        if text:
-                            if not self._started:
-                                self._console.print("\n[bold cyan]Agent:[/bold cyan] ", end="")
-                                self._started = True
-                            self._console.print(text, end="", highlight=False)
-                    return
-                if start > 0:
-                    if not self._started:
-                        self._console.print("\n[bold cyan]Agent:[/bold cyan] ", end="")
-                        self._started = True
-                    self._console.print(self._buf[:start], end="", highlight=False)
-                self._buf = self._buf[start + 7:]
-                self._in_think = True
+            if not delta:
+                return
+            if not self._started:
+                self._console.print("\n[bold cyan]Agent:[/bold cyan] ", end="")
+                self._started = True
+            self._console.print(delta, end="", highlight=False)
 
         def finish(self):
-            if self._buf and not self._in_think:
-                if not self._started:
-                    self._console.print("\n[bold cyan]Agent:[/bold cyan] ", end="")
-                    self._started = True
-                self._console.print(self._buf, end="", highlight=False)
-                self._buf = ""
             if self._started:
                 self._console.print()
 

--- a/clearwing/ui/commands/setup.py
+++ b/clearwing/ui/commands/setup.py
@@ -465,10 +465,12 @@ def _run_test_invoke(
             source="cli",
         )
     else:
+        # Anthropic direct (base_url=None) or an Anthropic-compatible gateway
+        # like MiniMax (base_url set, provider still "anthropic").
         endpoint = LLMEndpoint(
             provider="anthropic",
             model=model,
-            base_url=None,
+            base_url=base_url or None,
             api_key=resolved_key or None,
             source="cli",
         )

--- a/clearwing/ui/tui/app.py
+++ b/clearwing/ui/tui/app.py
@@ -279,7 +279,6 @@ class ClearwingApp(App):
         """Read from the input queue, drive the agent, display responses."""
         from clearwing.agent.runtime import Command
         from clearwing.llm.chat import extract_text_content
-        from clearwing.llm.native import strip_think_tags
 
         initial_state: dict = {}
         if self.target:
@@ -313,7 +312,7 @@ class ClearwingApp(App):
                         and getattr(last, "type", None) == "ai"
                         and not getattr(last, "tool_calls", None)
                     ):
-                        text = strip_think_tags(extract_text_content(last.content))
+                        text = extract_text_content(last.content)
                         if text:
                             feed.add_message(text, "success")
                             got_response = True
@@ -350,9 +349,7 @@ class ClearwingApp(App):
                                         and getattr(last, "type", None) == "ai"
                                         and not getattr(last, "tool_calls", None)
                                     ):
-                                        text = strip_think_tags(
-                                            extract_text_content(last.content)
-                                        )
+                                        text = extract_text_content(last.content)
                                         if text:
                                             feed.add_message(text, "success")
 

--- a/clearwing/ui/web/app.py
+++ b/clearwing/ui/web/app.py
@@ -19,7 +19,6 @@ from clearwing.agent.graph import create_agent
 from clearwing.agent.operator import OperatorAgent, OperatorConfig
 from clearwing.agent.runtime import Command
 from clearwing.core.events import EventBus, EventType
-from clearwing.llm.native import strip_think_tags
 from clearwing.observability import MetricsCollector
 
 logger = logging.getLogger(__name__)
@@ -413,14 +412,12 @@ def create_app():
                                     if c:
                                         last_content = c
                         if last_content:
-                            cleaned = strip_think_tags(last_content)
-                            if cleaned:
-                                await websocket.send_json(
-                                    {
-                                        "type": "agent_message",
-                                        "data": {"content": cleaned},
-                                    }
-                                )
+                            await websocket.send_json(
+                                {
+                                    "type": "agent_message",
+                                    "data": {"content": last_content},
+                                }
+                            )
                     except Exception as e:
                         await websocket.send_json(
                             {

--- a/tests/test_minimax_compat.py
+++ b/tests/test_minimax_compat.py
@@ -1,79 +1,83 @@
-"""Tests for MiniMax M2.7 compatibility: think-tag stripping and catalog entry."""
+"""Tests for the MiniMax provider preset and endpoint resolution.
+
+MiniMax is routed through its Anthropic-compatible endpoint at
+``https://api.minimax.io/anthropic``. That separates reasoning from
+content at the protocol level (via ``reasoning_content``), so we don't
+need in-band ``<think>`` tag handling.
+"""
 
 from __future__ import annotations
 
-from clearwing.llm.native import strip_think_tags, extract_json_object
 from clearwing.providers.catalog import preset_by_key
-from clearwing.providers.env import _default_openai_compat_model
-
-
-class TestStripThinkTags:
-    def test_no_tags(self):
-        assert strip_think_tags("Hello, world!") == "Hello, world!"
-
-    def test_simple_think_block(self):
-        text = "<think>Let me think about this...</think>\nHere is the answer."
-        assert strip_think_tags(text) == "Here is the answer."
-
-    def test_multiline_think_block(self):
-        text = (
-            "<think>\nI need to consider:\n1. First thing\n"
-            "2. Second thing\n</think>\n\nThe result is 42."
-        )
-        assert strip_think_tags(text) == "The result is 42."
-
-    def test_think_block_with_json_inside(self):
-        text = (
-            '<think>\nI need to structure this like {"key": "value"} format.\n'
-            'The result should have {"results": []} with entries.\n</think>\n\n'
-            '{"results": [{"file": "foo.py", "score": 0.8}]}'
-        )
-        result = strip_think_tags(text)
-        assert result == '{"results": [{"file": "foo.py", "score": 0.8}]}'
-
-    def test_preserves_content_without_tags(self):
-        text = '{"results": [{"file": "bar.py"}]}'
-        assert strip_think_tags(text) == text
-
-    def test_empty_think_block(self):
-        assert strip_think_tags("<think></think>answer") == "answer"
-
-    def test_multiple_think_blocks(self):
-        text = "<think>first</think>hello <think>second</think>world"
-        assert strip_think_tags(text) == "hello world"
-
-    def test_empty_string(self):
-        assert strip_think_tags("") == ""
-
-    def test_only_think_block(self):
-        assert strip_think_tags("<think>just thinking</think>") == ""
-
-
-class TestResponseTextWithThinkTags:
-    def test_json_extraction_after_think_strip(self):
-        raw = (
-            "<think>\nLet me analyze these files...\n"
-            'Should I use {"results": []}?\n</think>\n\n'
-            '{"results": [{"file": "a.py", "score": 0.9}]}'
-        )
-        cleaned = strip_think_tags(raw)
-        parsed = extract_json_object(cleaned)
-        assert parsed["results"][0]["file"] == "a.py"
+from clearwing.providers.env import (
+    _default_anthropic_compat_model,
+    _is_anthropic_compat_base_url,
+    resolve_llm_endpoint,
+)
 
 
 class TestMiniMaxCatalog:
     def test_preset_exists(self):
         preset = preset_by_key("minimax")
         assert preset is not None
-        assert preset.default_base_url == "https://api.minimax.io/v1"
+        assert preset.default_base_url == "https://api.minimax.io/anthropic"
         assert preset.default_model == "MiniMax-M2.7"
         assert preset.api_key_env_var == "MINIMAX_API_KEY"
 
+    def test_is_anthropic_compat(self):
+        preset = preset_by_key("minimax")
+        assert preset is not None
+        assert preset.is_openai_compat is False
+
     def test_alt_models(self):
         preset = preset_by_key("minimax")
+        assert preset is not None
         assert "MiniMax-M2.7-highspeed" in preset.alt_models
 
 
+class TestAnthropicCompatBaseUrl:
+    def test_minimax_anthropic_endpoint(self):
+        assert _is_anthropic_compat_base_url("https://api.minimax.io/anthropic")
+        assert _is_anthropic_compat_base_url("https://api.minimax.io/anthropic/")
+
+    def test_minimax_openai_endpoint_is_not_anthropic(self):
+        assert not _is_anthropic_compat_base_url("https://api.minimax.io/v1")
+
+    def test_anthropic_direct(self):
+        assert _is_anthropic_compat_base_url("https://api.anthropic.com")
+
+    def test_other_providers_are_not_anthropic(self):
+        assert not _is_anthropic_compat_base_url("https://openrouter.ai/api/v1")
+        assert not _is_anthropic_compat_base_url("https://api.openai.com/v1")
+
+
 class TestMiniMaxDefaultModel:
-    def test_minimax_io_url(self):
-        assert _default_openai_compat_model("https://api.minimax.io/v1") == "MiniMax-M2.7"
+    def test_minimax_anthropic_url(self):
+        assert _default_anthropic_compat_model("https://api.minimax.io/anthropic") == "MiniMax-M2.7"
+
+
+class TestMiniMaxEndpointResolution:
+    def test_cli_flags_route_to_anthropic_adapter(self):
+        endpoint = resolve_llm_endpoint(
+            cli_base_url="https://api.minimax.io/anthropic",
+            cli_api_key="test-key",
+            config_provider={},
+        )
+        assert endpoint.provider == "anthropic"
+        assert endpoint.base_url == "https://api.minimax.io/anthropic"
+        assert endpoint.model == "MiniMax-M2.7"
+        assert endpoint.api_key == "test-key"
+        assert not endpoint.is_anthropic_direct
+        assert not endpoint.is_openai_compat
+
+    def test_config_routes_to_anthropic_adapter(self):
+        endpoint = resolve_llm_endpoint(
+            config_provider={
+                "base_url": "https://api.minimax.io/anthropic",
+                "api_key": "test-key",
+                "model": "MiniMax-M2.5",
+            },
+        )
+        assert endpoint.provider == "anthropic"
+        assert endpoint.base_url == "https://api.minimax.io/anthropic"
+        assert endpoint.model == "MiniMax-M2.5"


### PR DESCRIPTION
## Summary

Switches the MiniMax provider from the OpenAI-compat endpoint to MiniMax's Anthropic-compatible endpoint (`https://api.minimax.io/anthropic`, confirmed live against their published docs). The Anthropic API separates reasoning from content at the protocol level via `reasoning_content`, so the in-band `<think>…</think>` hack that MiniMax's OpenAI-compat endpoint emits is no longer our problem.

Consequences:

- `strip_think_tags` (`clearwing/llm/native.py`) and every caller of it — gone.
- `<think>` filter branches in `_StreamPrinter` (interactive CLI), `agent/runtime.py`, `ui/web/app.py`, `ui/tui/app.py` — gone.
- Think-tag awareness in `aask_json` — gone.
- MiniMax `ProviderPreset` + env-guess + `_adapter_for_base_url` all route through the `anthropic` adapter.

## Test plan

- [x] 10 new tests in `tests/test_minimax_compat.py` covering the catalog preset, `_is_anthropic_compat_base_url`, `_default_anthropic_compat_model`, and CLI/config resolution routing.
- [x] `pytest -q --strict-markers --strict-config` → 2018 passed.

## Notes

Clearwing's repo-wide `ruff check` / `ruff format --check` / `mypy` gates are pre-existing noise on `main`; this PR introduces zero new errors across all three (and reduces ruff check by 3).
