### PR TITLE
PR #20 followup: CHANGELOG entry + tests for scan_type flip, _format_service_label, and scanner close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   reasoning from response content at the protocol level. This replaces
   the previous OpenAI-compat path that required in-band
   `<think>...</think>` tag stripping in every response handler.
+- **`ScanConfig.scan_type` default flipped from `"syn"` to `"connect"`**
+  (BREAKING for callers that relied on the old default). `clearwing scan`
+  now works out of the box for unprivileged users — the TCP-connect
+  scanner doesn't need raw-socket capability, so you no longer get an
+  empty "0 open ports" report when running without `sudo` /
+  `CAP_NET_RAW`. Callers that depended on the stealthier SYN scan must
+  now opt in explicitly with `scan_type="syn"` (or `ScanConfig(scan_type=
+  "syn")`), and the scan must still run as root for the raw sockets to
+  work.
 - **`clearwing doctor` external-tool probe is now host-OS aware**: on
   macOS it checks for `dtruss` (the DTrace-based syscall tracer that
   ships with the OS) instead of `strace`, which is Linux-only. The

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -4,6 +4,7 @@ import pytest
 
 from clearwing.core.engine import ScanResult, ScanState
 from clearwing.reporting import ReportGenerator
+from clearwing.reporting.report_generator import _format_service_label
 
 
 class TestReportGenerator:
@@ -98,3 +99,39 @@ class TestReportGenerator:
         generator.save(sample_result, str(html_path))
         content = html_path.read_text()
         assert "<html>" in content
+
+
+class TestFormatServiceLabel:
+    """Regression tests for the `_format_service_label` helper that
+    cleaned up `HTTP vNone` / `HTTP vVercel` ugliness in text reports
+    (see PR #20).
+    """
+
+    def test_version_none_returns_service_alone(self):
+        """`version=None` should drop the version segment entirely, not
+        render `HTTP vNone`."""
+        assert _format_service_label("HTTP", None) == "HTTP"
+
+    @pytest.mark.parametrize("blank", ["", "   ", "none", "None", "NONE", "Unknown", "unknown"])
+    def test_blank_or_placeholder_version_returns_service_alone(self, blank):
+        """Empty, whitespace, or the common placeholder strings ('none',
+        'Unknown', any case) should be treated as 'no version known' and
+        produce just the service name."""
+        assert _format_service_label("HTTP", blank) == "HTTP"
+
+    def test_numeric_version_gets_v_prefix(self):
+        """Version strings that start with a digit are real versions and
+        should be rendered as `service v<version>`."""
+        assert _format_service_label("SSH", "1.2.3") == "SSH v1.2.3"
+
+    def test_non_numeric_version_parenthesised(self):
+        """Non-numeric server/banner labels (e.g. `Vercel` captured from a
+        `Server:` header) should be parenthesised so they don't masquerade
+        as a version number."""
+        assert _format_service_label("HTTP", "Vercel") == "HTTP (Vercel)"
+
+    def test_version_with_trailing_distro_tag(self):
+        """Versions like Apache's `2.4.41 (Ubuntu)` start with a digit and
+        should keep the `v` prefix even though they contain non-version
+        characters after the numeric portion."""
+        assert _format_service_label("HTTP", "2.4.41 (Ubuntu)") == "HTTP v2.4.41 (Ubuntu)"

--- a/tests/test_scanners.py
+++ b/tests/test_scanners.py
@@ -1,3 +1,7 @@
+import logging
+import os
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from clearwing.scanning import OSScanner, PortScanner, ServiceScanner, VulnerabilityScanner
@@ -27,6 +31,45 @@ class TestPortScanner:
         """Test synchronous scan method."""
         result = scanner.scan_sync("127.0.0.1", [22, 80])
         assert isinstance(result, list)
+
+    @pytest.mark.asyncio
+    async def test_syn_scan_warns_when_unprivileged(self, scanner, monkeypatch, caplog):
+        """PR #20 regression: `scan_type='syn'` without root used to fail
+        silently and return 0 ports. The scanner now emits a WARNING so
+        the user can either re-run with sudo or switch to 'connect'.
+        """
+        # Pretend we're a regular (non-root) user. geteuid is guaranteed
+        # to exist on Linux, where this test runs; on Windows the
+        # privilege check skips entirely, so skip the test there.
+        if not hasattr(os, "geteuid"):
+            pytest.skip("raw-socket privilege check is Unix-only")
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+
+        with caplog.at_level(logging.WARNING, logger="clearwing.scanning.port_scanner"):
+            # Scan a single closed port on localhost so we exit fast
+            # regardless of whether scapy actually fires a packet.
+            await scanner.scan("127.0.0.1", [1], scan_type="syn")
+
+        warnings = [
+            r for r in caplog.records if r.levelno == logging.WARNING and "raw-socket" in r.message
+        ]
+        assert warnings, f"expected raw-socket WARNING, got {[r.message for r in caplog.records]}"
+        assert "syn" in warnings[0].message
+
+    @pytest.mark.asyncio
+    async def test_connect_scan_does_not_warn_when_unprivileged(self, scanner, monkeypatch, caplog):
+        """The raw-socket warning must not fire for the default
+        `scan_type='connect'`, which doesn't need root."""
+        if not hasattr(os, "geteuid"):
+            pytest.skip("raw-socket privilege check is Unix-only")
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+
+        with caplog.at_level(logging.WARNING, logger="clearwing.scanning.port_scanner"):
+            await scanner.scan("127.0.0.1", [1], scan_type="connect")
+
+        assert not [
+            r for r in caplog.records if r.levelno == logging.WARNING and "raw-socket" in r.message
+        ]
 
 
 class TestServiceScanner:
@@ -81,6 +124,34 @@ class TestVulnerabilityScanner:
         """Test closing aiohttp session."""
         await scanner.close()
         assert scanner.session is None
+
+    @pytest.mark.asyncio
+    async def test_engine_closes_scanner_even_when_scan_raises(self):
+        """PR #20 regression: `CoreEngine._vulnerability_scan` wraps the
+        scanner in `try/finally: await scanner.close()` so the
+        lazily-allocated aiohttp ClientSession is reliably cleaned up
+        even when `scanner.scan()` raises. Without the finally block,
+        aiohttp emits an `Unclosed client session` warning at interpreter
+        teardown.
+        """
+        from clearwing.core.config import ScanConfig
+        from clearwing.core.engine import CoreEngine, ScanResult
+
+        engine = CoreEngine()
+        engine.scan_result = ScanResult(target="127.0.0.1")
+        engine.scan_result.services = [{"port": 80, "service": "HTTP", "version": "2.4.41"}]
+
+        fake_scanner = AsyncMock()
+        fake_scanner.scan = AsyncMock(side_effect=RuntimeError("simulated NVD failure"))
+        fake_scanner.close = AsyncMock()
+
+        with (
+            patch("clearwing.core.engine.VulnerabilityScanner", return_value=fake_scanner),
+            pytest.raises(RuntimeError, match="simulated NVD failure"),
+        ):
+            await engine._vulnerability_scan("127.0.0.1", ScanConfig(target="127.0.0.1"))
+
+        fake_scanner.close.assert_awaited_once()
 
 
 class TestOSScanner:


### PR DESCRIPTION
## Summary

PR #20 ("Support non 'root' scanning") landed without a CHANGELOG entry (violates `CONTRIBUTING.md`'s PR checklist) and without tests for any of the new code. This PR is strictly docs + coverage — zero production changes.

- **CHANGELOG** under `[Unreleased] / ### Changed`: adds the missing `scan_type` default-flip bullet (existing `### Fixed` bullets from #20 left alone).
- **`tests/test_reporting.py::TestFormatServiceLabel`** — 5 tests covering `_format_service_label` edge cases: `None` / blank / `"Unknown"` / `"none"` version → service alone; numeric (`"1.2.3"`) → `v1.2.3`; non-numeric (`"Vercel"`) → `(Vercel)`; trailing distro (`"2.4.41 (Ubuntu)"`) → `v2.4.41 (Ubuntu)`.
- **`tests/test_scanners.py`** — 3 new async tests: raw-socket privilege warning fires on `scan_type="syn"` when not root, doesn't fire on `scan_type="connect"`, and the `try/finally` in `CoreEngine._vulnerability_scan` closes the aiohttp session even when `scanner.scan()` raises.

## Test plan

- [x] `pytest -q tests/test_reporting.py tests/test_scanners.py` → 32 passed.
- [x] Zero new ruff / mypy errors in files I touched.

## Notes

PR #20's own CHANGELOG `### Fixed` bullets were fine — I just added the missing `### Changed` entry for the behavior-breaking default flip so script callers relying on `scan_type="syn"` know to update. No bugs found in #20's merged production code.
