### PR TITLE
Bump genai-pyo3 to >=0.1.11; drop redundant doctor invoke-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   now opt in explicitly with `scan_type="syn"` (or `ScanConfig(scan_type=
   "syn")`), and the scan must still run as root for the raw sockets to
   work.
+- **`genai-pyo3` pinned to `>=0.1.11`**. 0.1.11 exposes reqwest's
+  `timeout` / `connect_timeout` / `read_timeout` on `Client` and
+  defaults the connect-timeout to 30 s. Before this bump, every
+  runtime call through genai-pyo3 was vulnerable to an indefinite
+  hang on a stalled TLS handshake, unresponsive proxy, or transient
+  mid-request drop — `clearwing doctor` was the most visible
+  symptom but every sourcehunt / ranker / hunter call had the same
+  exposure.
+- **`clearwing doctor` — removed the `ThreadPoolExecutor` wrapper
+  around `_invoke_test`**. The 30 s timeout it enforced is now a
+  library-level concern handled by genai-pyo3's default
+  `connect_timeout`, so the worker-thread + `FuturesTimeout`
+  plumbing (and the associated thread-leak-on-timeout behavior)
+  is no longer needed. Doctor returns to a simple try / except
+  around `llm.invoke`.
 - **`clearwing doctor` external-tool probe is now host-OS aware**: on
   macOS it checks for `dtruss` (the DTrace-based syscall tracer that
   ships with the OS) instead of `strace`, which is Linux-only. The

--- a/clearwing/ui/commands/doctor.py
+++ b/clearwing/ui/commands/doctor.py
@@ -34,7 +34,6 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
 from urllib.parse import urlparse
 
 from rich.console import Console
@@ -232,19 +231,15 @@ def _check_llm_provider(cli, *, skip_invoke: bool) -> DoctorSection:
     return section
 
 
-_INVOKE_TIMEOUT_SECONDS = 30
-
-
 def _invoke_test(endpoint) -> DoctorCheck:
     """Fire a 1-token prompt at the endpoint to confirm it actually works.
 
-    Runs the invoke on a worker thread so a stalled native call (hung
-    TLS handshake, unresponsive proxy, etc.) can't block doctor forever.
-    The worker thread is daemonized and abandoned on timeout — fine for
-    a CLI that exits right after.
+    The hung-TLS-handshake failure mode that used to require a worker
+    thread + timeout is now caught at the HTTP layer by genai-pyo3's
+    default 30 s ``connect_timeout`` (0.1.11+), so a stalled endpoint
+    surfaces as an ordinary reqwest error here — no special plumbing
+    needed.
     """
-    from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeout
-
     from clearwing.providers import ProviderManager
 
     try:
@@ -258,31 +253,15 @@ def _invoke_test(endpoint) -> DoctorCheck:
         )
 
     start = time.monotonic()
-    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="doctor-invoke")
     try:
-        future = executor.submit(llm.invoke, "Reply with exactly the word PONG.")
-        try:
-            response = future.result(timeout=_INVOKE_TIMEOUT_SECONDS)
-        except FuturesTimeout:
-            return DoctorCheck(
-                "Test invoke",
-                STATUS_ERR,
-                f"No response within {_INVOKE_TIMEOUT_SECONDS}s — endpoint appears stalled",
-                hint=(
-                    "Re-run with --skip-llm-invoke to bypass this check, then verify "
-                    "network reachability, API key, and that the model name is valid "
-                    "for this provider."
-                ),
-            )
-        except Exception as exc:
-            return DoctorCheck(
-                "Test invoke",
-                STATUS_ERR,
-                f"Invoke failed: {type(exc).__name__}: {exc}",
-                hint="Check your API key, base URL, and that the model exists on this provider.",
-            )
-    finally:
-        executor.shutdown(wait=False, cancel_futures=True)
+        response = llm.invoke("Reply with exactly the word PONG.")
+    except Exception as exc:
+        return DoctorCheck(
+            "Test invoke",
+            STATUS_ERR,
+            f"Invoke failed: {type(exc).__name__}: {exc}",
+            hint="Check your API key, base URL, and that the model exists on this provider.",
+        )
 
     elapsed_ms = int((time.monotonic() - start) * 1000)
     content = getattr(response, "content", str(response))
@@ -480,9 +459,7 @@ def _check_external_tools() -> DoctorSection:
             )
         )
     else:
-        optional.append(
-            ("strace", "Optional: syscall tracing inside the hunter sandbox.")
-        )
+        optional.append(("strace", "Optional: syscall tracing inside the hunter sandbox."))
 
     for tool, required_flag, hint in required:
         path = shutil.which(tool)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # Reporting
     "jinja2>=3.1.0",
     "reportlab>=4.0.0",
-    "genai-pyo3>=0.1.10",
+    "genai-pyo3>=0.1.11",
     "pydantic>=2.0.0",
     "docker>=7.0.0",
     # TUI

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "docker", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "genai-pyo3", specifier = ">=0.1.9" },
+    { name = "genai-pyo3", specifier = ">=0.1.11" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.0" },
@@ -1133,29 +1133,29 @@ wheels = [
 
 [[package]]
 name = "genai-pyo3"
-version = "0.1.9"
+version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/0b/673c21d4aa5876c34726ad90d50b762c5346763271833b899883383a373b/genai_pyo3-0.1.9.tar.gz", hash = "sha256:f756c8109a0060c3d49ab4a8b84f6820dca04b71b072485338ebe4d36771fd75", size = 39252 }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/a1/9a5410774de262775da5d644171b4e30fc9352f9aa2c8206f67c95beef10/genai_pyo3-0.1.11.tar.gz", hash = "sha256:590bfe3ef048880cf601ae329f7243b9d9744404822e44561f2b30152e6c36a9", size = 41193 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/bf/3dea5058b67dc4e5be6d72ff7c0dc110c658b6a16a19a21c70032c5c648b/genai_pyo3-0.1.9-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:58eec6c1ce3213de63c9ef2898d7daf255bdedffaf365e3e1eed0fcccb243ed7", size = 7677544 },
-    { url = "https://files.pythonhosted.org/packages/a9/c9/22b9581758eab776c2d639a81a46d1e60fba6ab46145f170aa88f4c3ffd7/genai_pyo3-0.1.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe0041e6b69453ab909b11435e76e29b7d54cbb2fe47926e1b7762a4e669cafb", size = 4024932 },
-    { url = "https://files.pythonhosted.org/packages/42/e1/e62371c433372a62d349088d01a0f55afd29b0bc61508519757bbf26cde7/genai_pyo3-0.1.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af346896b7e7ae98abdb898f77b7f85d7e3f0d500d8be2ff9fb6bf97dfc961fb", size = 4090369 },
-    { url = "https://files.pythonhosted.org/packages/b7/de/f457f518c2803758cdde3face9b4a0998688aa08536f30ea2f5aa0779566/genai_pyo3-0.1.9-cp310-cp310-win_amd64.whl", hash = "sha256:dbb99ffbdefe63d9d35ad6a5d12e60c57727755466309aefa22a2e3753caf032", size = 3288173 },
-    { url = "https://files.pythonhosted.org/packages/11/a6/ac159a222d4e7e8eae01c07e77287f112f1d7c2816b2ddea2347e9b8ea83/genai_pyo3-0.1.9-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:22cd685604ee496761450d0f1f717919b6b3b2b69f791bd4acfb96d0d78d79b8", size = 7676911 },
-    { url = "https://files.pythonhosted.org/packages/45/8b/c9971f78f52d01a04209b3f2f6ce0a96f39e754c9d95ce898bf380372ec1/genai_pyo3-0.1.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd05fcb3d83f733464552ed4479fb4edc0138116b3334121e697df8eb5f18344", size = 4025949 },
-    { url = "https://files.pythonhosted.org/packages/bb/db/796e3695e0c00f36d20db5d3ce07aba6ea04b20a1a90d578c4fff1a258cb/genai_pyo3-0.1.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:befec491da2e166621be4bc098249ed23864dbe6a2f5351423ff443cde6db235", size = 4090014 },
-    { url = "https://files.pythonhosted.org/packages/a8/5b/0f706c1eab48f6eb6bcf9e1c74f7b0438c7869293bf2c5652b58a86dc34d/genai_pyo3-0.1.9-cp311-cp311-win_amd64.whl", hash = "sha256:2f2b8a2aac92e27b063ccb517670df38355e2be3370db220fb611cbbb0e9bb41", size = 3288202 },
-    { url = "https://files.pythonhosted.org/packages/4b/05/6a1aa075c1ea3eac468ca1d79a48b07333d752c6f7c32b59a6a235e29d9d/genai_pyo3-0.1.9-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:1310fb37b46049a72b53993f479f1f5e7c72c4bc0b8baa26590f6596b5a50c67", size = 7657931 },
-    { url = "https://files.pythonhosted.org/packages/d3/55/124e2125b204e6e3f6cdbd9f9c7ae8483fa5e12b9f63cf5a6325f30530d8/genai_pyo3-0.1.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78430cd9af115e1954ff7e46bde52c87fdda597fdca35d373dea1ce94e3fc519", size = 4020739 },
-    { url = "https://files.pythonhosted.org/packages/9c/de/a70c96cfbdb6347a9d308fbedc4c924e2ee3ee13735f5808eec0b6a000cb/genai_pyo3-0.1.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76ec105d1687747f0aec95dc71de259cc2142cd95a7b3710512e9d9655a514ad", size = 4089642 },
-    { url = "https://files.pythonhosted.org/packages/08/8d/be8cbbd1e1d98a6dc2e477b4b562053ca83fcd56a939b0996eb67956f177/genai_pyo3-0.1.9-cp312-cp312-win_amd64.whl", hash = "sha256:3f49511c529ce5959e197ce945a1591b0fbe0b7c91c7035e0b8d939fab8174e3", size = 3283732 },
-    { url = "https://files.pythonhosted.org/packages/a5/60/1e713e91a56408aa55557f0f458dea166e0e681792e1eace8881c3edaecc/genai_pyo3-0.1.9-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6ad66acc97879b2f696f92954011d0b1960e275d75f89ddaa53ff08f68433066", size = 7657850 },
-    { url = "https://files.pythonhosted.org/packages/96/90/96f1372230ad708f70ae75735554312207a31e67f61ddef45220e5793f39/genai_pyo3-0.1.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a6a91131e80ec60f81fbb86b2eb87797ccfd80f3a197e019ce2aa01af524864", size = 4020296 },
-    { url = "https://files.pythonhosted.org/packages/04/c9/33088ed96769ce4c46e93554f67785a74c774949c13b0513f6f653086396/genai_pyo3-0.1.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77106d8d9888eea9e3990c2294bc3bf0e02a79f65efbd67ad0535aca5bd942d4", size = 4088481 },
-    { url = "https://files.pythonhosted.org/packages/98/7d/a10fab8221e485d8f631d87c521ae2c8d3a440bbb5f76b831071f570df0f/genai_pyo3-0.1.9-cp313-cp313-win_amd64.whl", hash = "sha256:a79216348586dec2869ca4a1dffc9d3331c469e3a8e67157d40d460ccec55b67", size = 3283573 },
+    { url = "https://files.pythonhosted.org/packages/ac/1c/2fdb54d17ce74098331badf5f18d2575740d09873949ef62a8864f1d85cf/genai_pyo3-0.1.11-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:217065859e2eca528f25ff3f7452ee5c4e041933363b123b87fb4c90850836d2", size = 9002350 },
+    { url = "https://files.pythonhosted.org/packages/de/81/75d9c2b01eb16ae2c43e831525cd6e7cae8c4d3cf4d2f9b1e97a671e0678/genai_pyo3-0.1.11-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a90bb8766149f4a83f913fb806ea57b1dd2df55d9fc7065e8be25fec46b750ac", size = 4786014 },
+    { url = "https://files.pythonhosted.org/packages/31/f2/26f2fb14cf0d0107bbf55dbd300f322d2e66ed038488e0551beef770b292/genai_pyo3-0.1.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d0fea3a3beadb682a684a5305f31c31e6697b873052f22dced143880d6a471a", size = 4854497 },
+    { url = "https://files.pythonhosted.org/packages/14/c4/6b6bb9b649b40c2ab505c6c558333778c127fd55570610f861876e0e10c6/genai_pyo3-0.1.11-cp310-cp310-win_amd64.whl", hash = "sha256:9d34048c276ceacb089722ff75538e0841b6a800adf5ac8ea671d9fa6dff0516", size = 3930329 },
+    { url = "https://files.pythonhosted.org/packages/c7/d1/3fae170156840597e7a22b6c7c53c47e3e36520107328a22398bd96089ad/genai_pyo3-0.1.11-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:32879efea6638f042cf45789e5c734c80d1e9b81ac6a0a76aff37a1d3ec17100", size = 9002379 },
+    { url = "https://files.pythonhosted.org/packages/2b/16/6d39e6b2ce3c7dcc518440d8f617b3605db3911bca8407e8e5c8fb86e3cd/genai_pyo3-0.1.11-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52fc01a16b879ae5f059af04f817d8993c2a1dd5e301d5fed70d02c7c7f07851", size = 4787459 },
+    { url = "https://files.pythonhosted.org/packages/b4/52/2efffa0bdb58e17e1234797a775bdf7388f655f575a88cb280ccc1be01d2/genai_pyo3-0.1.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59470384573116542edb6f0b89bf13aaff3b855631a8fb6eb7fd834936c2fb5e", size = 4853699 },
+    { url = "https://files.pythonhosted.org/packages/83/e5/04017300bc5670eea7b0bee4b3f04a37426d1ccd7252ac59e64544688a7b/genai_pyo3-0.1.11-cp311-cp311-win_amd64.whl", hash = "sha256:0fff9e5e3177ec27f93b589d20dd8f0be4a297fac3bfa72ac3de3b0802950bed", size = 3930950 },
+    { url = "https://files.pythonhosted.org/packages/1c/05/10ddca0ea23aad6d34c6b05fc7c8f790dd56ef8fdb497d7a6801199f98a7/genai_pyo3-0.1.11-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3c02f976de1897d1634274e017ccde2ffcf4bebe0325fdb6772891eb7b9c5999", size = 9000644 },
+    { url = "https://files.pythonhosted.org/packages/0f/8b/94c6ae7bae81a596ca86f64558d98efc09a52f596e1acddd783480e4c957/genai_pyo3-0.1.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:222a28614ee51cfac4cfa7377fa9e7fe14430bca2283c2d27b26e59df7dea549", size = 4783965 },
+    { url = "https://files.pythonhosted.org/packages/9a/63/3bce5f26b7d637c49a770e001366ed8a5240eb705515e365893b577003cd/genai_pyo3-0.1.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f44a488cc586a4bb5c323bf31388ca68719bd1e125a4ddde1c4a1cd941c156cb", size = 4849739 },
+    { url = "https://files.pythonhosted.org/packages/e7/b9/0ce3938bea06b525ceadacd972763aa6f7dff0c3295168a218463a04dc3a/genai_pyo3-0.1.11-cp312-cp312-win_amd64.whl", hash = "sha256:dfd1e4fcd6e6a9cdde067cf434ee0bb80ead53391f2148ba1a19145f4cbb2495", size = 3932603 },
+    { url = "https://files.pythonhosted.org/packages/3c/15/614f0872b64961179c9fd27c39834382caa1d3995eb2b27cfc15d0735c92/genai_pyo3-0.1.11-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:27e7a5f92ced67d10c24432a62aacfeac23c37f7ad51e13075e27790803dc845", size = 8998371 },
+    { url = "https://files.pythonhosted.org/packages/88/12/3a0361c03b90539e6d4255c9354389e3bf620519b0b2f31b03d4ee097f63/genai_pyo3-0.1.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:154795e205701d51d8bf6718bdf8bba88354e31da5b53342b087372a7b8e13f9", size = 4783262 },
+    { url = "https://files.pythonhosted.org/packages/7a/d5/754c5111d3984775195c1e10efb106a69a7d092a38ce1c863203658288fd/genai_pyo3-0.1.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93ede85a0a2a6b1410ae17e5c49fc0fc10814bcdc84f1cb6f69c336e4157f985", size = 4847766 },
+    { url = "https://files.pythonhosted.org/packages/84/ac/5ebfff5e52d9f6cf59b250708fd571352a0802be643e30b3ccc0b9f00235/genai_pyo3-0.1.11-cp313-cp313-win_amd64.whl", hash = "sha256:6e8698f83d6a1c04be590850029861c322c7c59cf8ff7959b703bb8efb482c6b", size = 3932520 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two related changes; one PR because the second depends on the first.

### Bump `genai-pyo3` pin: `>=0.1.10` → `>=0.1.11`

0.1.11 (on PyPI) exposes reqwest's `timeout` / `connect_timeout` / `read_timeout` on `Client` and defaults `connect_timeout` to 30 seconds.

Before this bump, every runtime call through genai-pyo3 was vulnerable to an indefinite hang on a stalled TLS handshake, an unresponsive proxy, or a transient mid-request drop. `reqwest::Client::builder()` was called with no timeouts set and fell back to OS-level TCP timeouts (measured in minutes). `clearwing doctor` was the most visible symptom because it's the only place we had a workaround, but every sourcehunt / ranker / hunter call had the same exposure — "ranker chunk 47 silently hangs for 8 minutes mid-run" was a real failure mode.

### Remove `_invoke_test`'s `ThreadPoolExecutor` + `FuturesTimeout` wrapper

Introduced in #16 (Matthias) as a defensive 30 s cap around `llm.invoke()`. That protection is now a library-level concern handled by genai-pyo3's default `connect_timeout`, so the worker-thread dance is redundant:

- The 30 s timeout was hand-chosen in #16 and happens to match 0.1.11's default exactly.
- The wrapper only protected doctor. The library-level fix protects every caller.
- The "daemonize a worker thread and abandon it on timeout" semantics had a latent thread-leak that "fine for a CLI that exits right after" downplayed — every `clearwing doctor` during a debugging session could accumulate zombie workers still hammering a broken endpoint.

Net: `-29 lines`, equal or better protection.

## Test plan

- [x] `uv sync --extra dev` → `genai-pyo3==0.1.11` installed.
- [x] `uv run python -m pytest -q tests/test_setup_and_doctor.py` → 29 passed.
- [x] Targeted ruff/format on `clearwing/ui/commands/doctor.py` clean (one import auto-removed).

## CHANGELOG

Two bullets added under `[Unreleased] / ### Changed` — one for the pin bump explaining the exposure class, one for the doctor simplification noting that the library-level fix obsoletes the worker-thread plumbing.

## Thanks

The `_invoke_test` timeout wrapper in #16 is what surfaced the underlying library-level gap and motivated the 0.1.11 release. PR author deserves credit for catching a failure mode that affected every part of the codebase, not just doctor.
