### PR TITLE
docs: refresh README + docs — drop rust-toolchain / LangGraph / deprecated refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Docs refresh — README + `docs/`**: drop the stale "built on
+  LangGraph" blurb in favor of accurate `genai-pyo3` / rust-genai
+  attribution, remove the "recent Rust toolchain required" install
+  caveat (genai-pyo3 ships prebuilt manylinux / macOS universal2 /
+  windows wheels for Python 3.9–3.13), rewrite `docs/providers.md`
+  Ollama section around the native rust-genai adapter instead of the
+  retired `langchain-ollama` transport, and update `docs/cli.md` +
+  `docs/architecture.md` to reflect the native ReAct runtime and the
+  current optional-extras list (`genai-pyo3`, `playwright`,
+  `sentence-transformers`, `fastapi`, `pymetasploit3`, `chromadb`).
+
 ### Added
 
 - **`clearwing setup` / `clearwing init`** — interactive provider

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Inspired by Anthropic's Glasswing.
 
 The challenge:  Produce similar results as Glasswing - using models everyone has access to.
 
-**Autonomous vulnerability scanner and source-code hunter built on
-LangGraph.**
+**Autonomous vulnerability scanner and source-code hunter.** Built on
+`genai-pyo3`, a native Rust-backed LLM runtime speaking every major
+provider (Anthropic, OpenAI, OpenRouter, Ollama, LM Studio, Together,
+Groq, DeepSeek, MiniMax, Gemini, any OpenAI-compatible endpoint).
 
 Clearwing is a dual-mode offensive-security tool:
 
@@ -105,10 +107,10 @@ source .venv/bin/activate  # fish: source .venv/bin/activate.fish
 clearwing --help
 ```
 
-Requirements: Python 3.10+, a recent Rust toolchain for the native
-`genai-pyo3` bridge, and optionally Docker for the Kali container and
-sanitizer-image sandbox features. If the install fails with a Rust version
-error, run `rustup update stable`.
+Requirements: Python 3.10+ and optionally Docker for the Kali container
+and sanitizer-image sandbox features. `genai-pyo3` ships as prebuilt
+wheels on PyPI (linux x86_64/aarch64, macOS universal2, windows x86_64,
+Python 3.9–3.13), so no Rust toolchain is needed for installation.
 
 ## Quickstart
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,7 +41,9 @@ bus.
 
 ## The network-pentest agent (`clearwing.agent.graph`)
 
-A LangGraph ReAct loop with 63 bind-tools. The graph has two nodes:
+A native ReAct loop with 63 bind-tools, driven by `clearwing.agent.runtime`
+on top of `clearwing.llm.native.AsyncLLMClient` (the `genai-pyo3` bridge
+to rust-genai). The graph has two nodes:
 
 - **`assistant`** — invokes the LLM with the current state and the
   full tool registry. Emits an AIMessage; detects CTF-style flags in
@@ -60,8 +62,8 @@ A LangGraph ReAct loop with 63 bind-tools. The graph has two nodes:
     through the episodic-memory recorder, the knowledge-graph
     populator, and the state updater.
 
-The loop terminates via the standard LangGraph `tools_condition` —
-when the assistant returns no tool_calls, the graph ends.
+The loop terminates when the assistant returns no tool_calls — the
+runtime's inner while-loop falls out and the graph returns.
 
 ### Capability gating
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -450,10 +450,9 @@ Runs ~25 checks across: Python version, clearwing version, LLM
 provider resolution (with an optional live test-invoke), filesystem
 (`~/.clearwing/` writable, `config.yaml` valid, `clearwing.log`
 writable), Docker daemon reachability, external CLI tools (git, rg,
-gh, gdb, strace — or dtruss on macOS), optional Python extras (langchain-ollama,
-langchain-google-genai, playwright, sentence-transformers, fastapi,
-pymetasploit3, chromadb), and network reachability to the configured
-LLM endpoint. Prints a per-section summary with green-yellow-red
+gh, gdb, strace — or dtruss on macOS), optional Python extras
+(genai-pyo3, playwright, sentence-transformers, fastapi, pymetasploit3,
+chromadb), and network reachability to the configured LLM endpoint. Prints a per-section summary with green-yellow-red
 glyphs plus a totals panel at the bottom.
 
 Exit code is 0 when every check is ok/warn and 1 when any check is

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,9 @@
 # Clearwing
 
-**Autonomous vulnerability scanner and source-code hunter built on
-LangGraph.**
+**Autonomous vulnerability scanner and source-code hunter.** Built on
+`genai-pyo3`, a native Rust-backed LLM runtime speaking every major
+provider (Anthropic, OpenAI, OpenRouter, Ollama, LM Studio, Together,
+Groq, DeepSeek, MiniMax, Gemini, any OpenAI-compatible endpoint).
 
 Clearwing is a dual-mode offensive-security tool:
 
@@ -28,7 +30,7 @@ Clearwing is a dual-mode offensive-security tool:
 | [**LLM providers**](providers.md) | OpenRouter / Ollama / LM Studio / vLLM / Together / Groq / DeepSeek / OpenAI — CLI + env + config.yaml recipes for each |
 | [**Architecture**](architecture.md) | How the ReAct loops, sandboxes, capabilities layer, Finding dataclass, and knowledge graph fit together |
 | [**CLI reference**](cli.md) | Every `clearwing <subcommand>` flag, with examples |
-| [**API reference**](api.md) | `clearwing.findings.Finding`, `clearwing.agent.graph.build_react_graph`, the sourcehunt runner, auto-generated from docstrings |
+| [**API reference**](api.md) | `clearwing.findings.Finding`, the sourcehunt runner, auto-generated from docstrings |
 
 ## Project status
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -136,24 +136,44 @@ YAML by hand, quote it so the shell doesn't eat the `$`.
 
 ## Ollama
 
-Two paths: the OpenAI-compatible endpoint (works out of the box,
-no extra install) or the native `langchain-ollama` transport
-(`pip install clearwing[ollama]`, tighter tool-calling semantics on
-some models).
+Ollama is spoken natively by `rust-genai` via its own adapter — no
+extra install, no `/v1` shim needed. You can also point Clearwing at
+Ollama's OpenAI-compatible endpoint if you prefer.
 
-### OpenAI-compat (recommended for most models)
+### Native Ollama adapter (recommended)
 
 ```bash
 # Start Ollama
 ollama serve &
 ollama pull qwen2.5-coder:32b
 
-# Point Clearwing at the /v1 endpoint
+# Point Clearwing at the native Ollama port (no /v1 suffix)
+export CLEARWING_BASE_URL=http://localhost:11434
+export CLEARWING_MODEL=qwen2.5-coder:32b
+# No API key required
+
+clearwing sourcehunt /path/to/repo --depth standard
+```
+
+Or pin it explicitly in `~/.clearwing/config.yaml`:
+
+```yaml
+providers:
+  local_ollama:
+    provider: ollama
+    base_url: http://localhost:11434
+    model: qwen2.5-coder:32b
+
+routes:
+  default: local_ollama
+```
+
+### OpenAI-compat endpoint (alternative)
+
+```bash
 export CLEARWING_BASE_URL=http://localhost:11434/v1
 export CLEARWING_API_KEY=ollama            # placeholder, Ollama ignores it
 export CLEARWING_MODEL=qwen2.5-coder:32b
-
-clearwing sourcehunt /path/to/repo --depth standard
 ```
 
 **Tool calling caveat**: Clearwing requires function calling. Not
@@ -161,26 +181,6 @@ every Ollama-served model handles it well. Known-good models as of
 2026-04: `qwen2.5-coder:32b`, `qwen2.5:72b`, `llama3.3:70b`,
 `mistral-small3:24b`. Base Llama models without function-calling
 training will fail on the first tool dispatch.
-
-### Native transport (optional)
-
-```bash
-pip install clearwing[ollama]
-```
-
-There's no CLI path for "use native" yet — you need the
-`~/.clearwing/config.yaml` form:
-
-```yaml
-providers:
-  local_ollama:
-    provider: ollama                     # forces native langchain-ollama
-    base_url: http://localhost:11434
-    model: qwen2.5-coder:32b
-
-routes:
-  default: local_ollama
-```
 
 ## LM Studio
 


### PR DESCRIPTION
## Summary

Refreshes the main README and `docs/` tree to match the current
`genai-pyo3` / rust-genai native-runtime reality. Fixes three stale
claims that have survived past the LangGraph demolition:

- **No Rust toolchain required for install.** `genai-pyo3` ships
  prebuilt wheels on PyPI (linux x86_64/aarch64, macOS universal2,
  windows x86_64, Python 3.9–3.13). The README install section no
  longer tells new users to install a Rust toolchain or run
  `rustup update stable` on failure.
- **"Built on LangGraph" is gone.** README + `docs/index.md` tagline
  now attributes the actual native Rust-backed LLM runtime instead of
  the long-removed LangGraph dependency.
- **Accurate architecture + provider docs.** `docs/architecture.md`
  now describes the native ReAct loop driven by
  `clearwing.agent.runtime` on top of `clearwing.llm.native.AsyncLLMClient`
  rather than the LangGraph `tools_condition` edge. `docs/providers.md`
  Ollama section rewritten around the native rust-genai Ollama
  adapter (no `/v1` shim, no `clearwing[ollama]` extra) with the
  OpenAI-compat endpoint kept as an alternative.
- **Doctor extras list corrected.** `docs/cli.md` now lists the
  modules actually probed by `clearwing/ui/commands/doctor.py`
  (`genai-pyo3`, `playwright`, `sentence-transformers`, `fastapi`,
  `pymetasploit3`, `chromadb`) instead of the retired
  `langchain-ollama` / `langchain-google-genai`.

CHANGELOG `[Unreleased]` gets a `Changed` entry per
`CONTRIBUTING.md`'s PR checklist.

## Test plan

- [x] README still renders as valid Markdown
- [x] `docs/` cross-links resolve
- [ ] `python -m mkdocs build --strict` passes (docs-only change, no
      code imports affected)