### PR TITLE
docs: retroactive CHANGELOG entry for dd5f093 (event streaming)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   known hosts, api_key placeholder behavior, `LLMEndpoint` helper
   properties, and both `ProviderManager.for_endpoint` /
   `from_config` factories.
+- **Event-driven progress streaming for sourcehunt, disclosure,
+  ossfuzz bench, eval preprocessing, and the TUI + web UI**. An
+  internal `EventBus` now publishes structured progress/stage events
+  from the long-running pipelines so user-facing surfaces can render
+  live updates without polling or parsing stdout. Wired emitters:
+  sourcehunt pool worker progress (`clearwing/sourcehunt/pool.py`),
+  sourcehunt stage transitions (`clearwing/sourcehunt/runner.py`),
+  sourcehunt campaign progress (`clearwing/sourcehunt/campaign.py`),
+  sourcehunt validator results (`clearwing/sourcehunt/validator.py`),
+  disclosure state updates (`clearwing/ui/commands/disclose.py`),
+  ossfuzz bench progress (`clearwing/bench/ossfuzz.py`), and eval
+  preprocessing progress (`clearwing/eval/preprocessing.py`).
+  Consumers: the TUI streaming-parser subscription
+  (`clearwing/ui/tui/streaming_parser.py`, `clearwing/ui/tui/app.py`)
+  and the web UI WebSocket bridge (`clearwing/ui/web/app.py`). Scope
+  note: this is not yet wired into `CoreEngine` (still uses the
+  legacy `_trigger_callback` pattern) or the network-scan, vuln-scan,
+  exploiter, patcher, ranker, or verifier paths — those continue to
+  run without EventBus emissions.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` (lines 71-72) requires every PR to add a `CHANGELOG.md` entry. Commit [`dd5f093`](https://github.com/Lazarus-AI/clearwing/commit/dd5f093) ("Add event-driven progress streaming for all backend features to TUI and web UI") was merged without one. This PR backfills the entry under `## [Unreleased]` → `### Added`.

## Scope correction

The commit subject overclaims: it says "all backend features" but the actual wiring is narrower. The CHANGELOG entry reflects what shipped, not the subject line:

- **Emitters wired**: sourcehunt pool / runner / campaign / validator, disclosure command, ossfuzz bench, eval preprocessing.
- **Consumers wired**: TUI streaming parser, web UI WebSocket bridge.
- **Not wired** (explicitly called out in the entry so future readers aren't misled): `CoreEngine` still uses its legacy `_trigger_callback` pattern, and the network-scan, vuln-scan, exploiter, patcher, ranker, and verifier paths do not emit `EventBus` events.

The merged commit message is left as-is (it's history); only the CHANGELOG is updated.

## Test plan

- [x] `CHANGELOG.md` is the only file changed
- [x] Entry appended to existing `## [Unreleased]` → `### Added` subsection
- [x] Prose style matches surrounding entries (bold term, explanation, concrete file refs)