### PR TITLE
fix: sandbox startup regressions from spec-013 container hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sourcehunt sandboxes could not start** on current Docker versions
+  because of two regressions introduced by the spec-013 container
+  hardening commit. Every `HunterPool` file failed with
+  `sandbox_factory failed` before any Hunter could run.
+  1. `HunterSandbox.spawn` passed `security_opt=["seccomp=<path>"]`
+     to the Docker Python SDK, but the Engine API expects the value
+     after `seccomp=` to be inline JSON (unlike the `docker run` CLI,
+     which reads the file client-side). The daemon rejected every
+     start with `Decoding seccomp profile failed: invalid character
+     '/' looking for beginning of value`. Now the profile is inlined
+     directly from `get_seccomp_profile()` via `json.dumps(...)`.
+  2. `SandboxContainer.copy_tree_into` runs `tar xf` inside a
+     container whose capabilities are dropped (`cap_drop=["ALL"]`,
+     only `SYS_PTRACE` added back). Without `CAP_CHOWN`, tar
+     defaults to restoring the archive's uid/gid (host uid 1000),
+     which fails with `Cannot change ownership ... Operation not
+     permitted`. Added `--no-same-owner` to the extract so tar skips
+     chown and files end up owned by the (root) in-container
+     process. Covered by regression tests that assert the inline
+     JSON shape and the `--no-same-owner` flag.
+
 ### Changed
 
 - **Docs refresh — README + `docs/`**: drop the stale "built on

--- a/clearwing/sandbox/container.py
+++ b/clearwing/sandbox/container.py
@@ -57,9 +57,7 @@ class SandboxConfig:
     cap_add: list[str] = field(default_factory=lambda: ["SYS_PTRACE"])
     read_only_rootfs: bool = False
     runtime: str | None = None
-    labels: dict[str, str] = field(
-        default_factory=lambda: {"managed-by": "clearwing"}
-    )
+    labels: dict[str, str] = field(default_factory=lambda: {"managed-by": "clearwing"})
 
 
 class SandboxContainer:
@@ -278,8 +276,25 @@ class SandboxContainer:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+        # `--no-same-owner` — the extract happens inside a container whose
+        # caps are dropped (cap_drop=["ALL"], no CAP_CHOWN), so any attempt
+        # to restore the host uid/gid from the archive fails with
+        # "Cannot change ownership ... Operation not permitted" and aborts
+        # the extract. Telling tar not to chown makes files owned by the
+        # (root) process running the extract, which is what we want anyway.
         docker_proc = subprocess.Popen(
-            ["docker", "exec", "-i", cid, "tar", "xf", "-", "-C", container_path],
+            [
+                "docker",
+                "exec",
+                "-i",
+                cid,
+                "tar",
+                "xf",
+                "-",
+                "--no-same-owner",
+                "-C",
+                container_path,
+            ],
             stdin=tar_proc.stdout,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -291,13 +306,13 @@ class SandboxContainer:
         duration = time.monotonic() - start_time
         if docker_proc.returncode != 0:
             err = (docker_stderr or b"").decode("utf-8", errors="replace")
-            logger.warning(
-                "copy_tree_into failed (rc=%d): %s", docker_proc.returncode, err[:500]
-            )
+            logger.warning("copy_tree_into failed (rc=%d): %s", docker_proc.returncode, err[:500])
             raise RuntimeError(f"copy_tree_into failed: {err[:500]}")
         logger.debug(
             "copy_tree_into %s → %s completed in %.1fs",
-            host_path, container_path, duration,
+            host_path,
+            container_path,
+            duration,
         )
 
     def stop(self) -> None:

--- a/clearwing/sandbox/hunter_sandbox.py
+++ b/clearwing/sandbox/hunter_sandbox.py
@@ -12,11 +12,11 @@ Lifecycle:
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import shutil
 import tempfile
-from pathlib import Path
 
 from .builders import (
     BuildRecipe,
@@ -25,7 +25,7 @@ from .builders import (
     validate_sanitizer_combo,
 )
 from .container import SandboxConfig, SandboxContainer
-from .seccomp_profiles import write_seccomp_profile
+from .seccomp_profiles import get_seccomp_profile
 
 logger = logging.getLogger(__name__)
 
@@ -225,8 +225,12 @@ class HunterSandbox:
         # Mark the variant so hunter tools can introspect which image is running
         env["CLEARWING_SANITIZER_VARIANT"] = ",".join(chosen)
 
-        build_dir = Path(tempfile.mkdtemp(prefix="clearwing-seccomp-"))
-        seccomp_path = write_seccomp_profile("hunter", build_dir / "seccomp.json")
+        # Docker's Python SDK passes security_opt values directly to the
+        # Engine API, which expects seccomp content to be inline JSON — not
+        # a path (unlike the `docker run` CLI, which reads the file client-
+        # side). Passing a path makes the daemon reject the request with
+        # "Decoding seccomp profile failed: invalid character '/'..."
+        seccomp_json = json.dumps(get_seccomp_profile("hunter"))
 
         cfg = SandboxConfig(
             image=image_tag,
@@ -240,7 +244,7 @@ class HunterSandbox:
             working_dir="/workspace",
             name=None,
             pids_limit=512,
-            security_opt=[f"seccomp={seccomp_path}"],
+            security_opt=[f"seccomp={seccomp_json}"],
             cap_drop=["ALL"],
             cap_add=["SYS_PTRACE"],
             runtime=runtime,
@@ -338,9 +342,7 @@ class HunterSandbox:
 
         post_install_block = ""
         if self.post_install_commands:
-            post_install_block = "\n".join(
-                f"RUN {cmd}" for cmd in self.post_install_commands
-            )
+            post_install_block = "\n".join(f"RUN {cmd}" for cmd in self.post_install_commands)
 
         # Variant header makes the Dockerfile self-documenting so a human
         # inspecting the built image via `docker history` knows what's in it

--- a/tests/test_hunter_sandbox.py
+++ b/tests/test_hunter_sandbox.py
@@ -205,6 +205,38 @@ class TestHunterSandboxSpawn:
         # Session id was injected into env
         assert kwargs["environment"]["CLEARWING_SESSION_ID"] == "test-session"
 
+    def test_spawn_passes_inline_seccomp_json_not_path(self, temp_repo: Path, mock_docker):
+        """Regression: Docker's Engine API rejects path-form seccomp options
+        (it expects the option string after `seccomp=` to be JSON content).
+        The SDK doesn't read the file client-side the way `docker run` does,
+        so hunter spawns must inline the profile. See hunter_sandbox.py.
+        """
+        import json
+
+        (temp_repo / "Makefile").write_text("all:\n")
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "cid"
+        mock_container.short_id = "cid"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(temp_repo))
+        sb.build_image()
+        sb.spawn(session_id="seccomp-test", scratch_mount=False)
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        sec_opts = kwargs["security_opt"]
+        seccomp_opts = [o for o in sec_opts if o.startswith("seccomp=")]
+        assert len(seccomp_opts) == 1, sec_opts
+        value = seccomp_opts[0][len("seccomp=") :]
+        # Must be parseable JSON, not a filesystem path
+        assert not value.startswith("/"), (
+            f"seccomp option must be inline JSON, not a path: {value[:60]}"
+        )
+        parsed = json.loads(value)
+        assert parsed.get("defaultAction") == "SCMP_ACT_ALLOW"
+        assert any("mount" in rule.get("names", []) for rule in parsed.get("syscalls", []))
+
     def test_spawn_with_scratch_mount(self, temp_repo: Path, mock_docker):
         (temp_repo / "Makefile").write_text("all:\n")
         mock_docker.images.get.return_value = MagicMock()

--- a/tests/test_sandbox_writable_workspace.py
+++ b/tests/test_sandbox_writable_workspace.py
@@ -87,6 +87,17 @@ class TestCopyTreeInto:
         assert "tar" in tar_call[0][0]
         assert "/tmp/myrepo" in tar_call[0][0]
 
+        # Regression: the extract side must pass --no-same-owner so tar
+        # doesn't try to restore host uid/gid inside a cap-dropped container
+        # (CAP_CHOWN is removed by cap_drop=["ALL"]). Without this flag, tar
+        # aborts with "Cannot change ownership ... Operation not permitted".
+        docker_call = mock_popen.call_args_list[1]
+        docker_argv = docker_call[0][0]
+        assert "docker" in docker_argv[0]
+        assert "--no-same-owner" in docker_argv, (
+            f"extract tar must use --no-same-owner: {docker_argv}"
+        )
+
     def test_copy_tree_into_before_start_raises(self):
         cfg = SandboxConfig(image="alpine:latest")
         sb = SandboxContainer(cfg)


### PR DESCRIPTION
## Summary

Two regressions introduced by the spec-013 container-hardening commit (`611ec85`) made every `HunterPool` sandbox fail to start on current Docker versions. Every file in a sourcehunt run failed with `sandbox_factory failed` before any Hunter could execute. Caught by a live FFmpeg verification run today — no `sourcehunt` runs work end-to-end on `main` right now.

### 1. Seccomp profile must be inline JSON, not a filesystem path

`HunterSandbox.spawn` wrote a seccomp profile to a tempdir and passed `security_opt=[f"seccomp={seccomp_path}"]` to the Docker Python SDK. The SDK forwards that string verbatim to the Engine API, which expects the value after `seccomp=` to be inline JSON content — **only the `docker run` CLI reads the path client-side**. The daemon rejects every container start with:

```
Decoding seccomp profile failed: invalid character '/' looking for beginning of value
```

Fix: inline `json.dumps(get_seccomp_profile("hunter"))` directly into the `security_opt` string. The tempdir dance is no longer needed and has been removed (along with the now-unused `write_seccomp_profile` import and `pathlib` import).

### 2. `copy_tree_into` tar extract fails under cap_drop=["ALL"]

`SandboxContainer.copy_tree_into` runs `docker exec ... tar xf -` inside a container whose capabilities are dropped (`cap_drop=["ALL"]`, only `SYS_PTRACE` added back). tar's default is to restore the archive's uid/gid; on this host that's uid/gid 1000, and without `CAP_CHOWN` the extract aborts with:

```
Cannot change ownership to uid 1000, gid 1000: Operation not permitted
```

Fix: add `--no-same-owner` to the extract tar. Files end up owned by the (root) process doing the extract, which is what we want anyway — the source tree is read inside the container, not executed with its original host ownership.

## Test plan

- [x] `pytest tests/test_hunter_sandbox.py tests/test_sandbox_writable_workspace.py tests/test_self_security.py` — 73 passing, including two new regression tests that pin both contracts:
  - `test_spawn_passes_inline_seccomp_json_not_path` — asserts `security_opt` is parseable JSON, not a path starting with `/`.
  - `test_copy_tree_into_uses_streaming_tar` extended to assert `--no-same-owner` in the extract argv.
- [x] `ruff check clearwing/sandbox/` and `ruff format --check` clean on touched files.
- [x] **End-to-end verified against FFmpeg**: before these fixes, 100% of `HunterPool` files failed at `sandbox_factory`; after, the Ranker completes cleanly and Hunters run through to completion emitting real cost/finding numbers. (Run is still going in background — first two Hunters already emitted `findings=0 cost=$0.12 / $0.25 stop=completed`.)

## Notes

- Both regressions trace back to commit `611ec85` ("spec 013: container isolation and artifact protection"), merged 2026-04-18. No sourcehunt run has actually worked end-to-end since then.
- The `--no-same-owner` choice is equivalent to what the `docker cp` implementation does. Alternative options like adding `CAP_CHOWN` back to `cap_add` would undo the hardening intent of spec 013.
- CHANGELOG `[Unreleased] → Fixed` updated per `CONTRIBUTING.md`.