### PR TITLE
feat: explicit adapter on every preset + add OpenAI Responses API

### DIFF
--- a/clearwing/providers/catalog.py
+++ b/clearwing/providers/catalog.py
@@ -58,6 +58,14 @@ class ProviderPreset:
     #: setup wizard ("Common models: ..." hint).
     alt_models: tuple[str, ...] = field(default_factory=tuple)
 
+    #: Required genai-pyo3 adapter name. Every preset in the catalog
+    #: declares exactly one of: `anthropic`, `openai`, `openai_resp`,
+    #: `openai_codex`, `ollama`, `gemini`. The wizard persists this as
+    #: `adapter:` under `provider:` in `~/.clearwing/config.yaml` and
+    #: the provider manager routes by it — no base-URL guessing on
+    #: preset-driven configs.
+    provider_adapter: str = ""
+
     #: Optional named auth flow. OAuth providers use this to skip API-key
     #: prompts and write an auth marker into config.yaml.
     auth_flow: str | None = None
@@ -80,6 +88,7 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         api_key_env_var="ANTHROPIC_API_KEY",
         is_openai_compat=False,
         alt_models=("claude-opus-4-7", "claude-opus-4-6", "claude-haiku-4-5-20251001"),
+        provider_adapter="anthropic",
     ),
     ProviderPreset(
         key="openrouter",
@@ -99,18 +108,20 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
             "qwen/qwen-2.5-coder-32b-instruct",
             "google/gemini-2.0-flash",
         ),
+        provider_adapter="openai",
     ),
     ProviderPreset(
         key="ollama",
-        display_name="Ollama (local)",
-        description="Local models, free, no API key. Uses the OpenAI-compatible "
-        "endpoint at http://localhost:11434/v1.",
+        display_name="Ollama (local, native adapter)",
+        description="Local models, free, no API key. Uses the native "
+        "rust-genai Ollama adapter at http://localhost:11434.",
         docs_url="https://ollama.com/download",
-        default_base_url="http://localhost:11434/v1",
+        default_base_url="http://localhost:11434",
         default_model="qwen2.5-coder:32b",
         api_key_env_var=None,
         is_local=True,
         alt_models=("qwen2.5:72b", "llama3.3:70b", "mistral-small3:24b"),
+        provider_adapter="ollama",
     ),
     ProviderPreset(
         key="lmstudio",
@@ -122,16 +133,33 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         default_model="local-model",
         api_key_env_var=None,
         is_local=True,
+        provider_adapter="openai",
     ),
     ProviderPreset(
         key="openai",
-        display_name="OpenAI direct",
-        description="GPT-4o / GPT-4o-mini / o1 via api.openai.com.",
+        display_name="OpenAI (Chat Completions API)",
+        description="GPT-4o / GPT-4o-mini via `/v1/chat/completions` on "
+        "api.openai.com. Use `openai-responses` for GPT-5.x and o-series "
+        "reasoning models.",
         docs_url="https://platform.openai.com/api-keys",
         default_base_url="https://api.openai.com/v1",
         default_model="gpt-4o",
         api_key_env_var="OPENAI_API_KEY",
-        alt_models=("gpt-4o-mini", "o1-preview", "o1-mini"),
+        alt_models=("gpt-4o-mini",),
+        provider_adapter="openai",
+    ),
+    ProviderPreset(
+        key="openai-responses",
+        display_name="OpenAI (Responses API)",
+        description="GPT-5.x / o-series / current reasoning models via "
+        "`/v1/responses` on api.openai.com. Required for GPT-5.x and "
+        "the o-series; works for GPT-4o too. Streams by default.",
+        docs_url="https://platform.openai.com/api-keys",
+        default_base_url="https://api.openai.com/v1",
+        default_model="gpt-5.4",
+        api_key_env_var="OPENAI_API_KEY",
+        alt_models=("gpt-5.4-mini", "gpt-5.3-codex", "o3", "o3-mini", "gpt-4o"),
+        provider_adapter="openai_resp",
     ),
     ProviderPreset(
         key="openai-oauth",
@@ -143,6 +171,7 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         api_key_env_var=None,
         is_openai_compat=False,
         alt_models=("gpt-5.4", "gpt-5.4-mini", "gpt-5.2"),
+        provider_adapter="openai_codex",
         auth_flow="openai_codex",
     ),
     ProviderPreset(
@@ -158,6 +187,7 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
             "deepseek-ai/DeepSeek-V3",
             "mistralai/Mixtral-8x22B-Instruct-v0.1",
         ),
+        provider_adapter="openai",
     ),
     ProviderPreset(
         key="groq",
@@ -168,6 +198,7 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         default_model="llama-3.3-70b-versatile",
         api_key_env_var="GROQ_API_KEY",
         alt_models=("qwen-2.5-coder-32b", "mixtral-8x7b-32768"),
+        provider_adapter="openai",
     ),
     ProviderPreset(
         key="fireworks",
@@ -177,6 +208,7 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         default_base_url="https://api.fireworks.ai/inference/v1",
         default_model="accounts/fireworks/models/qwen2p5-coder-32b-instruct",
         api_key_env_var="FIREWORKS_API_KEY",
+        provider_adapter="openai",
     ),
     ProviderPreset(
         key="deepseek",
@@ -187,6 +219,7 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         default_model="deepseek-chat",
         api_key_env_var="DEEPSEEK_API_KEY",
         alt_models=("deepseek-coder",),
+        provider_adapter="openai",
     ),
     ProviderPreset(
         key="minimax",
@@ -204,16 +237,19 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
             "MiniMax-M2.5-highspeed",
             "MiniMax-M2.1",
         ),
+        provider_adapter="anthropic",
     ),
     ProviderPreset(
         key="custom",
-        display_name="Custom OpenAI-compatible endpoint",
-        description="Any service that speaks /v1/chat/completions — vLLM, SGLang, "
-        "SiliconFlow, Anyscale, Fireworks, a reverse proxy, ...",
+        display_name="Custom OpenAI-compatible endpoint (/v1/chat/completions)",
+        description="Any service that speaks `/v1/chat/completions` — vLLM, "
+        "SGLang, SiliconFlow, Anyscale, a reverse proxy, etc. Use "
+        "`openai-responses` for `/v1/responses` endpoints instead.",
         docs_url="https://docs.anthropic.com/en/api/openai-sdk",  # generic reference
         default_base_url="",
         default_model="",
         api_key_env_var=None,
+        provider_adapter="openai",
     ),
 )
 

--- a/clearwing/providers/env.py
+++ b/clearwing/providers/env.py
@@ -77,6 +77,11 @@ class LLMEndpoint:
     base_url: str | None = None
     api_key: str | None = None
     source: str = "default"
+    #: Optional explicit genai-pyo3 adapter override. When set, the
+    #: ProviderManager uses it instead of the base-URL heuristic. Set
+    #: via `adapter:` in the `provider:` config block (e.g. the
+    #: `openai-responses` preset writes `adapter: openai_resp`).
+    adapter: str | None = None
 
     @property
     def is_openai_compat(self) -> bool:
@@ -219,6 +224,7 @@ def resolve_llm_endpoint(
         cfg_base_url = config_provider.get("base_url")
         cfg_model = config_provider.get("model")
         cfg_api_key = _resolve_config_secret(config_provider.get("api_key"))
+        cfg_adapter = config_provider.get("adapter")  # None if unset
         if cfg_base_url:
             if _is_anthropic_compat_base_url(cfg_base_url):
                 return LLMEndpoint(
@@ -227,6 +233,7 @@ def resolve_llm_endpoint(
                     base_url=cfg_base_url,
                     api_key=cfg_api_key or os.environ.get(ENV_ANTHROPIC_KEY),
                     source="config",
+                    adapter=cfg_adapter,
                 )
             return LLMEndpoint(
                 provider="openai_compat",
@@ -234,6 +241,7 @@ def resolve_llm_endpoint(
                 base_url=cfg_base_url,
                 api_key=cfg_api_key or _placeholder_for(cfg_base_url),
                 source="config",
+                adapter=cfg_adapter,
             )
         if cfg_model or cfg_api_key:
             return LLMEndpoint(
@@ -242,6 +250,7 @@ def resolve_llm_endpoint(
                 base_url=None,
                 api_key=cfg_api_key or os.environ.get(ENV_ANTHROPIC_KEY),
                 source="config",
+                adapter=cfg_adapter,
             )
 
     # 4. Default — Anthropic direct via ANTHROPIC_API_KEY

--- a/clearwing/providers/manager.py
+++ b/clearwing/providers/manager.py
@@ -22,6 +22,11 @@ class ProviderConfig:
     base_url: str = ""  # for custom endpoints (Ollama, etc.)
     max_tokens: int = 4096
     temperature: float = 0.0
+    # Optional explicit genai-pyo3 adapter name. When set, overrides the
+    # base-URL heuristic in _adapter_for_base_url. Expected values:
+    # "openai", "openai_resp", "openai_codex", "anthropic", "gemini",
+    # "ollama". Left empty for the default behavior (heuristic).
+    adapter: str = ""
 
 
 @dataclass
@@ -238,6 +243,7 @@ class ProviderManager:
                     model=pcfg.get("model", ""),
                     api_key=api_key,
                     base_url=base_url,
+                    adapter=pcfg.get("adapter", ""),
                 )
             )
 
@@ -505,6 +511,10 @@ def _expand_env(value: Any) -> str:
 
 
 def _adapter_for_endpoint(endpoint: LLMEndpoint) -> str:
+    # Explicit `adapter:` on the endpoint (propagated from the
+    # `provider:` config block) wins over every other rule.
+    if endpoint.adapter:
+        return endpoint.adapter.strip()
     if endpoint.provider == "anthropic":
         return "anthropic"
     if endpoint.provider == "openai_codex":
@@ -513,6 +523,11 @@ def _adapter_for_endpoint(endpoint: LLMEndpoint) -> str:
 
 
 def _adapter_for_provider_config(provider: str, config: ProviderConfig | None) -> str:
+    # Explicit `adapter:` on the provider config wins over every heuristic.
+    # Setup wizard writes this for presets that carry `provider_adapter`
+    # (e.g. the `openai-responses` preset → `adapter: openai_resp`).
+    if config is not None and config.adapter:
+        return config.adapter.strip()
     explicit = provider.lower().strip()
     if explicit == "anthropic":
         return "anthropic"
@@ -522,19 +537,20 @@ def _adapter_for_provider_config(provider: str, config: ProviderConfig | None) -
         return "gemini"
     if explicit == "ollama":
         return "ollama"
-    if explicit == "openai":
-        return _adapter_for_base_url(
-            config.base_url if config else None, config.model if config else ""
-        )
     return _adapter_for_base_url(
         config.base_url if config else None, config.model if config else ""
     )
 
 
 def _adapter_for_base_url(base_url: str | None, model: str) -> str:
+    """Fallback adapter resolution when no explicit `adapter:` is set.
+
+    Pure URL / model-name heuristics — no per-host hardcoded special
+    cases. Users on endpoints that aren't disambiguated by URL should
+    set `adapter:` on their provider config (the `openai-responses`
+    preset does this automatically).
+    """
     host = (base_url or "").lower()
-    if "localhost:8183" in host or "127.0.0.1:8183" in host:
-        return "openai_resp"
     if "11434" in host:
         return "ollama"
     if "generativelanguage.googleapis.com" in host or "googleapis.com" in host:

--- a/clearwing/ui/commands/setup.py
+++ b/clearwing/ui/commands/setup.py
@@ -256,9 +256,13 @@ def _prompt_api_key(
                 )
                 return ""
             except Exception as exc:
-                console.print(f"[yellow]Stored OpenAI OAuth credentials need renewal: {exc}[/yellow]")
+                console.print(
+                    f"[yellow]Stored OpenAI OAuth credentials need renewal: {exc}[/yellow]"
+                )
 
-        console.print("[dim]Starting OpenAI browser OAuth. Credentials are stored under ~/.clearwing/auth/.[/dim]")
+        console.print(
+            "[dim]Starting OpenAI browser OAuth. Credentials are stored under ~/.clearwing/auth/.[/dim]"
+        )
         creds = login_openai_oauth(
             no_open=no_open,
             timeout_seconds=timeout_seconds,
@@ -376,6 +380,11 @@ def _write_config(
         provider_section["api_key"] = api_key_literal
     if model:
         provider_section["model"] = model
+    if preset.provider_adapter:
+        # Presets like `openai-responses` that target a specific
+        # genai-pyo3 adapter persist the name so the provider manager
+        # doesn't have to guess from the base URL.
+        provider_section["adapter"] = preset.provider_adapter
 
     path = cli.config.DEFAULT_CONFIG_PATH
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,15 +1,31 @@
 # LLM providers
 
-Clearwing talks to any of five LLM backends:
+Clearwing runs on `genai-pyo3` (native Rust bindings to `rust-genai`),
+which speaks every major provider directly. The wizard
+(`clearwing setup`) exposes a menu of the known backends, each
+carrying an explicit **adapter** name that decides the wire
+protocol — `anthropic`, `openai` (chat completions), `openai_resp`
+(responses API), `openai_codex` (ChatGPT OAuth), `ollama`, or
+`gemini`. There's no heuristic guessing: the preset you pick in
+the wizard persists `adapter:` into `~/.clearwing/config.yaml`
+alongside `base_url`, `api_key`, and `model`.
 
-- **Anthropic direct** — default, via `ANTHROPIC_API_KEY`
-- **OpenAI-compatible endpoints** — the same `/v1/chat/completions`
-  wire format used by OpenRouter, Ollama, LM Studio, vLLM, Together,
-  Groq, DeepSeek, and OpenAI itself
-- **Native Ollama** — via `pip install clearwing[ollama]`
-- **Google Gemini** — via `pip install clearwing[google]`
-- **Custom routing** — per-task provider selection via
-  `~/.clearwing/config.yaml`
+Backends covered below:
+
+- **Anthropic direct** — Claude via `api.anthropic.com` (`anthropic` adapter).
+- **OpenAI (Chat Completions)** — GPT-4o / GPT-4o-mini via
+  `/v1/chat/completions` (`openai` adapter).
+- **OpenAI (Responses API)** — GPT-5.x / o-series via `/v1/responses`
+  (`openai_resp` adapter). Required for GPT-5.x and o-series.
+- **OpenAI OAuth (ChatGPT)** — Plus/Pro login via Codex backend (`openai_codex`).
+- **OpenRouter, Together, Groq, Fireworks, DeepSeek, LM Studio, vLLM, custom** —
+  anything that speaks `/v1/chat/completions` (`openai` adapter).
+- **MiniMax** — M2.7 / M2.5 via the Anthropic-compatible endpoint
+  (`anthropic` adapter at `api.minimax.io/anthropic`).
+- **Ollama** — local models via the native rust-genai Ollama adapter
+  (`ollama` adapter at `http://localhost:11434`, no `/v1` suffix).
+- **Gemini** — reserved for when a Gemini preset is added; adapter
+  name is `gemini`.
 
 This page walks through each backend with copy-paste snippets.
 
@@ -83,6 +99,66 @@ clearwing interactive --model claude-sonnet-4-6
 clearwing sourcehunt /path/to/repo
 ```
 
+Adapter: `anthropic` (the wizard writes this automatically; no
+heuristic is involved).
+
+## OpenAI (Chat Completions API)
+
+The classic OpenAI API. Use this for GPT-4o / GPT-4o-mini. For
+GPT-5.x and the o-series (o1, o3) use the Responses API preset
+below — those models require it.
+
+```bash
+clearwing setup --provider openai
+# or explicitly
+export CLEARWING_BASE_URL=https://api.openai.com/v1
+export CLEARWING_API_KEY=$OPENAI_API_KEY
+export CLEARWING_MODEL=gpt-4o
+```
+
+`~/.clearwing/config.yaml`:
+
+```yaml
+provider:
+  base_url: https://api.openai.com/v1
+  api_key: ${OPENAI_API_KEY}
+  model: gpt-4o
+  adapter: openai
+```
+
+## OpenAI (Responses API)
+
+Required for GPT-5.x and o-series models — those only speak the
+newer `/v1/responses` streaming protocol. Works for GPT-4o as well,
+but chat-completions is slightly cheaper for older models so pick
+the preset that matches your model generation.
+
+```bash
+clearwing setup --provider openai-responses
+# or explicitly
+export CLEARWING_BASE_URL=https://api.openai.com/v1
+export CLEARWING_API_KEY=$OPENAI_API_KEY
+export CLEARWING_MODEL=gpt-5.4
+```
+
+`~/.clearwing/config.yaml`:
+
+```yaml
+provider:
+  base_url: https://api.openai.com/v1
+  api_key: ${OPENAI_API_KEY}
+  model: gpt-5.4
+  adapter: openai_resp
+```
+
+The `adapter: openai_resp` line is what switches the wire protocol
+from chat-completions to responses. Leave it out and the request
+will 404 against GPT-5.x models. The wizard writes it automatically
+when you pick the `openai-responses` preset.
+
+Any `/v1/responses` proxy works — point `base_url` at your proxy
+host, keep `adapter: openai_resp`.
+
 ## OpenRouter
 
 OpenRouter routes your request to the specific model you name.
@@ -127,6 +203,7 @@ provider:
   base_url: https://openrouter.ai/api/v1
   api_key: ${OPENROUTER_API_KEY}
   model: anthropic/claude-opus-4
+  adapter: openai
 ```
 
 The `${OPENROUTER_API_KEY}` literal is expanded from the environment
@@ -158,14 +235,10 @@ clearwing sourcehunt /path/to/repo --depth standard
 Or pin it explicitly in `~/.clearwing/config.yaml`:
 
 ```yaml
-providers:
-  local_ollama:
-    provider: ollama
-    base_url: http://localhost:11434
-    model: qwen2.5-coder:32b
-
-routes:
-  default: local_ollama
+provider:
+  base_url: http://localhost:11434
+  model: qwen2.5-coder:32b
+  adapter: ollama
 ```
 
 ### OpenAI-compat endpoint (alternative)
@@ -218,7 +291,9 @@ clearwing sourcehunt /path/to/repo
 
 ## Together, Groq, Fireworks, Anyscale, SiliconFlow, DeepSeek
 
-All OpenAI-compatible — same pattern, different base URL.
+All `/v1/chat/completions` endpoints — same pattern, different base
+URL, `adapter: openai`. The wizard handles them directly; the env-var
+paths are here for scripting.
 
 ```bash
 # Together
@@ -240,11 +315,32 @@ export CLEARWING_MODEL=accounts/fireworks/models/qwen2p5-coder-32b-instruct
 export CLEARWING_BASE_URL=https://api.deepseek.com/v1
 export CLEARWING_API_KEY=$DEEPSEEK_API_KEY
 export CLEARWING_MODEL=deepseek-chat
+```
 
-# OpenAI direct
-export CLEARWING_BASE_URL=https://api.openai.com/v1
-export CLEARWING_API_KEY=$OPENAI_API_KEY
-export CLEARWING_MODEL=gpt-4o
+For OpenAI itself, use the [Chat Completions](#openai-chat-completions-api)
+or [Responses](#openai-responses-api) section above — the model
+generation decides which.
+
+## MiniMax
+
+MiniMax's M-series reasoning models are served via an
+Anthropic-compatible endpoint at `https://api.minimax.io/anthropic`
+(not an OpenAI-compat one). The wizard picks the right adapter
+automatically.
+
+```bash
+clearwing setup --provider minimax
+# writes adapter: anthropic + base_url: https://api.minimax.io/anthropic
+```
+
+`~/.clearwing/config.yaml`:
+
+```yaml
+provider:
+  base_url: https://api.minimax.io/anthropic
+  api_key: ${MINIMAX_API_KEY}
+  model: MiniMax-M2.7
+  adapter: anthropic
 ```
 
 ## Per-task routing (advanced)

--- a/tests/test_setup_and_doctor.py
+++ b/tests/test_setup_and_doctor.py
@@ -79,6 +79,49 @@ class TestProviderCatalog:
         assert preset.auth_flow == "openai_codex"
         assert not preset.is_openai_compat
 
+    def test_every_preset_declares_a_provider_adapter(self):
+        """Rule: every preset in the catalog must set
+        `provider_adapter` to one of the known genai-pyo3 adapter
+        names. No None, no empty string — the wizard refuses to
+        persist a config without an explicit adapter, so the
+        catalog can't ship a preset that lacks one.
+        """
+        valid_adapters = {
+            "anthropic",
+            "openai",
+            "openai_resp",
+            "openai_codex",
+            "ollama",
+            "gemini",
+        }
+        for preset in KNOWN_PROVIDERS:
+            assert preset.provider_adapter, (
+                f"{preset.key!r} must set provider_adapter to one of {sorted(valid_adapters)}"
+            )
+            assert preset.provider_adapter in valid_adapters, (
+                f"{preset.key!r} has unknown adapter "
+                f"{preset.provider_adapter!r}; valid={sorted(valid_adapters)}"
+            )
+
+    def test_openai_responses_preset_exists(self):
+        """The Responses API (used by GPT-5.x and o-series) must be
+        discoverable from the setup wizard — it's not enough to bolt
+        it on via the `custom` preset."""
+        preset = preset_by_key("openai-responses")
+        assert preset is not None
+        assert preset.provider_adapter == "openai_resp"
+        assert preset.default_base_url == "https://api.openai.com/v1"
+        assert preset.api_key_env_var == "OPENAI_API_KEY"
+
+    def test_openai_chat_and_responses_both_present(self):
+        """Both OpenAI API dialects have catalog entries."""
+        chat = preset_by_key("openai")
+        resp = preset_by_key("openai-responses")
+        assert chat is not None and chat.provider_adapter == "openai"
+        assert resp is not None and resp.provider_adapter == "openai_resp"
+        # Same API key env var, different wire shape
+        assert chat.api_key_env_var == resp.api_key_env_var == "OPENAI_API_KEY"
+
 
 # --- Setup wizard: _mask_secret -------------------------------------------
 
@@ -164,6 +207,7 @@ class TestWriteConfig:
                 "base_url": "https://openrouter.ai/api/v1",
                 "api_key": "${OPENROUTER_API_KEY}",
                 "model": "anthropic/claude-opus-4",
+                "adapter": "openai",
             }
         }
 
@@ -250,6 +294,7 @@ class TestWriteConfig:
                 "auth": "openai_codex",
                 "base_url": "https://chatgpt.com/backend-api",
                 "model": "gpt-5.2",
+                "adapter": "openai_codex",
             }
         }
 


### PR DESCRIPTION
Two linked changes:

## 1. Add the OpenAI Responses API to the setup wizard

GPT-5.x and the o-series (o1, o3, ...) are only accessible through `/v1/responses`. The wizard previously had only the classic OpenAI Chat Completions preset, so those users had no path through `clearwing setup` and had to hand-edit `config.yaml`. Added a sibling `openai-responses` preset:

| | `openai` preset | `openai-responses` preset |
|---|---|---|
| Wire protocol | `/v1/chat/completions` | `/v1/responses` (streaming) |
| Adapter | `openai` | `openai_resp` |
| Good for | GPT-4o / GPT-4o-mini | GPT-5.x, o3, o3-mini, reasoning models |
| Base URL | `https://api.openai.com/v1` | same |
| API key env | `OPENAI_API_KEY` | same |

## 2. Every preset now declares an explicit adapter

Per the "no optional, no cheating" rule: `ProviderPreset.provider_adapter` is a required field on every entry in the catalog. The wizard persists it into `~/.clearwing/config.yaml` under `provider:` as `adapter: <name>`, and the provider manager routes by that exact value — no base-URL heuristic guessing on preset-driven configs.

Valid adapters: `anthropic`, `openai`, `openai_resp`, `openai_codex`, `ollama`, `gemini`. A catalog-wide invariant test enforces this.

### The hardcoded localhost:8183 check is gone

`_adapter_for_base_url` used to contain this special case:

```python
if "localhost:8183" in host or "127.0.0.1:8183" in host:
    return "openai_resp"
```

That was **mine**, added for my local dev proxy. It was also the *only* path in the codebase that routed anything to `openai_resp`. Every other Responses API endpoint (including `api.openai.com` itself) silently fell through to chat-completions and 404ed against GPT-5.x. Dropped. Users who want Responses API now pick the explicit preset — which writes `adapter: openai_resp` into config, which the manager then uses verbatim.

### Ollama moved to the native adapter

The Ollama preset now uses `http://localhost:11434` (no `/v1` suffix) with `adapter: ollama` — the native rust-genai Ollama adapter. This matches the `docs/providers.md` rewrite from PR #25, which had documented the native path but the catalog was still pointing at the `/v1` shim.

## Mechanism

- `ProviderPreset` grows `provider_adapter: str`.
- `ProviderConfig` grows `adapter: str = ""`.
- `LLMEndpoint` grows `adapter: str | None = None`.
- `_adapter_for_endpoint` and `_adapter_for_provider_config` both check the explicit adapter first and use it verbatim when set.
- The old base-URL heuristic stays as a last-resort fallback for bare `--base-url` / `--api-key` CLI flags (no preset involved).

## Test plan

- [x] `pytest tests/test_providers_env.py tests/test_providers.py tests/test_setup_and_doctor.py` — **94 passing.**
- [x] New tests:
  - `test_every_preset_declares_a_provider_adapter` — fails CI if anyone adds a preset without an adapter or with an unrecognized one.
  - `test_openai_responses_preset_exists` — pins the new preset's base_url, api_key env, and adapter.
  - `test_openai_chat_and_responses_both_present` — asserts both OpenAI dialects coexist with the same env var, different adapters.
- [x] Existing `_write_config` tests updated to expect the `adapter:` key in the written YAML (two tests — `test_writes_minimal_provider_section` and `test_openai_oauth_writes_auth_marker_without_api_key`).
- [x] `ruff check` clean on touched files.

## Docs

`docs/providers.md`:
- Rewrote the top matter to describe the adapter model.
- Added dedicated sections for **OpenAI (Chat Completions API)** vs **OpenAI (Responses API)** with full config.yaml examples including the `adapter:` line.
- Added a **MiniMax** section (was missing) showing `adapter: anthropic` at `api.minimax.io/anthropic`.
- Fixed the Ollama config.yaml example to use `adapter: ollama` at `:11434` (no `/v1`).
- Removed the standalone "OpenAI direct" line from the consolidated `/v1/chat/completions` block — points readers at the dedicated sections.

## Labels

Applying `enhancement` — new capability in the setup wizard.

Per [discussion #26](https://github.com/Lazarus-AI/clearwing/discussions/26): no `CHANGELOG.md` entry, PR title is the release-notes line.
