### PR TITLE
fix: make disclose verify actually round-trip against commitments (spec 014)

### DIFF
--- a/clearwing/sourcehunt/commitment.py
+++ b/clearwing/sourcehunt/commitment.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import hashlib
 import json
 import threading
-import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -35,6 +34,30 @@ class Commitment:
     cwe: str = ""
 
 
+def _canonicalize(
+    finding_id: str,
+    document: str,
+    commitment_type: str,
+    committed_at: str,
+) -> str:
+    """Canonical JSON form that gets hashed.
+
+    Must produce identical output for `generate_commitment` at commit
+    time and `verify_commitment` at reveal time — any drift here
+    breaks every commitment. Kept deliberately small: four fields,
+    sort_keys so key order is irrelevant.
+    """
+    return json.dumps(
+        {
+            "finding_id": finding_id,
+            "document": document,
+            "type": commitment_type,
+            "committed_at": committed_at,
+        },
+        sort_keys=True,
+    )
+
+
 def generate_commitment(
     finding_id: str,
     document: str,
@@ -43,43 +66,63 @@ def generate_commitment(
     severity: str = "",
     cwe: str = "",
 ) -> Commitment:
-    canonical = json.dumps({
-        "finding_id": finding_id,
-        "document": document,
-        "type": commitment_type.value,
-        "generated_at": datetime.now(timezone.utc).isoformat(),
-    }, sort_keys=True)
+    # One now() call shared between the hash input and the stored
+    # timestamp. Previously these were two separate now() calls, so the
+    # hash input's `generated_at` differed from the stored
+    # `committed_at` by microseconds — making verification fundamentally
+    # impossible no matter what the caller supplied.
+    committed_at = datetime.now(timezone.utc).isoformat()
+    canonical = _canonicalize(
+        finding_id=finding_id,
+        document=document,
+        commitment_type=commitment_type.value,
+        committed_at=committed_at,
+    )
     digest = hashlib.sha3_224(canonical.encode()).hexdigest()
     return Commitment(
         finding_id=finding_id,
         digest=digest,
         algorithm="sha3-224",
         commitment_type=commitment_type.value,
-        committed_at=datetime.now(timezone.utc).isoformat(),
+        committed_at=committed_at,
         project=project,
         severity=severity,
         cwe=cwe,
     )
 
 
-def verify_commitment(document: str, expected_digest: str) -> bool:
-    actual = hashlib.sha3_224(document.encode()).hexdigest()
-    return actual == expected_digest
+def verify_commitment(document: str, commitment: Commitment) -> bool:
+    """Re-hash `document` under `commitment`'s canonical form and compare.
+
+    Reconstructs the exact canonical JSON that was hashed at commit
+    time — `finding_id`, `document`, `type`, `committed_at` — and
+    compares digests. Accepts a `Commitment` rather than a raw digest
+    string because verification requires all four fields; passing just
+    the digest would make the check silently wrong.
+    """
+    canonical = _canonicalize(
+        finding_id=commitment.finding_id,
+        document=document,
+        commitment_type=commitment.commitment_type,
+        committed_at=commitment.committed_at,
+    )
+    actual = hashlib.sha3_224(canonical.encode()).hexdigest()
+    return actual == commitment.digest
 
 
 def _build_report_document(finding: dict) -> str:
-    return json.dumps({
-        "finding_id": finding.get("id", ""),
-        "file": finding.get("file", ""),
-        "line_number": finding.get("line_number", 0),
-        "cwe": finding.get("cwe", ""),
-        "severity": (
-            finding.get("severity_verified")
-            or finding.get("severity", "")
-        ),
-        "description": finding.get("description", ""),
-        "evidence_level": finding.get("evidence_level", ""),
-    }, sort_keys=True)
+    return json.dumps(
+        {
+            "finding_id": finding.get("id", ""),
+            "file": finding.get("file", ""),
+            "line_number": finding.get("line_number", 0),
+            "cwe": finding.get("cwe", ""),
+            "severity": (finding.get("severity_verified") or finding.get("severity", "")),
+            "description": finding.get("description", ""),
+            "evidence_level": finding.get("evidence_level", ""),
+        },
+        sort_keys=True,
+    )
 
 
 def _default_log_path() -> Path:
@@ -112,19 +155,19 @@ class CommitmentLog:
                 f.write(json.dumps(record) + "\n")
 
     def commit_finding(self, finding: dict, project: str = "") -> list[Commitment]:
-        severity = (
-            finding.get("severity_verified")
-            or finding.get("severity", "")
-        )
+        severity = finding.get("severity_verified") or finding.get("severity", "")
         cwe = finding.get("cwe", "")
         finding_id = finding.get("id", "")
         commitments: list[Commitment] = []
 
         report_doc = _build_report_document(finding)
         c = generate_commitment(
-            finding_id, report_doc,
+            finding_id,
+            report_doc,
             commitment_type=CommitmentType.REPORT,
-            project=project, severity=severity, cwe=cwe,
+            project=project,
+            severity=severity,
+            cwe=cwe,
         )
         self.commit(c)
         commitments.append(c)
@@ -133,9 +176,12 @@ class CommitmentLog:
         if poc:
             poc_text = poc if isinstance(poc, str) else str(poc)
             c = generate_commitment(
-                finding_id, poc_text,
+                finding_id,
+                poc_text,
                 commitment_type=CommitmentType.POC,
-                project=project, severity=severity, cwe=cwe,
+                project=project,
+                severity=severity,
+                cwe=cwe,
             )
             self.commit(c)
             commitments.append(c)
@@ -144,9 +190,12 @@ class CommitmentLog:
         if exploit:
             exploit_text = exploit if isinstance(exploit, str) else str(exploit)
             c = generate_commitment(
-                finding_id, exploit_text,
+                finding_id,
+                exploit_text,
                 commitment_type=CommitmentType.EXPLOIT,
-                project=project, severity=severity, cwe=cwe,
+                project=project,
+                severity=severity,
+                cwe=cwe,
             )
             self.commit(c)
             commitments.append(c)
@@ -165,16 +214,18 @@ class CommitmentLog:
                 record = json.loads(line)
                 if finding_id and record.get("finding_id") != finding_id:
                     continue
-                results.append(Commitment(
-                    finding_id=record["finding_id"],
-                    digest=record["digest"],
-                    algorithm=record["algorithm"],
-                    commitment_type=record["commitment_type"],
-                    committed_at=record["committed_at"],
-                    project=record.get("project", ""),
-                    severity=record.get("severity", ""),
-                    cwe=record.get("cwe", ""),
-                ))
+                results.append(
+                    Commitment(
+                        finding_id=record["finding_id"],
+                        digest=record["digest"],
+                        algorithm=record["algorithm"],
+                        commitment_type=record["commitment_type"],
+                        committed_at=record["committed_at"],
+                        project=record.get("project", ""),
+                        severity=record.get("severity", ""),
+                        cwe=record.get("cwe", ""),
+                    )
+                )
         return results
 
     def format_public_table(self, fmt: str = "markdown") -> str:
@@ -185,17 +236,20 @@ class CommitmentLog:
             return "No commitments recorded."
 
         if fmt == "json":
-            return json.dumps([
-                {
-                    "date": c.committed_at,
-                    "project": c.project,
-                    "severity": c.severity,
-                    "cwe": c.cwe,
-                    "type": c.commitment_type,
-                    "sha3_224": c.digest,
-                }
-                for c in commitments
-            ], indent=2)
+            return json.dumps(
+                [
+                    {
+                        "date": c.committed_at,
+                        "project": c.project,
+                        "severity": c.severity,
+                        "cwe": c.cwe,
+                        "type": c.commitment_type,
+                        "sha3_224": c.digest,
+                    }
+                    for c in commitments
+                ],
+                indent=2,
+            )
 
         lines = [
             "| Date | Project | Severity | CWE | Type | SHA-3-224 |",

--- a/clearwing/ui/commands/disclose.py
+++ b/clearwing/ui/commands/disclose.py
@@ -311,7 +311,7 @@ def _handle_verify(cli, args, db, workflow):
         f"for {args.finding_id}:[/bold]",
     )
     for c in commitments:
-        match = verify_commitment(document, c.digest)
+        match = verify_commitment(document, c)
         status = "[green]MATCH[/green]" if match else "[red]MISMATCH[/red]"
         cli.console.print(
             f"  {c.commitment_type}: {c.digest[:16]}... {status}",

--- a/tests/test_commitments.py
+++ b/tests/test_commitments.py
@@ -6,8 +6,6 @@ import json
 import tempfile
 from pathlib import Path
 
-import pytest
-
 from clearwing.sourcehunt.commitment import (
     Commitment,
     CommitmentLog,
@@ -15,7 +13,6 @@ from clearwing.sourcehunt.commitment import (
     generate_commitment,
     verify_commitment,
 )
-
 
 # --- Commitment generation tests ---------------------------------------------
 
@@ -39,7 +36,8 @@ class TestGenerateCommitment:
 
     def test_includes_metadata(self):
         c = generate_commitment(
-            "f1", "doc",
+            "f1",
+            "doc",
             project="https://github.com/test/repo",
             severity="critical",
             cwe="CWE-787",
@@ -62,23 +60,75 @@ class TestGenerateCommitment:
 
 
 class TestVerifyCommitment:
-    def test_matching_document(self):
+    def test_round_trip_matches(self):
+        """Regression: commit then verify must MATCH for the same document.
+
+        Previously failed — `generate_commitment` hashed
+        `{finding_id, document, type, generated_at}` while
+        `verify_commitment` hashed only the document. Two different
+        hash functions, no round-trip possible.
+        """
         doc = "the exact original document"
-        import hashlib
-        digest = hashlib.sha3_224(doc.encode()).hexdigest()
-        assert verify_commitment(doc, digest) is True
+        c = generate_commitment("finding-001", doc)
+        assert verify_commitment(doc, c) is True
 
-    def test_mismatched_document(self):
-        import hashlib
-        doc = "original"
-        digest = hashlib.sha3_224(doc.encode()).hexdigest()
-        assert verify_commitment("different document", digest) is False
+    def test_mismatched_document_fails(self):
+        c = generate_commitment("finding-001", "original")
+        assert verify_commitment("different document", c) is False
 
-    def test_empty_document(self):
-        import hashlib
-        doc = ""
-        digest = hashlib.sha3_224(doc.encode()).hexdigest()
-        assert verify_commitment("", digest) is True
+    def test_empty_document_round_trip(self):
+        c = generate_commitment("finding-001", "")
+        assert verify_commitment("", c) is True
+
+    def test_mismatched_finding_id_fails(self):
+        """Commitment's finding_id is part of the hashed canonical form
+        — a commitment for finding-001 must not verify under a
+        commitment claiming to be for finding-002 even if the document
+        text is identical."""
+        doc = "report body"
+        c1 = generate_commitment("finding-001", doc)
+        c2 = Commitment(
+            finding_id="finding-002",
+            digest=c1.digest,
+            algorithm=c1.algorithm,
+            commitment_type=c1.commitment_type,
+            committed_at=c1.committed_at,
+        )
+        assert verify_commitment(doc, c2) is False
+
+    def test_mismatched_type_fails(self):
+        """commitment_type is part of the canonical form."""
+        doc = "report body"
+        c1 = generate_commitment("f1", doc, commitment_type=CommitmentType.REPORT)
+        c2 = Commitment(
+            finding_id=c1.finding_id,
+            digest=c1.digest,
+            algorithm=c1.algorithm,
+            commitment_type="poc",
+            committed_at=c1.committed_at,
+        )
+        assert verify_commitment(doc, c2) is False
+
+    def test_stored_timestamp_matches_hashed_timestamp(self):
+        """Regression: `generate_commitment` used to call
+        `datetime.now()` twice — once for the hash input's
+        `generated_at`, once for the stored `committed_at`. Those two
+        calls happened microseconds apart and produced different
+        timestamps, so the stored timestamp was NEVER the one that
+        was hashed, making verification impossible. A single `now()`
+        call shared between the two ensures round-trip.
+        """
+        doc = "anything"
+        c = generate_commitment("f1", doc)
+        assert verify_commitment(doc, c) is True
+        # Re-load from a jsonl-style round-trip to be sure the stored
+        # timestamp survives serialization without drift.
+        with tempfile.TemporaryDirectory() as td:
+            log = CommitmentLog(log_path=Path(td) / "commitments.jsonl")
+            log.commit(c)
+            loaded = log.get_commitments(finding_id="f1")[0]
+        assert loaded.committed_at == c.committed_at
+        assert verify_commitment(doc, loaded) is True
 
 
 # --- CommitmentLog tests -----------------------------------------------------
@@ -171,7 +221,8 @@ class TestCommitmentLog:
             log = CommitmentLog(log_path=Path(td) / "commitments.jsonl")
             finding = {"id": "f1", "description": "test", "severity": "high"}
             commitments = log.commit_finding(
-                finding, project="https://github.com/test/repo",
+                finding,
+                project="https://github.com/test/repo",
             )
             assert commitments[0].project == "https://github.com/test/repo"
 
@@ -183,11 +234,15 @@ class TestFormatPublicTable:
     def test_markdown_table(self):
         with tempfile.TemporaryDirectory() as td:
             log = CommitmentLog(log_path=Path(td) / "commitments.jsonl")
-            log.commit(generate_commitment(
-                "f1", "doc",
-                project="https://github.com/test/repo",
-                severity="critical", cwe="CWE-787",
-            ))
+            log.commit(
+                generate_commitment(
+                    "f1",
+                    "doc",
+                    project="https://github.com/test/repo",
+                    severity="critical",
+                    cwe="CWE-787",
+                )
+            )
             output = log.format_public_table(fmt="markdown")
             assert "| Date |" in output
             assert "SHA-3-224" in output
@@ -224,6 +279,7 @@ class TestFormatPublicTable:
 class TestCLIRegistration:
     def test_verify_subcommand(self):
         import argparse
+
         from clearwing.ui.commands import disclose
 
         parser = argparse.ArgumentParser()
@@ -238,6 +294,7 @@ class TestCLIRegistration:
 
     def test_commitments_subcommand(self):
         import argparse
+
         from clearwing.ui.commands import disclose
 
         parser = argparse.ArgumentParser()
@@ -248,6 +305,7 @@ class TestCLIRegistration:
 
     def test_commitments_format_flag(self):
         import argparse
+
         from clearwing.ui.commands import disclose
 
         parser = argparse.ArgumentParser()


### PR DESCRIPTION
Surfaced while playing with the spec 011 disclosure workflow on the 4 verified findings from today's FFmpeg sourcehunt run. **Every** `clearwing disclose verify --document <...>` call returned MISMATCH — not because my documents were wrong, but because the commit and verify paths literally computed two different hashes.

## Two bugs, both fatal

### 1. Two different hash functions

`generate_commitment` hashed:

```json
{"finding_id": "...", "document": "...", "type": "...", "generated_at": "..."}
```

`verify_commitment` hashed:

```text
<document bytes>
```

These were never going to agree. The commit side mixes in three extra fields (finding_id, type, generated_at) that the verify side never sees. A caller reconstructing the exact document they committed would still get MISMATCH. Every commitment ever produced by main branch was un-verifiable from day one of spec 014.

### 2. Two different timestamps

Same function, `generate_commitment`, called `datetime.now(timezone.utc)` **twice**:

```python
canonical = json.dumps({..., "generated_at": datetime.now(timezone.utc).isoformat()}, ...)
digest = hashlib.sha3_224(canonical.encode()).hexdigest()
return Commitment(..., committed_at=datetime.now(timezone.utc).isoformat(), ...)
```

Those two `now()` calls are microseconds apart. The timestamp inside the hash input was NEVER the one written to the stored `committed_at`. Even if bug #1 were fixed, users would have no way to reconstruct the exact timestamp that went into the digest.

## Fix

- Extract `_canonicalize(finding_id, document, type, committed_at)` — one canonical JSON form that both commit and verify use. Any drift here breaks every commitment, so having a single function is a safety property.
- `generate_commitment` calls `datetime.now()` **once**, shares the timestamp between the hash input and the stored `committed_at`.
- `verify_commitment` now takes a `Commitment` object, not a raw digest. It reconstructs the canonical form using the commitment's own `finding_id` / `commitment_type` / `committed_at` and compares digests against `commitment.digest`. Can't be misused — a caller can't pass a bare digest and silently get wrong semantics.
- CLI `disclose verify` handler updated to pass the `Commitment` through.

## End-to-end check

After the fix, with the 4 verified FFmpeg findings re-queued and re-committed:

```
$ clearwing disclose verify hunter-3f65dc9a --document /tmp/rtpenc_latm_report.json
Verifying 2 commitment(s) for hunter-3f65dc9a:
  report: cf28849f1e298698... MATCH
  poc:    b5e964a8518125df... MISMATCH  ← expected: report doc ≠ PoC doc
```

Report commitment MATCHes against its own report document. PoC commitment correctly MISMATCHes when fed the report document (not the PoC). Negative path works.

## Test plan

- [x] `pytest tests/test_commitments.py` — **28 passing**.
- [x] Replaced the 3 `TestVerifyCommitment` tests that asserted the broken behavior with 6 new ones:
  - Round-trip MATCH
  - Wrong document → MISMATCH
  - Empty-document round-trip
  - Wrong `finding_id` on otherwise-identical commitment → MISMATCH (id is bound into the hash)
  - Wrong `commitment_type` → MISMATCH
  - Timestamp-round-trip through JSONL → MATCH (pins the single-`now()` regression)
- [x] `ruff check clearwing/sourcehunt/commitment.py tests/test_commitments.py` clean.
- [x] Broader grep check: no other callers of `verify_commitment` besides `disclose.py`.

## Labels

Applying `bug` — spec 014 was broken from the moment it landed.

Per [discussion #26](https://github.com/Lazarus-AI/clearwing/discussions/26): no CHANGELOG entry, PR title is the release-notes line.

## Note on existing commitments

Commitments written by any previous run are permanently un-verifiable — their `generated_at` timestamps were lost when the second `datetime.now()` call overwrote the record. Users should discard old `commitments.jsonl` entries; there's no way to recover what was hashed. The fix only applies to commitments produced after this PR lands.
