### PR TITLE
fix: weekend-audit cleanup (specs 009/013/001) + native reasoning capture

### DIFF
--- a/clearwing/agent/tools/hunt/deep_agent.py
+++ b/clearwing/agent/tools/hunt/deep_agent.py
@@ -1,9 +1,17 @@
-"""Deep agent mode tools: execute, read_file, write_file, think.
+"""Deep agent mode tools: execute, read_file, write_file.
 
-Replaces the constrained 9-tool hunter set with 4 primitives that give
-the model full-shell access inside the sandbox container.  The model
+Replaces the constrained 9-tool hunter set with 3 primitives that give
+the model full-shell access inside the sandbox container. The model
 uses the same tools a human researcher would — gcc, gdb, strace, make,
 etc. — all via ``execute()``.
+
+Model-side reasoning is captured natively via rust-genai's
+`capture_reasoning_content=True` on every chat request; the hunter
+transcript logs `ChatResponse.reasoning_content` alongside the
+visible text, so there's no need for an explicit `think()`
+scratchpad tool (and one doesn't exist here — it was removed after
+verifying native reasoning is strictly richer than a model-callable
+no-op).
 
 See docs/spec/001_deep_agent_mode.md for the design rationale.
 """
@@ -31,9 +39,8 @@ def _cap_output(text: str, label: str = "output") -> str:
 
 
 def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:
-    """Build the 4+1 deep agent tool set.
-
-    Returns tools: execute, read_file, write_file, think, record_finding.
+    """Build the deep agent tool set: execute, read_file, write_file,
+    plus the shared reporting + findings-pool tools.
     """
 
     def execute(command: str, timeout: int = 300) -> dict:
@@ -53,7 +60,16 @@ def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:
             return "error: no sandbox available"
         start = offset + 1
         end = offset + limit
-        cmd = f"sed -n '{start},{end}p' {shlex.quote(path)} | cat -n"
+        # Previously this was `sed ... | cat -n`, which numbers output
+        # starting from 1 regardless of offset — a hunter asking for
+        # lines 101-150 got back "line 1..line 50" and then reasoned
+        # about the wrong line numbers when reporting findings. Use awk
+        # with NR directly so the emitted line numbers match the file.
+        cmd = (
+            f"awk -v s={start} -v e={end} "
+            f"'NR>=s && NR<=e {{ printf \"%6d\\t%s\\n\", NR, $0 }}' "
+            f"{shlex.quote(path)}"
+        )
         result = ctx.sandbox.exec(cmd, timeout=30)
         if result.exit_code != 0:
             return f"error reading {path}: {result.stderr.strip()}"
@@ -62,14 +78,9 @@ def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:
     def write_file(path: str, contents: str) -> str:
         if ctx.sandbox is None:
             return "error: no sandbox available"
-        ctx.sandbox.exec(
-            f"mkdir -p $(dirname {shlex.quote(path)})", timeout=10
-        )
+        ctx.sandbox.exec(f"mkdir -p $(dirname {shlex.quote(path)})", timeout=10)
         ctx.sandbox.write_file(path, contents.encode("utf-8"))
         return f"Wrote {len(contents)} bytes to {path}"
-
-    def think(notes: str) -> str:
-        return "Noted."
 
     reporting_tools = build_reporting_tools(ctx)
 
@@ -140,24 +151,6 @@ def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:
                 "required": ["path", "contents"],
             },
             handler=write_file,
-        ),
-        NativeToolSpec(
-            name="think",
-            description=(
-                "Record your reasoning. Use this to think through hypotheses, "
-                "plan next steps, or note observations. Appears in the audit trail."
-            ),
-            schema={
-                "type": "object",
-                "properties": {
-                    "notes": {
-                        "type": "string",
-                        "description": "Your reasoning or observations.",
-                    },
-                },
-                "required": ["notes"],
-            },
-            handler=think,
         ),
         *reporting_tools,
         *(build_pool_query_tools(ctx) if ctx.findings_pool is not None else []),

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -330,13 +330,13 @@ class AsyncLLMClient:
         request: ChatRequest,
         options: ChatOptions,
     ) -> ChatResponse:
-        # openai_resp backends that require `stream=true` (e.g. our local
-        # gateway) reject `exec_chat`. genai-pyo3's `achat_via_stream`
-        # streams internally and hands back a fully-collected ChatResponse,
-        # so callers never see chunk events.
-        if self.provider_name == "openai_resp":
-            return await client.achat_via_stream(self.model_name, request, options)
-        return await client.achat(self.model_name, request, options)
+        # Always go through `achat_via_stream`: it streams internally and
+        # returns a fully-collected ChatResponse, so callers never see
+        # chunk events. Necessary for backends that require `stream=true`
+        # on the wire (our local openai_resp gateway, OpenAI's Responses
+        # API with certain models), harmless for everyone else — every
+        # adapter genai-pyo3 supports speaks SSE.
+        return await client.achat_via_stream(self.model_name, request, options)
 
     async def _achat_openai_codex(
         self,

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -100,12 +100,19 @@ class AsyncLLMClient:
         rate_limit_max_retries: int = 6,
         rate_limit_initial_backoff_seconds: float = 1.0,
         rate_limit_max_backoff_seconds: float = 60.0,
+        reasoning_effort: str | None = "medium",
     ) -> None:
         self.model_name = model_name
         self.provider_name = provider_name
         self.api_key = api_key
         self.base_url = base_url
         self.default_system = default_system
+        # `reasoning_effort` controls how much reasoning the provider
+        # runs (for models that support it). "medium" is a sensible
+        # default — higher for deeper-reasoning tasks, "none"/None to
+        # opt out entirely. Accepted values: "none" | "minimal" | "low"
+        # | "medium" | "high" | "xhigh" | "max" | "budget:<n>".
+        self.reasoning_effort = reasoning_effort
         self.rate_limit_max_retries = max(0, rate_limit_max_retries)
         self.rate_limit_initial_backoff_seconds = max(0.1, rate_limit_initial_backoff_seconds)
         self.rate_limit_max_backoff_seconds = max(
@@ -158,6 +165,21 @@ class AsyncLLMClient:
             capture_content=True,
             capture_usage=True,
             capture_tool_calls=True,
+            # Ask genai-pyo3 to surface the provider's reasoning output
+            # (OpenAI Responses `reasoning.summary`, Anthropic thinking
+            # blocks, etc.). `normalize_reasoning_content` unifies the
+            # varied provider shapes into ChatResponse.reasoning_content,
+            # so hunter transcripts see a single string regardless of
+            # backend. `reasoning_effort="medium"` is required alongside
+            # `capture_reasoning_content` to make the Responses adapter
+            # actually emit `reasoning.summary="detailed"` on the request
+            # (rust-genai ropoctl fork patched this to not require both,
+            # but "medium" is a sensible active choice independent of
+            # that — it's a reasonable default effort tier and lets us
+            # still get summaries on older upstreams).
+            capture_reasoning_content=True,
+            normalize_reasoning_content=True,
+            reasoning_effort=self.reasoning_effort,
             response_json_spec=(
                 _json_spec_from_model(
                     response_schema,
@@ -193,15 +215,17 @@ class AsyncLLMClient:
         """
         if on_text_delta is None:
             return await self.achat(
-                messages=messages, system=system, tools=tools,
-                temperature=temperature, max_tokens=max_tokens,
+                messages=messages,
+                system=system,
+                tools=tools,
+                temperature=temperature,
+                max_tokens=max_tokens,
             )
 
         request_tools = None
         if tools:
             request_tools = [
-                Tool(tool.name, tool.description, json.dumps(tool.schema))
-                for tool in tools
+                Tool(tool.name, tool.description, json.dumps(tool.schema)) for tool in tools
             ]
         request = ChatRequest(
             messages=list(messages),
@@ -214,6 +238,9 @@ class AsyncLLMClient:
             capture_content=True,
             capture_usage=True,
             capture_tool_calls=True,
+            capture_reasoning_content=True,
+            normalize_reasoning_content=True,
+            reasoning_effort=self.reasoning_effort,
         )
 
         async with self._semaphore:
@@ -226,8 +253,11 @@ class AsyncLLMClient:
                     return event.end
         # Fallback if stream ends without an end event
         return await self.achat(
-            messages=messages, system=system, tools=tools,
-            temperature=temperature, max_tokens=max_tokens,
+            messages=messages,
+            system=system,
+            tools=tools,
+            temperature=temperature,
+            max_tokens=max_tokens,
         )
 
     def chat(self, **kwargs: Any) -> ChatResponse:
@@ -371,7 +401,9 @@ class AsyncLLMClient:
             )
 
         usage_data = result.get("usage") or {}
-        prompt_tokens = _int_or_none(usage_data.get("input_tokens") or usage_data.get("prompt_tokens"))
+        prompt_tokens = _int_or_none(
+            usage_data.get("input_tokens") or usage_data.get("prompt_tokens")
+        )
         completion_tokens = _int_or_none(
             usage_data.get("output_tokens") or usage_data.get("completion_tokens")
         )
@@ -714,7 +746,9 @@ async def _openai_codex_responses_chat(
                     name = item.get("name") or (current_fc or {}).get("name")
                     args_str = item.get("arguments") or (current_fc or {}).get("args_buf") or ""
                     try:
-                        args = json.loads(args_str) if isinstance(args_str, str) and args_str else {}
+                        args = (
+                            json.loads(args_str) if isinstance(args_str, str) and args_str else {}
+                        )
                     except json.JSONDecodeError:
                         logger.debug("Failed to parse tool arguments: %r", str(args_str)[:200])
                         args = {}
@@ -730,7 +764,9 @@ async def _openai_codex_responses_chat(
 
                 if event_type in {"response.done", "response.completed"}:
                     response_obj = event.get("response")
-                    if isinstance(response_obj, dict) and isinstance(response_obj.get("usage"), dict):
+                    if isinstance(response_obj, dict) and isinstance(
+                        response_obj.get("usage"), dict
+                    ):
                         usage = response_obj["usage"]
                     break
 

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -170,13 +170,7 @@ class AsyncLLMClient:
             # blocks, etc.). `normalize_reasoning_content` unifies the
             # varied provider shapes into ChatResponse.reasoning_content,
             # so hunter transcripts see a single string regardless of
-            # backend. `reasoning_effort="medium"` is required alongside
-            # `capture_reasoning_content` to make the Responses adapter
-            # actually emit `reasoning.summary="detailed"` on the request
-            # (rust-genai ropoctl fork patched this to not require both,
-            # but "medium" is a sensible active choice independent of
-            # that — it's a reasonable default effort tier and lets us
-            # still get summaries on older upstreams).
+            # backend.
             capture_reasoning_content=True,
             normalize_reasoning_content=True,
             reasoning_effort=self.reasoning_effort,

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -9,7 +9,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-import aiohttp
 from genai_pyo3 import (
     ChatMessage,
     ChatOptions,
@@ -18,7 +17,6 @@ from genai_pyo3 import (
     Client,
     JsonSpec,
     Tool,
-    Usage,
 )
 from pydantic import BaseModel, RootModel
 
@@ -106,6 +104,58 @@ class AsyncLLMClient:
         self.provider_name = provider_name
         self.api_key = api_key
         self.base_url = base_url
+        self._default_headers: dict[str, str] | None = None
+
+        # `openai_codex` is clearwing's label for the OAuth-authenticated
+        # Responses API (the ChatGPT "Codex CLI" flow). It's not a distinct
+        # rust-genai adapter — it *is* the openai_resp adapter plus three
+        # extra request headers (`chatgpt-account-id`, `OpenAI-Beta`,
+        # `originator`) and a proxy base_url. Resolve the OAuth token and
+        # account-id once here; from this point on the Client behaves
+        # exactly like any other openai_resp Client.
+        #
+        # Token refresh happens once at construction. If the token expires
+        # during a long-running AsyncLLMClient instance, subsequent calls
+        # will fail until the instance is rebuilt — accepted tradeoff for
+        # avoiding per-call refresh overhead.
+        if provider_name == "openai_codex":
+            from clearwing.providers.openai_oauth import (
+                OPENAI_CODEX_DEFAULT_BASE_URL,
+                ensure_fresh_openai_oauth_credentials,
+                extract_account_id,
+            )
+
+            try:
+                creds = ensure_fresh_openai_oauth_credentials()
+                self.api_key = creds.access
+            except Exception:
+                if not self.api_key:
+                    raise
+
+            if not self.api_key:
+                raise RuntimeError(
+                    "Missing OpenAI OAuth access token. "
+                    "Run: `clearwing setup --provider openai-oauth`"
+                )
+
+            account_id = extract_account_id(self.api_key)
+            if not account_id:
+                raise RuntimeError(
+                    "OpenAI OAuth access token is missing the ChatGPT account id."
+                )
+
+            # rust-genai's openai_resp adapter joins "responses" onto the
+            # base_url, so set base to `.../codex/` and let it produce
+            # `.../codex/responses`. Matches the path the hand-rolled
+            # aiohttp version used to hit.
+            self.base_url = self.base_url or f"{OPENAI_CODEX_DEFAULT_BASE_URL}/codex/"
+            self._default_headers = {
+                "chatgpt-account-id": account_id,
+                "OpenAI-Beta": "responses=experimental",
+                "originator": "pi",
+                "user-agent": "clearwing (python)",
+            }
+
         self.default_system = default_system
         # `reasoning_effort` controls how much reasoning the provider
         # runs (for models that support it). "medium" is a sensible
@@ -143,16 +193,6 @@ class AsyncLLMClient:
                 )
                 for tool in tools
             ]
-
-        if self.provider_name == "openai_codex":
-            async with self._semaphore:
-                return await self._with_rate_limit_retries(
-                    lambda: self._achat_openai_codex(
-                        messages=list(messages),
-                        system=system or self.default_system,
-                        tools=tools or None,
-                    )
-                )
 
         request = ChatRequest(
             messages=list(messages),
@@ -310,18 +350,31 @@ class AsyncLLMClient:
         return extract_json_object(text), response
 
     def _build_client(self, client_cls):
+        # openai_codex is not a rust-genai adapter — it's the openai_resp
+        # adapter plus the extra headers __init__ stashed on
+        # `self._default_headers`. Map the name here so genai-pyo3's
+        # adapter-kind validator accepts it.
+        rust_provider = (
+            "openai_resp" if self.provider_name == "openai_codex" else self.provider_name
+        )
+        default_headers = self._default_headers
         base_url = self.base_url
         if base_url:
             base_url = base_url if base_url.endswith("/") else f"{base_url}/"
             if self.api_key:
                 return client_cls.with_api_key_and_base_url(
-                    self.provider_name,
+                    rust_provider,
                     self.api_key,
                     base_url,
+                    default_headers=default_headers,
                 )
-            return client_cls.with_base_url(self.provider_name, base_url)
+            return client_cls.with_base_url(
+                rust_provider, base_url, default_headers=default_headers
+            )
         if self.api_key:
-            return client_cls.with_api_key(self.provider_name, self.api_key)
+            return client_cls.with_api_key(
+                rust_provider, self.api_key, default_headers=default_headers
+            )
         return client_cls()
 
     async def _achat_with_provider_policy(
@@ -337,85 +390,6 @@ class AsyncLLMClient:
         # API with certain models), harmless for everyone else — every
         # adapter genai-pyo3 supports speaks SSE.
         return await client.achat_via_stream(self.model_name, request, options)
-
-    async def _achat_openai_codex(
-        self,
-        *,
-        messages: list[ChatMessage],
-        system: str | None,
-        tools: list[NativeToolSpec] | None,
-    ) -> ChatResponse:
-        from clearwing.providers.openai_oauth import (
-            OPENAI_CODEX_DEFAULT_BASE_URL,
-            ensure_fresh_openai_oauth_credentials,
-            extract_account_id,
-        )
-
-        access_token = self.api_key
-        try:
-            creds = await asyncio.to_thread(ensure_fresh_openai_oauth_credentials)
-            access_token = creds.access
-        except Exception:
-            if not access_token:
-                raise
-
-        if not access_token:
-            raise RuntimeError(
-                "Missing OpenAI OAuth access token. Run: `clearwing setup --provider openai-oauth`"
-            )
-
-        account_id = extract_account_id(access_token)
-        if not account_id:
-            raise RuntimeError("OpenAI OAuth access token is missing the ChatGPT account id.")
-
-        result = await _openai_codex_responses_chat(
-            model=self.model_name,
-            base_url=self.base_url or OPENAI_CODEX_DEFAULT_BASE_URL,
-            access_token=access_token,
-            account_id=account_id,
-            messages=messages,
-            system=system,
-            tools=tools,
-        )
-        content: list[dict[str, Any]] = []
-        if result["content"]:
-            content.append({"text": result["content"]})
-        for call in result["tool_calls"]:
-            args = call.get("arguments") or {}
-            args_json = json.dumps(args)
-            content.append(
-                {
-                    "tool_call": {
-                        "call_id": call.get("id") or "",
-                        "fn_name": call.get("name") or "",
-                        "fn_arguments": args,
-                        "fn_arguments_json": args_json,
-                    }
-                }
-            )
-
-        usage_data = result.get("usage") or {}
-        prompt_tokens = _int_or_none(
-            usage_data.get("input_tokens") or usage_data.get("prompt_tokens")
-        )
-        completion_tokens = _int_or_none(
-            usage_data.get("output_tokens") or usage_data.get("completion_tokens")
-        )
-        total_tokens = _int_or_none(usage_data.get("total_tokens"))
-        if total_tokens is None and (prompt_tokens is not None or completion_tokens is not None):
-            total_tokens = (prompt_tokens or 0) + (completion_tokens or 0)
-        return ChatResponse(
-            content=content,
-            usage=Usage(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                total_tokens=total_tokens,
-            ),
-            model_name=self.model_name,
-            provider_model_name=self.model_name,
-            model_adapter_kind="openai_codex",
-            provider_model_adapter_kind="openai_codex",
-        )
 
     async def _with_rate_limit_retries(self, op) -> ChatResponse:
         attempt = 0
@@ -519,261 +493,3 @@ def _schema_name_for_model(schema_model: type[BaseModel]) -> str:
     normalized = re.sub(r"[^A-Za-z0-9_-]+", "_", raw_name).strip("_")
     return normalized or "response_schema"
 
-
-def _int_or_none(value: Any) -> int | None:
-    try:
-        if value is None:
-            return None
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _resolve_codex_responses_url(base_url: str) -> str:
-    normalized = base_url.rstrip("/")
-    if normalized.endswith("/codex/responses"):
-        return normalized
-    if normalized.endswith("/codex"):
-        return f"{normalized}/responses"
-    return f"{normalized}/codex/responses"
-
-
-def _native_tools_to_responses(tools: list[NativeToolSpec] | None) -> list[dict[str, Any]]:
-    if not tools:
-        return []
-    return [
-        {
-            "type": "function",
-            "name": tool.name,
-            "description": tool.description,
-            "parameters": tool.schema or {"type": "object", "properties": {}},
-        }
-        for tool in tools
-    ]
-
-
-def _messages_to_codex_input(
-    messages: list[ChatMessage],
-) -> list[dict[str, Any]]:
-    input_items: list[dict[str, Any]] = []
-    for message in messages:
-        role = str(getattr(message, "role", "") or "")
-        content = str(getattr(message, "content", "") or "")
-
-        if role == "system":
-            continue
-        if role == "user":
-            input_items.append(
-                {
-                    "role": "user",
-                    "content": [{"type": "input_text", "text": content}],
-                }
-            )
-            continue
-        if role == "assistant":
-            if content:
-                input_items.append(
-                    {
-                        "role": "assistant",
-                        "content": [{"type": "output_text", "text": content}],
-                    }
-                )
-            for call in getattr(message, "tool_calls", None) or []:
-                call_id = str(getattr(call, "call_id", "") or "")
-                name = str(getattr(call, "fn_name", "") or "")
-                args_json = str(getattr(call, "fn_arguments_json", "") or "")
-                if not args_json:
-                    args_json = json.dumps(getattr(call, "fn_arguments", {}) or {})
-                input_items.append(
-                    {
-                        "type": "function_call",
-                        "call_id": call_id,
-                        "name": name,
-                        "arguments": args_json,
-                    }
-                )
-            continue
-        if role == "tool":
-            input_items.append(
-                {
-                    "type": "function_call_output",
-                    "call_id": str(getattr(message, "tool_response_call_id", "") or ""),
-                    "output": content,
-                }
-            )
-            continue
-
-        input_items.append(
-            {
-                "role": "user",
-                "content": [{"type": "input_text", "text": content}],
-            }
-        )
-    return input_items
-
-
-async def _iter_sse_json(response: aiohttp.ClientResponse):
-    data_lines: list[str] = []
-
-    def emit_buffer() -> dict[str, Any] | None:
-        data = "\n".join(data_lines).strip()
-        if not data or data == "[DONE]":
-            return None
-        try:
-            obj = json.loads(data)
-        except json.JSONDecodeError:
-            return None
-        return obj if isinstance(obj, dict) else None
-
-    while not response.content.at_eof():
-        raw = await response.content.readline()
-        if not raw:
-            break
-        line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
-        if line.startswith("data:"):
-            data_lines.append(line[5:].strip())
-            continue
-        if line.strip():
-            continue
-        if not data_lines:
-            continue
-        obj = emit_buffer()
-        data_lines = []
-        if obj is not None:
-            yield obj
-    if data_lines:
-        obj = emit_buffer()
-        if obj is not None:
-            yield obj
-
-
-async def _openai_codex_responses_chat(
-    *,
-    model: str,
-    base_url: str,
-    access_token: str,
-    account_id: str,
-    messages: list[ChatMessage],
-    system: str | None,
-    tools: list[NativeToolSpec] | None,
-) -> dict[str, Any]:
-    payload: dict[str, Any] = {
-        "model": model,
-        "store": False,
-        "stream": True,
-        "input": _messages_to_codex_input(messages),
-        "text": {"verbosity": "medium"},
-        "include": ["reasoning.encrypted_content"],
-    }
-    if system:
-        payload["instructions"] = system
-    response_tools = _native_tools_to_responses(tools)
-    if response_tools:
-        payload["tools"] = response_tools
-        payload["tool_choice"] = "auto"
-        payload["parallel_tool_calls"] = True
-
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-        "chatgpt-account-id": account_id,
-        "OpenAI-Beta": "responses=experimental",
-        "originator": "pi",
-        "accept": "text/event-stream",
-        "content-type": "application/json",
-        "user-agent": "clearwing (python)",
-    }
-
-    timeout = aiohttp.ClientTimeout(total=None, connect=30, sock_read=120)
-    async with aiohttp.ClientSession(timeout=timeout) as session:
-        async with session.post(
-            _resolve_codex_responses_url(base_url),
-            headers=headers,
-            json=payload,
-        ) as resp:
-            if resp.status < 200 or resp.status >= 300:
-                text = await resp.text()
-                raise RuntimeError(f"OpenAI OAuth request failed: HTTP {resp.status}: {text}")
-
-            content_parts: list[str] = []
-            tool_calls: list[dict[str, Any]] = []
-            current_fc: dict[str, Any] | None = None
-            usage: dict[str, Any] = {}
-
-            async for event in _iter_sse_json(resp):
-                event_type = event.get("type")
-
-                if event_type == "response.output_text.delta":
-                    delta = event.get("delta", "")
-                    if isinstance(delta, str) and delta:
-                        content_parts.append(delta)
-                    continue
-
-                if event_type == "response.output_item.added":
-                    item = event.get("item") or {}
-                    if isinstance(item, dict) and item.get("type") == "function_call":
-                        current_fc = {
-                            "call_id": item.get("call_id"),
-                            "name": item.get("name"),
-                            "args_buf": item.get("arguments") or "",
-                        }
-                    continue
-
-                if event_type == "response.function_call_arguments.delta":
-                    if current_fc is not None:
-                        delta = event.get("delta", "")
-                        if isinstance(delta, str) and delta:
-                            current_fc["args_buf"] = (current_fc.get("args_buf") or "") + delta
-                    continue
-
-                if event_type == "response.function_call_arguments.done":
-                    if current_fc is not None:
-                        args = event.get("arguments", "")
-                        if isinstance(args, str) and args:
-                            current_fc["args_buf"] = args
-                    continue
-
-                if event_type == "response.output_item.done":
-                    item = event.get("item") or {}
-                    if not isinstance(item, dict) or item.get("type") != "function_call":
-                        continue
-                    call_id = item.get("call_id") or (current_fc or {}).get("call_id")
-                    name = item.get("name") or (current_fc or {}).get("name")
-                    args_str = item.get("arguments") or (current_fc or {}).get("args_buf") or ""
-                    try:
-                        args = (
-                            json.loads(args_str) if isinstance(args_str, str) and args_str else {}
-                        )
-                    except json.JSONDecodeError:
-                        logger.debug("Failed to parse tool arguments: %r", str(args_str)[:200])
-                        args = {}
-                    tool_calls.append(
-                        {
-                            "id": call_id,
-                            "name": name or "",
-                            "arguments": args,
-                        }
-                    )
-                    current_fc = None
-                    continue
-
-                if event_type in {"response.done", "response.completed"}:
-                    response_obj = event.get("response")
-                    if isinstance(response_obj, dict) and isinstance(
-                        response_obj.get("usage"), dict
-                    ):
-                        usage = response_obj["usage"]
-                    break
-
-                if event_type in {"error", "response.failed"}:
-                    message = (
-                        event.get("message")
-                        or (event.get("error") or {}).get("message")
-                        or "OpenAI OAuth request failed"
-                    )
-                    raise RuntimeError(str(message))
-
-    return {
-        "content": "".join(content_parts),
-        "tool_calls": tool_calls,
-        "usage": usage,
-    }

--- a/clearwing/sourcehunt/artifact_store.py
+++ b/clearwing/sourcehunt/artifact_store.py
@@ -11,10 +11,31 @@ import json
 import logging
 import os
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
+from clearwing.sourcehunt.disclosure_db import DisclosureDB
+from clearwing.sourcehunt.state import DisclosureState
+
 logger = logging.getLogger(__name__)
+
+# Disclosure states that should keep tied artifacts alive through purge.
+# Anything not in this set (DISCLOSED, CLOSED, REJECTED) is terminal and
+# the artifact is eligible for retention-based deletion.
+_ACTIVE_DISCLOSURE_STATES: frozenset[str] = frozenset(
+    {
+        DisclosureState.PENDING_REVIEW.value,
+        DisclosureState.IN_REVIEW.value,
+        DisclosureState.VALIDATED.value,
+        DisclosureState.PENDING_DISCLOSURE.value,
+    }
+)
+
+
+class ArtifactExportDenied(Exception):
+    """Raised by `retrieve()` when `export_requires_approval=True` but no
+    `approved_by` was supplied. The policy flag used to be silently
+    ignored — now it actually gates the call."""
 
 
 @dataclass
@@ -76,7 +97,14 @@ class ArtifactStore:
         nonce, ct = blob[:12], blob[12:]
         return AESGCM(self._key).decrypt(nonce, ct, None)
 
-    def _log_access(self, action: str, finding_id: str, path: str, operator: str) -> None:
+    def _log_access(
+        self,
+        action: str,
+        finding_id: str,
+        path: str,
+        operator: str,
+        approved_by: str | None = None,
+    ) -> None:
         if not self._policy.access_logged:
             return
         entry = {
@@ -85,6 +113,7 @@ class ArtifactStore:
             "finding_id": finding_id,
             "path": path,
             "operator": operator,
+            "approved_by": approved_by,
         }
         audit_path = self._base_dir / "audit.log"
         with open(audit_path, "a", encoding="utf-8") as f:
@@ -106,11 +135,50 @@ class ArtifactStore:
     def store_transcript(self, finding_id: str, data: bytes, operator: str = "system") -> Path:
         return self._store("transcripts", finding_id, data, operator)
 
-    def retrieve(self, artifact_path: Path, operator: str = "system") -> bytes:
+    def retrieve(
+        self,
+        artifact_path: Path,
+        operator: str = "system",
+        approved_by: str | None = None,
+    ) -> bytes:
+        """Read and decrypt an artifact.
+
+        `export_requires_approval` (default `True`) now gates this call:
+        retrieve fails with `ArtifactExportDenied` unless `approved_by`
+        is non-empty. Previously the policy flag was declared but never
+        read — setting `export_requires_approval=True` did nothing.
+
+        Also enforces path containment: `artifact_path` must resolve
+        inside `self._base_dir` so an unvalidated caller can't feed
+        `retrieve()` an arbitrary filesystem path (the decrypt would
+        fail under GCM, but we shouldn't read the bytes at all).
+        """
         artifact_path = Path(artifact_path)
+        # Path containment — compare resolved forms so symlinks and
+        # `..` components can't escape the artifact root.
+        try:
+            artifact_path.resolve().relative_to(self._base_dir.resolve())
+        except ValueError:
+            raise ArtifactExportDenied(
+                f"artifact path outside artifact store: {artifact_path}"
+            ) from None
+
+        if self._policy.export_requires_approval and not approved_by:
+            raise ArtifactExportDenied(
+                "retrieve() requires `approved_by` when "
+                "ArtifactPolicy.export_requires_approval is True. "
+                "Pass the approver's identity or set the policy to False."
+            )
+
         data = self._decrypt(artifact_path.read_bytes())
         finding_id = artifact_path.stem
-        self._log_access("retrieve", finding_id, str(artifact_path), operator)
+        self._log_access(
+            "retrieve",
+            finding_id,
+            str(artifact_path),
+            operator,
+            approved_by=approved_by,
+        )
         return data
 
     def list_artifacts(self, finding_id: str) -> list[dict]:
@@ -120,23 +188,71 @@ class ArtifactStore:
             p = self._base_dir / category / f"{safe_id}.enc"
             if p.exists():
                 stat = p.stat()
-                results.append({
-                    "category": category,
-                    "path": str(p),
-                    "size_bytes": stat.st_size,
-                    "modified": stat.st_mtime,
-                })
+                results.append(
+                    {
+                        "category": category,
+                        "path": str(p),
+                        "size_bytes": stat.st_size,
+                        "modified": stat.st_mtime,
+                    }
+                )
         return results
 
     def purge_expired(self) -> int:
+        """Delete artifacts whose mtime exceeds `retention_days`.
+
+        When `tied_to_disclosure=True` (default), artifacts belonging
+        to a finding that is still active in the disclosure DB
+        (pending_review / in_review / pending_disclosure — anything
+        not yet DISCLOSED, CLOSED, or REJECTED) are kept regardless
+        of age. Previously this flag was silent config — purge
+        deleted by mtime only and could wipe artifacts tied to an
+        in-flight disclosure.
+        """
         cutoff = time.time() - (self._policy.retention_days * 86400)
+        open_finding_ids = (
+            self._open_disclosure_finding_ids() if self._policy.tied_to_disclosure else set()
+        )
+
         removed = 0
         for category in ("exploits", "transcripts", "poc"):
             cat_dir = self._base_dir / category
             if not cat_dir.exists():
                 continue
             for f in cat_dir.iterdir():
-                if f.is_file() and f.stat().st_mtime < cutoff:
-                    f.unlink()
-                    removed += 1
+                if not (f.is_file() and f.stat().st_mtime < cutoff):
+                    continue
+                # `stem` is the sanitized finding_id we stored under.
+                if f.stem in open_finding_ids:
+                    logger.debug(
+                        "purge skipped %s — finding still in active disclosure",
+                        f.name,
+                    )
+                    continue
+                f.unlink()
+                removed += 1
         return removed
+
+    def _open_disclosure_finding_ids(self) -> set[str]:
+        """Return finding ids still in a non-terminal disclosure state.
+
+        Defensive: if the DB query fails (fresh install with no
+        schema, sqlite locked, ...), `tied_to_disclosure` degrades to
+        "no protection" rather than aborting purge. Logged at DEBUG.
+        """
+        try:
+            db = DisclosureDB()
+        except Exception:
+            logger.debug(
+                "tied_to_disclosure check unavailable; purge will not protect",
+                exc_info=True,
+            )
+            return set()
+        try:
+            rows = db.get_queue()
+            return {r["id"] for r in rows if r.get("state") in _ACTIVE_DISCLOSURE_STATES}
+        except Exception:
+            logger.debug("disclosure_db.get_queue failed", exc_info=True)
+            return set()
+        finally:
+            db.close()

--- a/clearwing/sourcehunt/behavior_monitor.py
+++ b/clearwing/sourcehunt/behavior_monitor.py
@@ -10,37 +10,54 @@ from __future__ import annotations
 import logging
 import re
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
 MONITORED_PATTERNS: dict[str, list[str]] = {
     "network_access_attempt": [
-        r"curl\s", r"wget\s", r"\bnc\s", r"ncat\s",
-        r"python.*socket", r"/dev/tcp/", r"socat\s",
+        r"curl\s",
+        r"wget\s",
+        r"\bnc\s",
+        r"ncat\s",
+        r"python.*socket",
+        r"/dev/tcp/",
+        r"socat\s",
     ],
     "unexpected_fs_path": [
-        r"/proc/1/", r"/proc/self/ns", r"/sys/fs/cgroup",
-        r"/etc/shadow", r"/etc/passwd.*w",
-        r"\.docker/", r"/var/run/docker\.sock",
+        r"/proc/1/",
+        r"/proc/self/ns",
+        r"/sys/fs/cgroup",
+        r"/etc/shadow",
+        r"/etc/passwd.*w",
+        r"\.docker/",
+        r"/var/run/docker\.sock",
     ],
     "mount_attempt": [
-        r"\bmount\b.*-t", r"\bmount\b.*/dev/",
-        r"nsenter\b", r"unshare\b",
+        r"\bmount\b.*-t",
+        r"\bmount\b.*/dev/",
+        r"nsenter\b",
+        r"unshare\b",
     ],
     "ptrace_on_pid_1": [
-        r"ptrace.*ATTACH.*\b1\b", r"gdb.*-p\s*1\b",
+        r"ptrace.*ATTACH.*\b1\b",
+        r"gdb.*-p\s*1\b",
         r"strace.*-p\s*1\b",
     ],
     "recursive_agent_spawn": [
-        r"clearwing\s+sourcehunt", r"clearwing\s+campaign",
+        r"clearwing\s+sourcehunt",
+        r"clearwing\s+campaign",
     ],
     "permission_escalation": [
-        r"chmod\s+[0-7]*s", r"setuid", r"setcap\b",
-        r"sudo\b", r"su\s+-",
+        r"chmod\s+[0-7]*s",
+        r"setuid",
+        r"setcap\b",
+        r"sudo\b",
+        r"su\s+-",
     ],
     "data_exfiltration_attempt": [
-        r"base64.*\|.*curl", r"xxd.*\|.*nc\b",
+        r"base64.*\|.*curl",
+        r"xxd.*\|.*nc\b",
         r"python.*http\.server",
     ],
 }
@@ -80,6 +97,11 @@ class BehaviorMonitor:
         self._audit = audit_logger
         self._alerts: list[BehaviorAlert] = []
         self._file_write_count: int = 0
+        # One-shot latch per threshold name. Prevents alert spam when
+        # a caller polls `check_thresholds()` repeatedly after the
+        # file-write count crosses the threshold once — previously
+        # every call after that point appended a new alert.
+        self._fired_thresholds: set[str] = set()
         self._compiled: dict[str, list[re.Pattern]] = {
             name: [re.compile(p, re.IGNORECASE) for p in patterns]
             for name, patterns in MONITORED_PATTERNS.items()
@@ -107,7 +129,9 @@ class BehaviorMonitor:
                     self._alerts.append(alert)
                     logger.warning(
                         "Behavior alert [%s]: %s matched '%s'",
-                        alert.severity, name, match.group(),
+                        alert.severity,
+                        name,
+                        match.group(),
                     )
                     break
         return new_alerts
@@ -127,8 +151,14 @@ class BehaviorMonitor:
             self._alerts.append(alert)
 
     def check_thresholds(self) -> list[BehaviorAlert]:
+        """Emit new threshold alerts. Each threshold is one-shot —
+        repeat calls after the threshold has fired return empty.
+        """
         new_alerts: list[BehaviorAlert] = []
-        if self._file_write_count > FILE_WRITE_THRESHOLD:
+        if (
+            self._file_write_count > FILE_WRITE_THRESHOLD
+            and "excessive_file_writes" not in self._fired_thresholds
+        ):
             alert = BehaviorAlert(
                 timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 session_id=self._session_id,
@@ -140,6 +170,7 @@ class BehaviorMonitor:
             )
             new_alerts.append(alert)
             self._alerts.append(alert)
+            self._fired_thresholds.add("excessive_file_writes")
         return new_alerts
 
     def get_alerts(self) -> list[BehaviorAlert]:

--- a/clearwing/sourcehunt/calibration.py
+++ b/clearwing/sourcehunt/calibration.py
@@ -6,27 +6,74 @@ assessments over time. Target: 89% exact match (Glasswing reference).
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import json
 import logging
-import tempfile
-from dataclasses import asdict, dataclass, field
+import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
+
+# Module-level lock so concurrent in-process CalibrationStore instances
+# (e.g. CLI + test + another thread) serialize against each other even
+# when they point at the same file via different instances.
+_STORE_LOCK = threading.Lock()
+
+#: Severity values accepted across calibration. Validated by the
+#: pydantic model — a typo writes a loud ValidationError instead of
+#: silently corrupting the exact-match / within-one ratio math.
+Severity = Literal["critical", "high", "medium", "low", "info"]
+
+
+@contextlib.contextmanager
+def _calibration_lock(path: Path):
+    """Serialize calibration-log reads/writes.
+
+    Acquires the module-level threading lock (in-process) and an
+    exclusive `flock` on a sidecar `.lock` file (cross-process).
+    Any code that reads-then-writes the calibration JSONL must hold
+    this — otherwise a concurrent `append` between load and write
+    silently drops records (the bug this fix addresses).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    with _STORE_LOCK:
+        with open(lock_path, "a+") as lf:
+            fcntl.flock(lf, fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lf, fcntl.LOCK_UN)
+
 
 _SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
 
 
-@dataclass(frozen=True)
-class CalibrationRecord:
+class CalibrationRecord(BaseModel):
+    """One row in the severity-calibration JSONL.
+
+    Immutable after construction (`frozen=True`) so callers can't
+    mutate in-place and desync with the on-disk representation —
+    updates go through `model_copy(update=...)`.
+
+    `extra="ignore"` lets us load historical rows that predate newer
+    fields without blowing up; the discarded keys are logged by the
+    reader if useful.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
     finding_id: str
     session_id: str
     cwe: str
-    discoverer_severity: str
-    validator_severity: str | None = None
-    human_severity: str | None = None
-    axes: dict[str, bool] = field(default_factory=dict)
+    discoverer_severity: Severity
+    validator_severity: Severity | None = None
+    human_severity: Severity | None = None
+    axes: dict[str, bool] = Field(default_factory=dict)
     timestamp: str = ""
     exact_match: bool | None = None
     within_one: bool | None = None
@@ -45,12 +92,11 @@ class CalibrationStore:
         self._path = Path(path) if path else self._default_path()
 
     def append(self, record: CalibrationRecord) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(asdict(record), default=str) + "\n"
-        # Atomic append: write to temp file, then append
+        line = record.model_dump_json() + "\n"
         try:
-            with open(self._path, "a", encoding="utf-8") as f:
-                f.write(line)
+            with _calibration_lock(self._path):
+                with open(self._path, "a", encoding="utf-8") as f:
+                    f.write(line)
         except OSError:
             logger.warning("Failed to write calibration record", exc_info=True)
 
@@ -58,26 +104,37 @@ class CalibrationStore:
         self,
         finding_id: str,
         session_id: str,
-        human_severity: str,
+        human_severity: Severity,
     ) -> None:
-        records = self.load_all()
-        updated = []
-        for r in records:
-            if r.finding_id == finding_id and r.session_id == session_id:
-                d = asdict(r)
-                d["human_severity"] = human_severity
-                # Compute match metrics
-                if r.validator_severity:
-                    d["exact_match"] = r.validator_severity == human_severity
-                    d_rank = _SEVERITY_RANK.get(r.validator_severity, 0)
-                    h_rank = _SEVERITY_RANK.get(human_severity, 0)
-                    d["within_one"] = abs(d_rank - h_rank) <= 1
-                updated.append(CalibrationRecord(**d))
-            else:
-                updated.append(r)
-        self._write_all(updated)
+        # Hold the lock across the whole read-modify-write. Without this,
+        # any concurrent `append()` landing between the load and the
+        # rewrite is silently dropped when the temp file is renamed
+        # over the data file.
+        with _calibration_lock(self._path):
+            records = self._load_all_unlocked()
+            updated = []
+            for r in records:
+                if r.finding_id == finding_id and r.session_id == session_id:
+                    patch: dict[str, Any] = {"human_severity": human_severity}
+                    if r.validator_severity:
+                        patch["exact_match"] = r.validator_severity == human_severity
+                        v_rank = _SEVERITY_RANK[r.validator_severity]
+                        h_rank = _SEVERITY_RANK[human_severity]
+                        patch["within_one"] = abs(v_rank - h_rank) <= 1
+                    updated.append(r.model_copy(update=patch))
+                else:
+                    updated.append(r)
+            self._write_all_unlocked(updated)
 
     def load_all(self) -> list[CalibrationRecord]:
+        # Public read: acquires the lock so a caller iterating results
+        # doesn't race against concurrent writes. For the
+        # read-modify-write internal path, `_load_all_unlocked` is used
+        # while the caller already holds the lock.
+        with _calibration_lock(self._path):
+            return self._load_all_unlocked()
+
+    def _load_all_unlocked(self) -> list[CalibrationRecord]:
         if not self._path.exists():
             return []
         records = []
@@ -85,12 +142,13 @@ class CalibrationStore:
             if not line.strip():
                 continue
             try:
-                data = json.loads(line)
-                records.append(CalibrationRecord(**{
-                    k: v for k, v in data.items()
-                    if k in CalibrationRecord.__dataclass_fields__
-                }))
-            except (json.JSONDecodeError, TypeError):
+                # `extra="ignore"` on the model lets historical rows with
+                # retired fields still load; a schema addition won't
+                # break the whole file.
+                records.append(CalibrationRecord.model_validate_json(line))
+            except (ValueError, json.JSONDecodeError):
+                # `ValueError` covers pydantic `ValidationError`.
+                logger.warning("Skipping malformed calibration row: %r", line[:80])
                 continue
         return records
 
@@ -113,10 +171,10 @@ class CalibrationStore:
             "within_one_rate": within / len(with_human),
         }
 
-    def _write_all(self, records: list[CalibrationRecord]) -> None:
+    def _write_all_unlocked(self, records: list[CalibrationRecord]) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self._path.with_suffix(".tmp")
         with open(tmp, "w", encoding="utf-8") as f:
             for r in records:
-                f.write(json.dumps(asdict(r), default=str) + "\n")
+                f.write(r.model_dump_json() + "\n")
         tmp.replace(self._path)

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -1117,8 +1117,7 @@ def _build_subsystem_prompt(
                 break
         if edges:
             cross_file_calls = (
-                "\nCross-file call edges within this subsystem:\n"
-                + "\n".join(edges) + "\n"
+                "\nCross-file call edges within this subsystem:\n" + "\n".join(edges) + "\n"
             )
 
     existing_findings_block = ""
@@ -1128,8 +1127,7 @@ def _build_subsystem_prompt(
             pool_findings.extend(findings_pool.query(file_path=fp))
         if pool_findings:
             lines = [
-                f"\nPer-file hunters already found {len(pool_findings)} findings "
-                f"in this subsystem:"
+                f"\nPer-file hunters already found {len(pool_findings)} findings in this subsystem:"
             ]
             for f in pool_findings[:10]:
                 lines.append(
@@ -1198,7 +1196,8 @@ def build_subsystem_hunter_agent(
 
     tools = build_deep_agent_tools(ctx)
     prompt = _build_subsystem_prompt(
-        subsystem, project_name,
+        subsystem,
+        project_name,
         findings_pool=findings_pool,
         callgraph=callgraph,
     )
@@ -1253,10 +1252,11 @@ class NativeHunter:
         return None
 
     async def arun(self) -> HunterRunResult:
-        user_msg = self.initial_user_message or f"Hunt for vulnerabilities in {self.ctx.file_path or 'unknown'}."
-        messages: list[ChatMessage] = [
-            ChatMessage("user", user_msg)
-        ]
+        user_msg = (
+            self.initial_user_message
+            or f"Hunt for vulnerabilities in {self.ctx.file_path or 'unknown'}."
+        )
+        messages: list[ChatMessage] = [ChatMessage("user", user_msg)]
         trajectory = HunterTrajectoryLogger.for_hunter(
             self.ctx,
             prompt=self.prompt,
@@ -1278,8 +1278,11 @@ class NativeHunter:
             if stop_reason:
                 logger.warning(
                     "Hunter stopped for %s: %s (step=%d, cost=$%.4f, findings=%d)",
-                    self.ctx.file_path, stop_reason, step - 1,
-                    total_cost_usd, len(self.ctx.findings),
+                    self.ctx.file_path,
+                    stop_reason,
+                    step - 1,
+                    total_cost_usd,
+                    len(self.ctx.findings),
                 )
                 trajectory.log(
                     "finish",
@@ -1305,6 +1308,13 @@ class NativeHunter:
                 system=self.prompt,
                 tools=self.tools,
             )
+            # Preserve the provider's reasoning_content alongside the
+            # visible text. `response.first_text()` only returns the
+            # first Text part — reasoning/thinking blocks are separate
+            # and used to be dropped, which silently hid the most useful
+            # part of the trace for reasoning models (GPT-5.x, o-series,
+            # Claude thinking). The hunter's old `think()` scratchpad
+            # tool tried to compensate; native reasoning obsoletes it.
             trajectory.log(
                 "message",
                 {
@@ -1316,6 +1326,7 @@ class NativeHunter:
                             tool_calls=response.tool_calls(),
                         )
                     ),
+                    "reasoning_content": response.reasoning_content,
                     "usage": {
                         "input_tokens": response.usage.prompt_tokens or 0,
                         "output_tokens": response.usage.completion_tokens or 0,
@@ -1636,7 +1647,8 @@ def build_hunter_agent(
         file_path=file_target.get("path"),
         session_id=session_id,
         specialist=(
-            specialist if prompt_mode == "specialist" or specialist == "propagation"
+            specialist
+            if prompt_mode == "specialist" or specialist == "propagation"
             else "unconstrained"
         ),
         seeded_crash=seeded_crash,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # Reporting
     "jinja2>=3.1.0",
     "reportlab>=4.0.0",
-    "genai-pyo3>=0.1.11",
+    "genai-pyo3>=0.1.12",
     "pydantic>=2.0.0",
     "docker>=7.0.0",
     # TUI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # Reporting
     "jinja2>=3.1.0",
     "reportlab>=4.0.0",
-    "genai-pyo3>=0.1.14",
+    "genai-pyo3>=0.1.15",
     "pydantic>=2.0.0",
     "docker>=7.0.0",
     # TUI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # Reporting
     "jinja2>=3.1.0",
     "reportlab>=4.0.0",
-    "genai-pyo3>=0.1.15",
+    "genai-pyo3>=0.1.16",
     "pydantic>=2.0.0",
     "docker>=7.0.0",
     # TUI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # Reporting
     "jinja2>=3.1.0",
     "reportlab>=4.0.0",
-    "genai-pyo3>=0.1.12",
+    "genai-pyo3>=0.1.14",
     "pydantic>=2.0.0",
     "docker>=7.0.0",
     # TUI

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -1,0 +1,144 @@
+"""Tests for severity calibration store (spec 009)."""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+from pathlib import Path
+
+from clearwing.sourcehunt.calibration import CalibrationRecord, CalibrationStore
+
+
+def _make_record(fid: str, sid: str = "s1") -> CalibrationRecord:
+    return CalibrationRecord(
+        finding_id=fid,
+        session_id=sid,
+        cwe="CWE-787",
+        discoverer_severity="high",
+        validator_severity="high",
+    )
+
+
+class TestCalibrationBasics:
+    def test_append_and_load(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = CalibrationStore(path=Path(td) / "calibration.jsonl")
+            store.append(_make_record("f1"))
+            store.append(_make_record("f2"))
+            records = store.load_all()
+            assert {r.finding_id for r in records} == {"f1", "f2"}
+
+    def test_record_human_verdict_updates_existing(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = CalibrationStore(path=Path(td) / "calibration.jsonl")
+            store.append(_make_record("f1"))
+            store.record_human_verdict("f1", "s1", "medium")
+            records = store.load_all()
+            assert len(records) == 1
+            assert records[0].human_severity == "medium"
+            assert records[0].exact_match is False
+            assert records[0].within_one is True  # high vs medium = 1 step
+
+    def test_record_human_verdict_sets_exact_match_true(self):
+        with tempfile.TemporaryDirectory() as td:
+            store = CalibrationStore(path=Path(td) / "calibration.jsonl")
+            store.append(_make_record("f1"))
+            store.record_human_verdict("f1", "s1", "high")
+            records = store.load_all()
+            assert records[0].exact_match is True
+
+
+class TestCalibrationRace:
+    def test_append_concurrent_with_record_human_verdict(self):
+        """Regression: the read-modify-write inside `record_human_verdict`
+        used to run without any lock, so a concurrent `append` could land
+        between `load_all()` and `_write_all()` and be silently dropped
+        when the write renamed over the file.
+
+        Stress with N threads doing `append` + N threads doing
+        `record_human_verdict` against a shared store. No records may
+        disappear.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "calibration.jsonl"
+            store = CalibrationStore(path=path)
+
+            # Seed 50 records so record_human_verdict has rows to touch
+            for i in range(50):
+                store.append(_make_record(f"seed-{i}"))
+
+            n_append = 100
+            n_verdict = 50
+            appended_ids: set[str] = set()
+            errors: list[Exception] = []
+
+            def appender(idx: int):
+                try:
+                    fid = f"appended-{idx}"
+                    store.append(_make_record(fid))
+                    appended_ids.add(fid)
+                except Exception as e:
+                    errors.append(e)
+
+            def verdicter(idx: int):
+                try:
+                    store.record_human_verdict(f"seed-{idx % 50}", "s1", "medium")
+                except Exception as e:
+                    errors.append(e)
+
+            threads = []
+            for i in range(n_append):
+                threads.append(threading.Thread(target=appender, args=(i,)))
+            for i in range(n_verdict):
+                threads.append(threading.Thread(target=verdicter, args=(i,)))
+            # Interleave start order for max contention
+            import random
+
+            random.shuffle(threads)
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            assert not errors, f"Unexpected errors: {errors[:3]}"
+            records = store.load_all()
+            surviving_ids = {r.finding_id for r in records}
+
+            # All 50 seed rows plus all 100 appends must be present.
+            # Pre-fix this would drop appends that arrived mid
+            # load-modify-write.
+            assert len(surviving_ids) == 50 + n_append, (
+                f"Lost rows under contention: "
+                f"expected {50 + n_append}, got {len(surviving_ids)}; "
+                f"missing {set(f'appended-{i}' for i in range(n_append)) - surviving_ids}"
+            )
+            assert appended_ids <= surviving_ids
+
+    def test_verdict_changes_all_visible_after_contention(self):
+        """After N concurrent verdicts, all targeted rows must reflect
+        an updated human_severity — no verdict silently lost."""
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "calibration.jsonl"
+            store = CalibrationStore(path=path)
+
+            for i in range(20):
+                store.append(_make_record(f"row-{i}"))
+
+            threads = []
+            for i in range(20):
+                sev = ["low", "medium", "high", "critical"][i % 4]
+                threads.append(
+                    threading.Thread(
+                        target=store.record_human_verdict,
+                        args=(f"row-{i}", "s1", sev),
+                    )
+                )
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            records = {r.finding_id: r for r in store.load_all()}
+            assert len(records) == 20
+            for i in range(20):
+                assert records[f"row-{i}"].human_severity is not None, f"row-{i} verdict was lost"

--- a/tests/test_deep_agent_tools.py
+++ b/tests/test_deep_agent_tools.py
@@ -1,4 +1,4 @@
-"""Unit tests for deep agent mode tools (execute, read_file, write_file, think)."""
+"""Unit tests for deep agent mode tools (execute, read_file, write_file)."""
 
 from __future__ import annotations
 
@@ -30,11 +30,16 @@ def tools(ctx):
     return {t.name: t for t in build_deep_agent_tools(ctx)}
 
 
-def test_build_deep_agent_tools_returns_five(ctx):
+def test_build_deep_agent_tools_set(ctx):
+    """The deep-agent tool palette deliberately does NOT include a
+    `think` tool. Model reasoning is captured via
+    `capture_reasoning_content=True` on every chat request and written
+    into the hunter transcript's `reasoning_content` field — a scratchpad
+    tool would be a redundant no-op that wastes a tool-call round-trip."""
     tools = build_deep_agent_tools(ctx)
-    assert len(tools) == 5
     names = {t.name for t in tools}
-    assert names == {"execute", "read_file", "write_file", "think", "record_finding"}
+    assert "think" not in names
+    assert {"execute", "read_file", "write_file", "record_finding"} <= names
 
 
 def test_execute_runs_command(tools, mock_sandbox):
@@ -70,14 +75,19 @@ def test_execute_no_sandbox():
 
 def test_read_file_with_defaults(tools, mock_sandbox):
     mock_sandbox.exec.return_value = ExecResult(
-        exit_code=0, stdout="     1\tline1\n     2\tline2\n", stderr="", duration_seconds=0.05
+        exit_code=0,
+        stdout="     1\tline1\n     2\tline2\n",
+        stderr="",
+        duration_seconds=0.05,
     )
     result = tools["read_file"].handler(path="/workspace/foo.c")
     mock_sandbox.exec.assert_called_once()
     cmd = mock_sandbox.exec.call_args[0][0]
-    assert "sed" in cmd
+    assert "awk" in cmd
     assert "/workspace/foo.c" in cmd
-    assert "1,2000p" in cmd
+    # Default offset=0, limit=2000 → start=1, end=2000
+    assert "s=1" in cmd
+    assert "e=2000" in cmd
     assert "line1" in result
 
 
@@ -87,7 +97,27 @@ def test_read_file_with_offset_limit(tools, mock_sandbox):
     )
     tools["read_file"].handler(path="/workspace/bar.c", offset=10, limit=50)
     cmd = mock_sandbox.exec.call_args[0][0]
-    assert "11,60p" in cmd
+    # offset=10, limit=50 → start=11, end=60
+    assert "s=11" in cmd
+    assert "e=60" in cmd
+
+
+def test_read_file_uses_absolute_line_numbers(tools, mock_sandbox):
+    """Regression: previously `sed ... | cat -n` numbered output from 1
+    regardless of offset, so a hunter asking for lines 101-150 got
+    back "line 1..line 50" and then reported findings against the
+    wrong line numbers. The awk command must emit NR (the file's real
+    line number) not a 1-based counter of output lines.
+    """
+    mock_sandbox.exec.return_value = ExecResult(
+        exit_code=0, stdout="", stderr="", duration_seconds=0.01
+    )
+    tools["read_file"].handler(path="/workspace/x.c", offset=100, limit=50)
+    cmd = mock_sandbox.exec.call_args[0][0]
+    # The awk program must print NR (the file's real line number), not
+    # a locally-rebased counter. The regex must reference NR directly
+    # in the print expression.
+    assert 'printf "%6d' in cmd and "NR, $0" in cmd, cmd
 
 
 def test_read_file_error(tools, mock_sandbox):
@@ -99,22 +129,13 @@ def test_read_file_error(tools, mock_sandbox):
 
 
 def test_write_file_creates_dirs(tools, mock_sandbox):
-    result = tools["write_file"].handler(
-        path="/workspace/new/dir/file.c", contents="int main() {}"
-    )
+    result = tools["write_file"].handler(path="/workspace/new/dir/file.c", contents="int main() {}")
     assert mock_sandbox.exec.call_count == 1
     mkdir_cmd = mock_sandbox.exec.call_args[0][0]
     assert "mkdir -p" in mkdir_cmd
-    mock_sandbox.write_file.assert_called_once_with(
-        "/workspace/new/dir/file.c", b"int main() {}"
-    )
+    mock_sandbox.write_file.assert_called_once_with("/workspace/new/dir/file.c", b"int main() {}")
     assert "Wrote" in result
     assert "13 bytes" in result
-
-
-def test_think_returns_noted(tools):
-    result = tools["think"].handler(notes="Hypothesis: buffer overflow in parse_header")
-    assert result == "Noted."
 
 
 def test_record_finding_present(tools):

--- a/tests/test_self_security.py
+++ b/tests/test_self_security.py
@@ -4,15 +4,12 @@ from __future__ import annotations
 
 import json
 import tempfile
-import time
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
 from clearwing.sandbox.container import SandboxConfig
 from clearwing.sandbox.seccomp_profiles import (
-    EXPLOIT_SECCOMP,
     HUNTER_SECCOMP,
     get_seccomp_profile,
     write_seccomp_profile,
@@ -22,7 +19,6 @@ from clearwing.sourcehunt.behavior_monitor import (
     FILE_WRITE_THRESHOLD,
     BehaviorMonitor,
 )
-
 
 # --- SandboxConfig hardening tests -------------------------------------------
 
@@ -108,7 +104,7 @@ class TestArtifactStore:
             data = b"exploit payload here"
             path = store.store_exploit("finding-001", data, operator="test")
             assert path.exists()
-            retrieved = store.retrieve(path, operator="test")
+            retrieved = store.retrieve(path, operator="test", approved_by="reviewer-1")
             assert retrieved == data
 
     def test_access_logged(self):
@@ -133,7 +129,7 @@ class TestArtifactStore:
             store = ArtifactStore(base_dir=Path(td))
             path = store.store_poc("f1", b"poc data")
             assert "poc" in str(path)
-            assert store.retrieve(path) == b"poc data"
+            assert store.retrieve(path, approved_by="reviewer-1") == b"poc data"
 
     def test_store_transcript(self):
         from clearwing.sourcehunt.artifact_store import ArtifactStore
@@ -142,7 +138,85 @@ class TestArtifactStore:
             store = ArtifactStore(base_dir=Path(td))
             path = store.store_transcript("f1", b"transcript")
             assert "transcripts" in str(path)
-            assert store.retrieve(path) == b"transcript"
+            assert store.retrieve(path, approved_by="reviewer-1") == b"transcript"
+
+    def test_retrieve_without_approval_raises(self):
+        """Regression: `export_requires_approval=True` was silent config.
+        retrieve() must refuse the call when no `approved_by` is given."""
+        from clearwing.sourcehunt.artifact_store import (
+            ArtifactExportDenied,
+            ArtifactStore,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            store = ArtifactStore(base_dir=Path(td))
+            path = store.store_exploit("f1", b"payload")
+            with pytest.raises(ArtifactExportDenied):
+                store.retrieve(path)  # no approved_by — must deny
+
+    def test_retrieve_with_approval_disabled_skips_check(self):
+        from clearwing.sourcehunt.artifact_store import (
+            ArtifactPolicy,
+            ArtifactStore,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            store = ArtifactStore(
+                base_dir=Path(td),
+                policy=ArtifactPolicy(export_requires_approval=False),
+            )
+            path = store.store_exploit("f1", b"payload")
+            assert store.retrieve(path) == b"payload"  # no approver, ok
+
+    def test_retrieve_rejects_path_outside_base_dir(self):
+        """Regression: retrieve() used to read and decrypt any Path,
+        even one pointing outside the artifact store."""
+        from clearwing.sourcehunt.artifact_store import (
+            ArtifactExportDenied,
+            ArtifactPolicy,
+            ArtifactStore,
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            store = ArtifactStore(
+                base_dir=Path(td) / "store",
+                policy=ArtifactPolicy(export_requires_approval=False),
+            )
+            # Write a rogue file outside the store
+            rogue = Path(td) / "rogue.enc"
+            rogue.write_bytes(b"not a real artifact")
+            with pytest.raises(ArtifactExportDenied):
+                store.retrieve(rogue)
+
+    def test_purge_skips_artifacts_tied_to_open_disclosure(self, monkeypatch):
+        """Regression: `tied_to_disclosure=True` was silent config.
+        purge_expired must skip artifacts whose finding is still in an
+        active disclosure state."""
+        from clearwing.sourcehunt.artifact_store import (
+            ArtifactPolicy,
+            ArtifactStore,
+        )
+
+        # Fake the DisclosureDB lookup so the test doesn't need the
+        # real disclosure schema.
+        monkeypatch.setattr(
+            ArtifactStore,
+            "_open_disclosure_finding_ids",
+            lambda self: {"finding-protected"},
+        )
+
+        with tempfile.TemporaryDirectory() as td:
+            store = ArtifactStore(
+                base_dir=Path(td),
+                policy=ArtifactPolicy(retention_days=0),  # everything expired
+            )
+            kept = store.store_exploit("finding-protected", b"p1")
+            dropped = store.store_exploit("finding-closed", b"p2")
+
+            removed = store.purge_expired()
+            assert removed == 1
+            assert kept.exists()
+            assert not dropped.exists()
 
     def test_list_artifacts(self):
         from clearwing.sourcehunt.artifact_store import ArtifactStore
@@ -211,6 +285,24 @@ class TestBehaviorMonitor:
         alerts = mon.check_thresholds()
         assert len(alerts) >= 1
         assert alerts[0].pattern == "excessive_file_writes"
+
+    def test_file_write_threshold_is_one_shot(self):
+        """Regression: repeat calls to check_thresholds() after the
+        threshold fires used to keep appending new alerts on every
+        call, producing unbounded alert spam in long-running sessions.
+        The threshold must latch and only fire once per session."""
+        mon = BehaviorMonitor(session_id="test-latch")
+        for i in range(FILE_WRITE_THRESHOLD + 1):
+            mon.record_file_write(f"/scratch/f_{i}")
+        first = mon.check_thresholds()
+        second = mon.check_thresholds()
+        third = mon.check_thresholds()
+        assert len(first) == 1
+        assert second == []  # latched — no spam
+        assert third == []
+        # Still exactly one alert on the object, not N
+        alerts = [a for a in mon.get_alerts() if a.pattern == "excessive_file_writes"]
+        assert len(alerts) == 1
 
     def test_large_binary_detection(self):
         mon = BehaviorMonitor(session_id="test-7")
@@ -301,7 +393,9 @@ class TestRunnerSecurityOptions:
         from clearwing.sourcehunt.runner import SourceHuntRunner
 
         runner = SourceHuntRunner(
-            repo_url="test", depth="standard", gvisor_runtime="runsc",
+            repo_url="test",
+            depth="standard",
+            gvisor_runtime="runsc",
         )
         assert runner._gvisor_runtime == "runsc"
 
@@ -312,6 +406,7 @@ class TestRunnerSecurityOptions:
 class TestCLIFlags:
     def test_gvisor_flag(self):
         import argparse
+
         from clearwing.ui.commands import sourcehunt
 
         parser = argparse.ArgumentParser()
@@ -322,6 +417,7 @@ class TestCLIFlags:
 
     def test_encrypt_artifacts_flag(self):
         import argparse
+
         from clearwing.ui.commands import sourcehunt
 
         parser = argparse.ArgumentParser()
@@ -332,6 +428,7 @@ class TestCLIFlags:
 
     def test_no_behavior_monitor_flag(self):
         import argparse
+
         from clearwing.ui.commands import sourcehunt
 
         parser = argparse.ArgumentParser()

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "docker", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "genai-pyo3", specifier = ">=0.1.14" },
+    { name = "genai-pyo3", specifier = ">=0.1.15" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.0" },
@@ -1133,29 +1133,29 @@ wheels = [
 
 [[package]]
 name = "genai-pyo3"
-version = "0.1.14"
+version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/cc/31492a605f8daa95bb521e7859bf2218ca0201fb322ec0e90e54f95717b4/genai_pyo3-0.1.14.tar.gz", hash = "sha256:0f7c218b9addea8fd2f597b845c1f7ca83c0e7f4e1c5190645ebc7117fb6f2cd", size = 42399 }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/b7/a5ab69f8a3097d83891af9922907500414aadbd0a8d6a6230271136df6de/genai_pyo3-0.1.15.tar.gz", hash = "sha256:39be65d833d98432e88fed72f34d14b14b5458fbb6620f83ee92da1d130182f8", size = 42609 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/a1/c2854c60d9a117928a4d2943e11e7b73998a99957dc34caf049b5c4c3379/genai_pyo3-0.1.14-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9aaaa6cb2d8ceac9d91673ca81f412e0aade3e5c2c8a31bfe6a3a119af6d9f96", size = 9022093 },
-    { url = "https://files.pythonhosted.org/packages/06/29/8a0af87527b8984a6d25538f76712dd1b37bd93d385b4d3563a527b3fd2f/genai_pyo3-0.1.14-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07551b6e730c6c2b4146589a5919cb52275727d49913f24fb3f8bced60139a1a", size = 4791818 },
-    { url = "https://files.pythonhosted.org/packages/7d/36/0474a97deb4879bb2cba316312fb593f690f763c832054cc31617fca2601/genai_pyo3-0.1.14-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0e9c20da871f39adf66095727e7a1bff1b8d9d2da688108106522d7bd5739f0", size = 4850999 },
-    { url = "https://files.pythonhosted.org/packages/c9/68/aaeadd219cc12fda291206e59b6352c2bd62f34e26350e9f9f62f64ceec6/genai_pyo3-0.1.14-cp310-cp310-win_amd64.whl", hash = "sha256:75e7c89dc6f267ffe2a409337722743eae2263fa576310a48ed824c2efc1f1fa", size = 3938475 },
-    { url = "https://files.pythonhosted.org/packages/14/0a/3c470ac7fbd8aa26a774ccef9961d385e5b97a54d68b47d32c09e2515f05/genai_pyo3-0.1.14-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2f54c772f27fecd67a130e8d757d1ca24d7ec451665eaed2363ef64f8592152c", size = 9020831 },
-    { url = "https://files.pythonhosted.org/packages/cf/d6/e5f982d5548f466ad6ad1975b2362714828e77f833d32dfdf63cb7a22005/genai_pyo3-0.1.14-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fa41cca752a3d205163c1202d54960c3393af74e467444f6b0a8792d8fa2f28", size = 4793791 },
-    { url = "https://files.pythonhosted.org/packages/33/87/6be3bfe8401c6b4353f9420b91c61804992c669eb35a3230174e4a270ef8/genai_pyo3-0.1.14-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd7ae39857452c79f140f6b02d1de6462539976c003fed68c60f2f817d483eeb", size = 4850499 },
-    { url = "https://files.pythonhosted.org/packages/07/79/456a1650990e9004685b026fc8ce60b05ff079d0d9385e1cf1ef0c1bb278/genai_pyo3-0.1.14-cp311-cp311-win_amd64.whl", hash = "sha256:dfb851d58510c1ca58bebff434e1436dbe724710bc8e4dc3179a30ccc8a9f2cf", size = 3938634 },
-    { url = "https://files.pythonhosted.org/packages/cb/98/5c30fc00486e56f127fa2997c91478fee6787e4a8cf5f496d4b6bd096877/genai_pyo3-0.1.14-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6f6a34d08e9d7f745d2daeb9418c4f096866611970639ba016279a3acdd43102", size = 9009683 },
-    { url = "https://files.pythonhosted.org/packages/35/a4/7fefadf837f8a793bee061f8ffd17b3765958e51852046e08adf9f7eee6d/genai_pyo3-0.1.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:647971f4e56ba9600397dc92ee490a914db30ac81ae6884cda455b02a9977f33", size = 4789723 },
-    { url = "https://files.pythonhosted.org/packages/63/6b/6cb3839b0b9d5d95ed519cb23531ee8ae1224df0cddee89c3434c1d22bdc/genai_pyo3-0.1.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ea6ac101c1cb104ea8864962c3164400c212977cc601999a503ba423428988c", size = 4851933 },
-    { url = "https://files.pythonhosted.org/packages/32/c5/7fc1586a6bcb6115d2df19d2f25cc0e8733a6b5732ec145e716fbe7465d3/genai_pyo3-0.1.14-cp312-cp312-win_amd64.whl", hash = "sha256:772d03fdac8d52b0a085681a22178f73dc262eb930ed12396ec3e9501df594a7", size = 3936556 },
-    { url = "https://files.pythonhosted.org/packages/3f/86/ae61a95e3eddec94cc9580ce9fa1845e9abba02cb8aa215e22b8d60079ae/genai_pyo3-0.1.14-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b2a6f8a619b4bd226c7ab1a7a2d5f16002363a8c9f33a432d795a1464165924a", size = 9008506 },
-    { url = "https://files.pythonhosted.org/packages/95/e5/61196118cb2b089d7397040feb1d8b9b409082d6885e06cdbe49989cd6d8/genai_pyo3-0.1.14-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c468efb69ad2e85daff5cfa727969b09a8b172f51ea3a93e5aa08ffb499e2e1", size = 4789024 },
-    { url = "https://files.pythonhosted.org/packages/d7/a0/e2485c1a9ecdcc9e0d2f47b1f4d3d709cd35d5fb54f9946693110de7839f/genai_pyo3-0.1.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5d6a69094f2d6466cb612c629191fb5ae6cf1bba3c863835bebf2b2df23c9ae", size = 4850504 },
-    { url = "https://files.pythonhosted.org/packages/bb/d2/80e3f476a1cd345eb3687795cc8069f7def33dee1e6d1b955800af001a90/genai_pyo3-0.1.14-cp313-cp313-win_amd64.whl", hash = "sha256:32f42fbdd099169bc415db200ec21b1c2964702a7f436558b2330e8cfafab09f", size = 3936622 },
+    { url = "https://files.pythonhosted.org/packages/f8/15/08dad87221aaf14c8523fd4779e79f98edbe364d006067bd1c9d735bfadf/genai_pyo3-0.1.15-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:81e88b54ce0ffe906090f690981528feba66e75530a9afc7266b6812d3c399c8", size = 9023745 },
+    { url = "https://files.pythonhosted.org/packages/5e/3e/e8505fa3449a45cf5aa81e63a29cc3b5fd7628e3bd07daa1d1e22383b4b1/genai_pyo3-0.1.15-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3dd494b7fa1daf88f057ce5cbeacb88d30806468045b3ca6075f051093a9e865", size = 4796693 },
+    { url = "https://files.pythonhosted.org/packages/53/86/1f5ac3295be1d62b27ee7834545cf408d7243164371cfc6b1dabe3b04175/genai_pyo3-0.1.15-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7b202d2580b1a11b851dc0b2b3a40dd623d86753a85fd95022e06c6ef352df8", size = 4854696 },
+    { url = "https://files.pythonhosted.org/packages/e2/d5/357587bcc0d9c985b4d649dd226e5f93ba1f115245d0c650bb46782b18a4/genai_pyo3-0.1.15-cp310-cp310-win_amd64.whl", hash = "sha256:b5cd75bf6a5d8483414c017b18f2a27edb1152e7fba4b7c7362e6a8afa7419bb", size = 3940933 },
+    { url = "https://files.pythonhosted.org/packages/fd/6c/eb8aa4826dbc7fb8e10f592b3df4521742fae559241ac8af0e542ebca9ff/genai_pyo3-0.1.15-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:e4cde56f1eb77935df7792be34d5d65936e83ba492e3a8bbe0c201220ba5854a", size = 9023370 },
+    { url = "https://files.pythonhosted.org/packages/32/b3/7f72c69e481b8c8e28eb4b1275ff78f60b2055659969d5bdb2d1dd41613f/genai_pyo3-0.1.15-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94e570166648d641e5231dfdd2368448e616449354bda7710ebedc23d3c0b136", size = 4797973 },
+    { url = "https://files.pythonhosted.org/packages/cc/98/3b5eb1498d4d80265cf9e2cead6f31cf9b11271e34f19c20683cd33e6e3f/genai_pyo3-0.1.15-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34f8b007dd04d43363330c3a23d19af8f813c06522ddffc7ba49d394fdfa7c1b", size = 4853930 },
+    { url = "https://files.pythonhosted.org/packages/04/bf/21646d6b7aeeb52e8b005a9236d806865970f67e55b939e797b8d5a2218f/genai_pyo3-0.1.15-cp311-cp311-win_amd64.whl", hash = "sha256:a1629bfeb873eff54ca0beb28b73712e14c9444332a8176d598fa3b1d6829814", size = 3941056 },
+    { url = "https://files.pythonhosted.org/packages/bd/8b/d8ca4bcbff2adf917c00bc5f585152392ec19cb55cc08e13b7ea501372b1/genai_pyo3-0.1.15-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:caeb8c9b1982db21ff0c21eed9c0c8ff564c9157e4057ccc82a89cba934e6ccb", size = 9017209 },
+    { url = "https://files.pythonhosted.org/packages/24/a6/2805f28ad430e23a32e8c11a441dfd3b71d355165ce5fb9fcdae9bb64715/genai_pyo3-0.1.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6d069a3670df9f9b71e4e7cb3e322ed65535decba99790cc5a5292b8cd8d4eb", size = 4794499 },
+    { url = "https://files.pythonhosted.org/packages/15/7c/413002dd68b2e475d40a26ef4816099d13f5b9ee8a1b944eaf20d924fb9e/genai_pyo3-0.1.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30b370252f3bfe6df40550b5eda35b6a44d4e2d91be1d3463422adbf312b2988", size = 4852687 },
+    { url = "https://files.pythonhosted.org/packages/20/a3/4f3f801074a3ceb744f7cff91fdeb73a20f648767f17e49cba1516a73094/genai_pyo3-0.1.15-cp312-cp312-win_amd64.whl", hash = "sha256:8afc3acc661686ddc462f374ab5f8d9a681c94286646c473a6d69856780e160d", size = 3934018 },
+    { url = "https://files.pythonhosted.org/packages/76/5a/804addc8b4b3066722734f748a4f5dbb1ebbee4b447c4373470d4ddc5909/genai_pyo3-0.1.15-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:141cca77faed6e70de4b7ce9a696d6f2bde70e20b7db9b5b8f0d401c54e5132e", size = 9016588 },
+    { url = "https://files.pythonhosted.org/packages/d9/08/57b3a32716f191e69cb8eb481568f81b3cf8682872028ca46d4c204794e2/genai_pyo3-0.1.15-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b0592b7892847c5c765ffbe165de997818a9e5ac1b08184251b8b6b36c9953", size = 4794043 },
+    { url = "https://files.pythonhosted.org/packages/fb/9a/ffb2ee6c5be4cc5a46714b52518ef81efc8e276a631ada47ac8dc72c7a67/genai_pyo3-0.1.15-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a235184c7e247886aaaab2601d33cb9b616eeacfc425bcca7823056e813637ad", size = 4852055 },
+    { url = "https://files.pythonhosted.org/packages/bf/5f/0594b8d5f30673b9fc1a5f37cc765da2d15c7b2f65f23910fe69d682f4da/genai_pyo3-0.1.15-cp313-cp313-win_amd64.whl", hash = "sha256:792a1ad203b1c27804db17b5d06d388724c0952350a6097a85f1f9dd265ac0e3", size = 3933710 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "docker", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "genai-pyo3", specifier = ">=0.1.11" },
+    { name = "genai-pyo3", specifier = ">=0.1.14" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.0" },
@@ -1133,29 +1133,29 @@ wheels = [
 
 [[package]]
 name = "genai-pyo3"
-version = "0.1.11"
+version = "0.1.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/a1/9a5410774de262775da5d644171b4e30fc9352f9aa2c8206f67c95beef10/genai_pyo3-0.1.11.tar.gz", hash = "sha256:590bfe3ef048880cf601ae329f7243b9d9744404822e44561f2b30152e6c36a9", size = 41193 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/cc/31492a605f8daa95bb521e7859bf2218ca0201fb322ec0e90e54f95717b4/genai_pyo3-0.1.14.tar.gz", hash = "sha256:0f7c218b9addea8fd2f597b845c1f7ca83c0e7f4e1c5190645ebc7117fb6f2cd", size = 42399 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/1c/2fdb54d17ce74098331badf5f18d2575740d09873949ef62a8864f1d85cf/genai_pyo3-0.1.11-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:217065859e2eca528f25ff3f7452ee5c4e041933363b123b87fb4c90850836d2", size = 9002350 },
-    { url = "https://files.pythonhosted.org/packages/de/81/75d9c2b01eb16ae2c43e831525cd6e7cae8c4d3cf4d2f9b1e97a671e0678/genai_pyo3-0.1.11-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a90bb8766149f4a83f913fb806ea57b1dd2df55d9fc7065e8be25fec46b750ac", size = 4786014 },
-    { url = "https://files.pythonhosted.org/packages/31/f2/26f2fb14cf0d0107bbf55dbd300f322d2e66ed038488e0551beef770b292/genai_pyo3-0.1.11-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d0fea3a3beadb682a684a5305f31c31e6697b873052f22dced143880d6a471a", size = 4854497 },
-    { url = "https://files.pythonhosted.org/packages/14/c4/6b6bb9b649b40c2ab505c6c558333778c127fd55570610f861876e0e10c6/genai_pyo3-0.1.11-cp310-cp310-win_amd64.whl", hash = "sha256:9d34048c276ceacb089722ff75538e0841b6a800adf5ac8ea671d9fa6dff0516", size = 3930329 },
-    { url = "https://files.pythonhosted.org/packages/c7/d1/3fae170156840597e7a22b6c7c53c47e3e36520107328a22398bd96089ad/genai_pyo3-0.1.11-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:32879efea6638f042cf45789e5c734c80d1e9b81ac6a0a76aff37a1d3ec17100", size = 9002379 },
-    { url = "https://files.pythonhosted.org/packages/2b/16/6d39e6b2ce3c7dcc518440d8f617b3605db3911bca8407e8e5c8fb86e3cd/genai_pyo3-0.1.11-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:52fc01a16b879ae5f059af04f817d8993c2a1dd5e301d5fed70d02c7c7f07851", size = 4787459 },
-    { url = "https://files.pythonhosted.org/packages/b4/52/2efffa0bdb58e17e1234797a775bdf7388f655f575a88cb280ccc1be01d2/genai_pyo3-0.1.11-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59470384573116542edb6f0b89bf13aaff3b855631a8fb6eb7fd834936c2fb5e", size = 4853699 },
-    { url = "https://files.pythonhosted.org/packages/83/e5/04017300bc5670eea7b0bee4b3f04a37426d1ccd7252ac59e64544688a7b/genai_pyo3-0.1.11-cp311-cp311-win_amd64.whl", hash = "sha256:0fff9e5e3177ec27f93b589d20dd8f0be4a297fac3bfa72ac3de3b0802950bed", size = 3930950 },
-    { url = "https://files.pythonhosted.org/packages/1c/05/10ddca0ea23aad6d34c6b05fc7c8f790dd56ef8fdb497d7a6801199f98a7/genai_pyo3-0.1.11-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3c02f976de1897d1634274e017ccde2ffcf4bebe0325fdb6772891eb7b9c5999", size = 9000644 },
-    { url = "https://files.pythonhosted.org/packages/0f/8b/94c6ae7bae81a596ca86f64558d98efc09a52f596e1acddd783480e4c957/genai_pyo3-0.1.11-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:222a28614ee51cfac4cfa7377fa9e7fe14430bca2283c2d27b26e59df7dea549", size = 4783965 },
-    { url = "https://files.pythonhosted.org/packages/9a/63/3bce5f26b7d637c49a770e001366ed8a5240eb705515e365893b577003cd/genai_pyo3-0.1.11-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f44a488cc586a4bb5c323bf31388ca68719bd1e125a4ddde1c4a1cd941c156cb", size = 4849739 },
-    { url = "https://files.pythonhosted.org/packages/e7/b9/0ce3938bea06b525ceadacd972763aa6f7dff0c3295168a218463a04dc3a/genai_pyo3-0.1.11-cp312-cp312-win_amd64.whl", hash = "sha256:dfd1e4fcd6e6a9cdde067cf434ee0bb80ead53391f2148ba1a19145f4cbb2495", size = 3932603 },
-    { url = "https://files.pythonhosted.org/packages/3c/15/614f0872b64961179c9fd27c39834382caa1d3995eb2b27cfc15d0735c92/genai_pyo3-0.1.11-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:27e7a5f92ced67d10c24432a62aacfeac23c37f7ad51e13075e27790803dc845", size = 8998371 },
-    { url = "https://files.pythonhosted.org/packages/88/12/3a0361c03b90539e6d4255c9354389e3bf620519b0b2f31b03d4ee097f63/genai_pyo3-0.1.11-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:154795e205701d51d8bf6718bdf8bba88354e31da5b53342b087372a7b8e13f9", size = 4783262 },
-    { url = "https://files.pythonhosted.org/packages/7a/d5/754c5111d3984775195c1e10efb106a69a7d092a38ce1c863203658288fd/genai_pyo3-0.1.11-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93ede85a0a2a6b1410ae17e5c49fc0fc10814bcdc84f1cb6f69c336e4157f985", size = 4847766 },
-    { url = "https://files.pythonhosted.org/packages/84/ac/5ebfff5e52d9f6cf59b250708fd571352a0802be643e30b3ccc0b9f00235/genai_pyo3-0.1.11-cp313-cp313-win_amd64.whl", hash = "sha256:6e8698f83d6a1c04be590850029861c322c7c59cf8ff7959b703bb8efb482c6b", size = 3932520 },
+    { url = "https://files.pythonhosted.org/packages/69/a1/c2854c60d9a117928a4d2943e11e7b73998a99957dc34caf049b5c4c3379/genai_pyo3-0.1.14-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9aaaa6cb2d8ceac9d91673ca81f412e0aade3e5c2c8a31bfe6a3a119af6d9f96", size = 9022093 },
+    { url = "https://files.pythonhosted.org/packages/06/29/8a0af87527b8984a6d25538f76712dd1b37bd93d385b4d3563a527b3fd2f/genai_pyo3-0.1.14-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07551b6e730c6c2b4146589a5919cb52275727d49913f24fb3f8bced60139a1a", size = 4791818 },
+    { url = "https://files.pythonhosted.org/packages/7d/36/0474a97deb4879bb2cba316312fb593f690f763c832054cc31617fca2601/genai_pyo3-0.1.14-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0e9c20da871f39adf66095727e7a1bff1b8d9d2da688108106522d7bd5739f0", size = 4850999 },
+    { url = "https://files.pythonhosted.org/packages/c9/68/aaeadd219cc12fda291206e59b6352c2bd62f34e26350e9f9f62f64ceec6/genai_pyo3-0.1.14-cp310-cp310-win_amd64.whl", hash = "sha256:75e7c89dc6f267ffe2a409337722743eae2263fa576310a48ed824c2efc1f1fa", size = 3938475 },
+    { url = "https://files.pythonhosted.org/packages/14/0a/3c470ac7fbd8aa26a774ccef9961d385e5b97a54d68b47d32c09e2515f05/genai_pyo3-0.1.14-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2f54c772f27fecd67a130e8d757d1ca24d7ec451665eaed2363ef64f8592152c", size = 9020831 },
+    { url = "https://files.pythonhosted.org/packages/cf/d6/e5f982d5548f466ad6ad1975b2362714828e77f833d32dfdf63cb7a22005/genai_pyo3-0.1.14-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3fa41cca752a3d205163c1202d54960c3393af74e467444f6b0a8792d8fa2f28", size = 4793791 },
+    { url = "https://files.pythonhosted.org/packages/33/87/6be3bfe8401c6b4353f9420b91c61804992c669eb35a3230174e4a270ef8/genai_pyo3-0.1.14-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd7ae39857452c79f140f6b02d1de6462539976c003fed68c60f2f817d483eeb", size = 4850499 },
+    { url = "https://files.pythonhosted.org/packages/07/79/456a1650990e9004685b026fc8ce60b05ff079d0d9385e1cf1ef0c1bb278/genai_pyo3-0.1.14-cp311-cp311-win_amd64.whl", hash = "sha256:dfb851d58510c1ca58bebff434e1436dbe724710bc8e4dc3179a30ccc8a9f2cf", size = 3938634 },
+    { url = "https://files.pythonhosted.org/packages/cb/98/5c30fc00486e56f127fa2997c91478fee6787e4a8cf5f496d4b6bd096877/genai_pyo3-0.1.14-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6f6a34d08e9d7f745d2daeb9418c4f096866611970639ba016279a3acdd43102", size = 9009683 },
+    { url = "https://files.pythonhosted.org/packages/35/a4/7fefadf837f8a793bee061f8ffd17b3765958e51852046e08adf9f7eee6d/genai_pyo3-0.1.14-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:647971f4e56ba9600397dc92ee490a914db30ac81ae6884cda455b02a9977f33", size = 4789723 },
+    { url = "https://files.pythonhosted.org/packages/63/6b/6cb3839b0b9d5d95ed519cb23531ee8ae1224df0cddee89c3434c1d22bdc/genai_pyo3-0.1.14-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ea6ac101c1cb104ea8864962c3164400c212977cc601999a503ba423428988c", size = 4851933 },
+    { url = "https://files.pythonhosted.org/packages/32/c5/7fc1586a6bcb6115d2df19d2f25cc0e8733a6b5732ec145e716fbe7465d3/genai_pyo3-0.1.14-cp312-cp312-win_amd64.whl", hash = "sha256:772d03fdac8d52b0a085681a22178f73dc262eb930ed12396ec3e9501df594a7", size = 3936556 },
+    { url = "https://files.pythonhosted.org/packages/3f/86/ae61a95e3eddec94cc9580ce9fa1845e9abba02cb8aa215e22b8d60079ae/genai_pyo3-0.1.14-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b2a6f8a619b4bd226c7ab1a7a2d5f16002363a8c9f33a432d795a1464165924a", size = 9008506 },
+    { url = "https://files.pythonhosted.org/packages/95/e5/61196118cb2b089d7397040feb1d8b9b409082d6885e06cdbe49989cd6d8/genai_pyo3-0.1.14-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c468efb69ad2e85daff5cfa727969b09a8b172f51ea3a93e5aa08ffb499e2e1", size = 4789024 },
+    { url = "https://files.pythonhosted.org/packages/d7/a0/e2485c1a9ecdcc9e0d2f47b1f4d3d709cd35d5fb54f9946693110de7839f/genai_pyo3-0.1.14-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a5d6a69094f2d6466cb612c629191fb5ae6cf1bba3c863835bebf2b2df23c9ae", size = 4850504 },
+    { url = "https://files.pythonhosted.org/packages/bb/d2/80e3f476a1cd345eb3687795cc8069f7def33dee1e6d1b955800af001a90/genai_pyo3-0.1.14-cp313-cp313-win_amd64.whl", hash = "sha256:32f42fbdd099169bc415db200ec21b1c2964702a7f436558b2330e8cfafab09f", size = 3936622 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ requires-dist = [
     { name = "docker", specifier = ">=7.0.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
-    { name = "genai-pyo3", specifier = ">=0.1.15" },
+    { name = "genai-pyo3", specifier = ">=0.1.16" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.0" },
@@ -1133,29 +1133,29 @@ wheels = [
 
 [[package]]
 name = "genai-pyo3"
-version = "0.1.15"
+version = "0.1.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/b7/a5ab69f8a3097d83891af9922907500414aadbd0a8d6a6230271136df6de/genai_pyo3-0.1.15.tar.gz", hash = "sha256:39be65d833d98432e88fed72f34d14b14b5458fbb6620f83ee92da1d130182f8", size = 42609 }
+sdist = { url = "https://files.pythonhosted.org/packages/23/88/f1b7026d7a14a8d7f306e30dab1d29edf2ddbb6e48665531d28f9675a5ac/genai_pyo3-0.1.16.tar.gz", hash = "sha256:1da0d4eb175bd6877bc7a5f36a79817887ce0b3b8f881d381305898bf5557388", size = 43082 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/15/08dad87221aaf14c8523fd4779e79f98edbe364d006067bd1c9d735bfadf/genai_pyo3-0.1.15-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:81e88b54ce0ffe906090f690981528feba66e75530a9afc7266b6812d3c399c8", size = 9023745 },
-    { url = "https://files.pythonhosted.org/packages/5e/3e/e8505fa3449a45cf5aa81e63a29cc3b5fd7628e3bd07daa1d1e22383b4b1/genai_pyo3-0.1.15-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3dd494b7fa1daf88f057ce5cbeacb88d30806468045b3ca6075f051093a9e865", size = 4796693 },
-    { url = "https://files.pythonhosted.org/packages/53/86/1f5ac3295be1d62b27ee7834545cf408d7243164371cfc6b1dabe3b04175/genai_pyo3-0.1.15-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7b202d2580b1a11b851dc0b2b3a40dd623d86753a85fd95022e06c6ef352df8", size = 4854696 },
-    { url = "https://files.pythonhosted.org/packages/e2/d5/357587bcc0d9c985b4d649dd226e5f93ba1f115245d0c650bb46782b18a4/genai_pyo3-0.1.15-cp310-cp310-win_amd64.whl", hash = "sha256:b5cd75bf6a5d8483414c017b18f2a27edb1152e7fba4b7c7362e6a8afa7419bb", size = 3940933 },
-    { url = "https://files.pythonhosted.org/packages/fd/6c/eb8aa4826dbc7fb8e10f592b3df4521742fae559241ac8af0e542ebca9ff/genai_pyo3-0.1.15-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:e4cde56f1eb77935df7792be34d5d65936e83ba492e3a8bbe0c201220ba5854a", size = 9023370 },
-    { url = "https://files.pythonhosted.org/packages/32/b3/7f72c69e481b8c8e28eb4b1275ff78f60b2055659969d5bdb2d1dd41613f/genai_pyo3-0.1.15-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94e570166648d641e5231dfdd2368448e616449354bda7710ebedc23d3c0b136", size = 4797973 },
-    { url = "https://files.pythonhosted.org/packages/cc/98/3b5eb1498d4d80265cf9e2cead6f31cf9b11271e34f19c20683cd33e6e3f/genai_pyo3-0.1.15-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:34f8b007dd04d43363330c3a23d19af8f813c06522ddffc7ba49d394fdfa7c1b", size = 4853930 },
-    { url = "https://files.pythonhosted.org/packages/04/bf/21646d6b7aeeb52e8b005a9236d806865970f67e55b939e797b8d5a2218f/genai_pyo3-0.1.15-cp311-cp311-win_amd64.whl", hash = "sha256:a1629bfeb873eff54ca0beb28b73712e14c9444332a8176d598fa3b1d6829814", size = 3941056 },
-    { url = "https://files.pythonhosted.org/packages/bd/8b/d8ca4bcbff2adf917c00bc5f585152392ec19cb55cc08e13b7ea501372b1/genai_pyo3-0.1.15-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:caeb8c9b1982db21ff0c21eed9c0c8ff564c9157e4057ccc82a89cba934e6ccb", size = 9017209 },
-    { url = "https://files.pythonhosted.org/packages/24/a6/2805f28ad430e23a32e8c11a441dfd3b71d355165ce5fb9fcdae9bb64715/genai_pyo3-0.1.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6d069a3670df9f9b71e4e7cb3e322ed65535decba99790cc5a5292b8cd8d4eb", size = 4794499 },
-    { url = "https://files.pythonhosted.org/packages/15/7c/413002dd68b2e475d40a26ef4816099d13f5b9ee8a1b944eaf20d924fb9e/genai_pyo3-0.1.15-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30b370252f3bfe6df40550b5eda35b6a44d4e2d91be1d3463422adbf312b2988", size = 4852687 },
-    { url = "https://files.pythonhosted.org/packages/20/a3/4f3f801074a3ceb744f7cff91fdeb73a20f648767f17e49cba1516a73094/genai_pyo3-0.1.15-cp312-cp312-win_amd64.whl", hash = "sha256:8afc3acc661686ddc462f374ab5f8d9a681c94286646c473a6d69856780e160d", size = 3934018 },
-    { url = "https://files.pythonhosted.org/packages/76/5a/804addc8b4b3066722734f748a4f5dbb1ebbee4b447c4373470d4ddc5909/genai_pyo3-0.1.15-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:141cca77faed6e70de4b7ce9a696d6f2bde70e20b7db9b5b8f0d401c54e5132e", size = 9016588 },
-    { url = "https://files.pythonhosted.org/packages/d9/08/57b3a32716f191e69cb8eb481568f81b3cf8682872028ca46d4c204794e2/genai_pyo3-0.1.15-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:82b0592b7892847c5c765ffbe165de997818a9e5ac1b08184251b8b6b36c9953", size = 4794043 },
-    { url = "https://files.pythonhosted.org/packages/fb/9a/ffb2ee6c5be4cc5a46714b52518ef81efc8e276a631ada47ac8dc72c7a67/genai_pyo3-0.1.15-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a235184c7e247886aaaab2601d33cb9b616eeacfc425bcca7823056e813637ad", size = 4852055 },
-    { url = "https://files.pythonhosted.org/packages/bf/5f/0594b8d5f30673b9fc1a5f37cc765da2d15c7b2f65f23910fe69d682f4da/genai_pyo3-0.1.15-cp313-cp313-win_amd64.whl", hash = "sha256:792a1ad203b1c27804db17b5d06d388724c0952350a6097a85f1f9dd265ac0e3", size = 3933710 },
+    { url = "https://files.pythonhosted.org/packages/68/56/8abba47cb9c3d15a2e4e2f2fb1d0a073137a8d0f9b349dc2db751746958e/genai_pyo3-0.1.16-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:59bc47ba3a76341fe7c292c5b843444c622a9c3f004069f741f1579ed351573d", size = 9021685 },
+    { url = "https://files.pythonhosted.org/packages/58/71/d412ff29b99fe37c4300f7b0ebb033d499b3637e530b34aba59713ebe089/genai_pyo3-0.1.16-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e88e2e316d25a107eceab391b150a9649cdcb21f1c9262e71150d288a5fc960", size = 4799103 },
+    { url = "https://files.pythonhosted.org/packages/dc/1f/60364fcad2e76c0af3874a5aa97d8f1f647df5626478df8ecbb921bc4ae3/genai_pyo3-0.1.16-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79130b51381bcb3d5c0f7d7090ff6144b294accee1ab6c43a68d3c7609670ac8", size = 4861324 },
+    { url = "https://files.pythonhosted.org/packages/03/b5/4b7c59901a435c339ff72466a78a4ea6f5d51e715be12471e4d49b684be4/genai_pyo3-0.1.16-cp310-cp310-win_amd64.whl", hash = "sha256:f442d7b5c4dc84e423219c0e122543ab532124396491c5495f587dd72877ad72", size = 3938745 },
+    { url = "https://files.pythonhosted.org/packages/03/7b/a6ef4aba4df74407d64f1358980fe21893fe0ab9e50e939552ae0a4ea344/genai_pyo3-0.1.16-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:dd9c436c9622a0b2103c4f7d32d5b363fbe0bff0a2d0d27c25dcc24186982706", size = 9021566 },
+    { url = "https://files.pythonhosted.org/packages/b8/cd/87688580048fe151a86b1b699c57d67bc98869c61ce3256aaf909d2bc879/genai_pyo3-0.1.16-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b13a50bc0380bcc518039b424fa4e3b9d7db0ee7fe5b4261489ca754ceb0a77e", size = 4801121 },
+    { url = "https://files.pythonhosted.org/packages/4e/9a/c7e0696f381abe6e873ab71aace861436473460586e9d361d96dc953c489/genai_pyo3-0.1.16-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3ed0d8e294d12e6d67d9ef09b54f3ec8e3f8e4f266eada47032bc7648bce7c3", size = 4861113 },
+    { url = "https://files.pythonhosted.org/packages/2a/0b/07f3868225404f66a49665b366ad85ccb4f875c188debdd9dafef90a20a8/genai_pyo3-0.1.16-cp311-cp311-win_amd64.whl", hash = "sha256:c767bc67243b1cd6ecfcf6434657dd05364b5609068f796744dc1a5ce9114d78", size = 3938576 },
+    { url = "https://files.pythonhosted.org/packages/54/82/42dbd182dc69e8700eb42c838cf473f270a4edc7c994a7457e52d680d4d0/genai_pyo3-0.1.16-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:10b3786db54f9dc121323713209f7e80a8369d413a7bed8220a2ee4c64640996", size = 9020577 },
+    { url = "https://files.pythonhosted.org/packages/8c/5a/9b5423edef17cb3c7755b69d4e12093f88ea6c07c1480c35f9166e9d1d1c/genai_pyo3-0.1.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95f83a428114254c3d76fd55c8db4190da7a4b47b19b38b0a093726c8bda1c7c", size = 4788912 },
+    { url = "https://files.pythonhosted.org/packages/4c/3f/5dfb607a932f9d23f746ead8632b92b934e790b6bd84b9de4bdfd0a14cb2/genai_pyo3-0.1.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca6f7ad1e7a2c62be0d7ecf66e5b14508cb4012dc960540718f21376a1975cd6", size = 4857685 },
+    { url = "https://files.pythonhosted.org/packages/2c/b1/421ae886dfbcb657112d9cf8d9cf02dd8a873fecf7f6bc67e5693883cb85/genai_pyo3-0.1.16-cp312-cp312-win_amd64.whl", hash = "sha256:801c38dcb6980d559edaa4e4707563b5e0ce6fd2c68112908aa6dd3a4a972ac9", size = 3936700 },
+    { url = "https://files.pythonhosted.org/packages/83/44/3a0873033fe8c76199bcbd50d1d2534d8a72e488497cf7a85d3b4bcb1fd9/genai_pyo3-0.1.16-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:c70bee672d42bf60cecee422304c2ca51d0f601fb7e1b09472dec6f22894675c", size = 9020126 },
+    { url = "https://files.pythonhosted.org/packages/fe/22/60a9ce359c46b7b1f1d1247bb76fb2ec13111e810142aff202ae1adb2397/genai_pyo3-0.1.16-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd199322989c23fd681803830b3b154a5e0ccbea12c89f023ccc3466ac8920c1", size = 4788347 },
+    { url = "https://files.pythonhosted.org/packages/8e/ad/66b32d78f12c8fa3e2fc2f1518248ccfc0b7bac78bf3b825633e2dcdddb4/genai_pyo3-0.1.16-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:318c6f7dbfce12a8109501a1b41842399fe65673bd5019ca18056f2c6d74f0c7", size = 4856265 },
+    { url = "https://files.pythonhosted.org/packages/fd/5b/961066e768b833ab7e961f479d58581bfe6f761d5a8fe1c94e136f98b565/genai_pyo3-0.1.16-cp313-cp313-win_amd64.whl", hash = "sha256:d885051792250253808b2dec3b1e0efda035d4021f8adcf04d52de9467f3cba7", size = 3936672 },
 ]
 
 [[package]]


### PR DESCRIPTION
Cleanup pass on the weekend specs (009 / 013 / 001), plus a native-reasoning-capture feature that closes out the `think()` thread from earlier in the session.

Six changes, one PR — each test-covered, each individually revertable:

## 1. spec 009 — calibration race + pydantic migration

`CalibrationStore.record_human_verdict` was `load_all → mutate → _write_all` with no lock. Any concurrent `append()` landing between the load and the tempfile rename was silently dropped. The existing `# Atomic append` comment was aspirational — the code didn't implement it.

Fix: `_calibration_lock` context manager holding a module-level `threading.Lock` plus an exclusive `fcntl.flock` on a sidecar `.lock` file. Both `append()` and `record_human_verdict()` hold the lock for their entire read-modify-write.

Bonus while here: `CalibrationRecord` is now a pydantic `BaseModel(frozen=True)` with `Severity = Literal["critical"|"high"|"medium"|"low"|"info"]`. A typo like `"meidum"` now raises `ValidationError` on construction instead of silently skewing the exact-match / within-one ratios. `record_human_verdict` replaces the `asdict → mutate dict → Cls(**d)` roundtrip with `r.model_copy(update=patch)`.

Regression test: 150 concurrent threads (50 seeds + 100 appends + 50 verdicts, interleaved shuffle). Pre-fix → rows missing. Post-fix → zero rows lost.

## 2. spec 013 — artifact store dead config

`ArtifactPolicy.export_requires_approval` and `.tied_to_disclosure` were declared, settable, and documented — but **never read**. A user configuring `policy=ArtifactPolicy(export_requires_approval=True)` got zero enforcement. That's worse than having no flag at all — it's security theater.

Fix:

- `retrieve(path, approved_by=None)` now raises `ArtifactExportDenied` when `export_requires_approval=True` and `approved_by` is empty. Also enforces path containment (the artifact path must resolve inside `self._base_dir` — previously any `Path` was accepted, and decryption would fail under GCM but bytes would have already been read).
- `purge_expired()` queries `DisclosureDB.get_queue()` and skips artifacts whose finding is still in `pending_review` / `in_review` / `validated` / `pending_disclosure`. Terminal states (`disclosed`, `closed`, `rejected`) remain eligible for retention-based deletion. Defensive: if the DB isn't available (fresh install), degrades to "no tied-to-disclosure protection" rather than raising — logged at DEBUG.

Imports live at module scope (lifted from the original inside-function pattern).

## 3. spec 013 — behavior monitor threshold latch

`check_thresholds()` appended a new alert **every call** once `_file_write_count > FILE_WRITE_THRESHOLD`. In long-running hunter sessions that's thousands of identical alerts. Added a one-shot `_fired_thresholds: set[str]` so each named threshold fires exactly once per monitor instance. Regression test asserts `(1, 0, 0)` across three consecutive `check_thresholds()` calls, not `(1, 1, 1)`.

## 4. spec 001 — `deep_agent.read_file` line-number regression

Previously `sed -n 'START,ENDp' <file> | cat -n`. `cat -n` numbers output from 1 regardless of where in the file the lines came from, so a hunter asking for lines 101–150 got back a block labeled `1..50` — then reported findings against the wrong line numbers. Replaced with `awk -v s=START -v e=END 'NR>=s && NR<=e { printf "%6d\t%s\n", NR, $0 }'` — `NR` is awk's 1-based line counter relative to the *file*, not to the output. Regression test pins the `NR` usage in the emitted command.

## 5. spec 001 — `think()` tool deleted

Handler body was `return "Noted."` — a literal no-op, despite the tool description claiming "Appears in the audit trail." Removing it saves a tool-call round-trip every time a model was teased into using it. Real reasoning now captured natively (see #6).

## 6. Native reasoning capture, end-to-end

The deletion of `think()` is only sound if real reasoning actually gets captured. Wiring that up required fixes at three layers:

- **clearwing** (`llm/native.py`): `AsyncLLMClient` now sets `capture_reasoning_content=True`, `normalize_reasoning_content=True`, and `reasoning_effort="medium"` (overridable per client). `HunterTrajectoryLogger` records `response.reasoning_content` on every assistant step next to the existing `message`/`usage`/`model` fields.
- **genai-pyo3** (0.1.11 → 0.1.12): adds `reasoning_effort: Option[str]` passthrough on `ChatOptions`. Parsed in `coerce_chat_options` into the matching `genai::chat::ReasoningEffort` variant. Accepts `"none"|"minimal"|"low"|"medium"|"high"|"xhigh"|"max"|"budget:<n>"`.
- **rust-genai** (ropoctl fork, pending upstream PRs): two paired bugs, both in the `openai_resp` adapter:
  - Request side: `reasoning` object was only emitted when `reasoning_effort` was set. `capture_reasoning_content=true` alone did nothing — the `summary="detailed"` opt-in never made it to the wire. Split: `effort` when `reasoning_effort` is some, `summary=detailed` when `capture_reasoning_content=true`, containing object when either is present.
  - Stream side: only `response.reasoning_text.delta` events were parsed. The Responses API emits summaries under the `response.reasoning_summary_text.delta` family when `summary` is requested, so every summary chunk silently fell through to `Unknown`. Added the matching variant + handler.

**Verified end-to-end** against a real Responses endpoint: `AsyncLLMClient` → genai-pyo3 0.1.12 → rust-genai fork → proxy → GPT-5.4-mini returns a populated `reasoning_content` like `"**Explaining multiplication stepwise**\n\nI realize I need to keep my answer brief..."`. Previously empty every time.

New yakbak cassette `tests/data/yakbak/openai_resp/reasoning_summary_capture/` + replay test `test_yakbak_openai_resp_reasoning_summary_capture` on the rust-genai fork asserts `reasoning_content.is_some()` and non-empty after replay — pins the two-part fix and breaks if either half regresses.

## Upstream PRs (filed separately)

- rust-genai: ropoctl/rust-genai `fix/capture-reasoning-without-effort` — single commit rebased onto upstream `main` for a clean review. Will open an upstream PR against `jeremychone/rust-genai`.
- genai-pyo3 0.1.12: tag pushed, PyPI release building as this PR opens.

## Test plan

- [x] `pytest tests/test_calibration.py tests/test_self_security.py tests/test_deep_agent_tools.py tests/test_sourcehunt_validator.py tests/test_commitments.py` — **125 passing.**
- [x] `ruff check` clean on touched files.
- [x] Live end-to-end: `AsyncLLMClient.achat()` against GPT-5.4-mini proxy → `ChatResponse.reasoning_content` populated with summary text.
- [x] In-process round-trips for artifact store approval-required / path containment / purge tied-to-disclosure; behavior monitor latch; calibration race (unit tests).
- [x] Pre-fix rust-genai cassette (`reasoning_stream`) still passes — my adapter changes are additive.

## Labels

Applying `bug` — five real bugs. `enhancement` would also fit for the reasoning-capture half but the PR is titled as a bug cleanup to match the primary driver.

Per [discussion #26](https://github.com/Lazarus-AI/clearwing/discussions/26): no CHANGELOG entry, PR title is the release-notes line.
