### PR TITLE
fix: preserve tool_use/tool_result pairing across approval flows

### DIFF
--- a/clearwing/agent/runtime.py
+++ b/clearwing/agent/runtime.py
@@ -303,6 +303,9 @@ class NativeAgentGraph:
                 try:
                     content = await self._ainvoke_tool(tool, tool_args, resume_decision)
                 except InterruptRequest as exc:
+                    if result_messages:  # preserve earlier parallel tool_results so their tool_use blocks aren't orphaned in history
+                        state.setdefault("messages", []).extend(result_messages)
+                        events.append(dict(state))
                     self._pending[self._find_thread_id_for_state(state)] = _PendingToolResume(
                         tool_calls=tool_calls[index:],
                         prompt=exc.prompt,

--- a/clearwing/ui/tui/app.py
+++ b/clearwing/ui/tui/app.py
@@ -320,9 +320,15 @@ class ClearwingApp(App):
                 if not got_response:
                     feed.add_message("(no response from agent)", "warning")
 
-                # Check for approval interrupts
-                state = self._agent_graph.get_state(self._agent_config)
-                if state.next and state.tasks:
+                # Drain pending approvals; the agent can chain them (each
+                # resume may surface another interrupt). Re-check state after
+                # every resume so subsequent interrupts are prompted instead
+                # of leaking a dangling tool_use when the outer loop consumes
+                # the next keystroke.
+                while True:
+                    state = self._agent_graph.get_state(self._agent_config)
+                    if not (state.next and state.tasks):
+                        break
                     for task in state.tasks:
                         if hasattr(task, "interrupts") and task.interrupts:
                             for intr in task.interrupts:


### PR DESCRIPTION
Two paths left assistant tool_use blocks unpaired, causing Anthropic to reject the next request with `messages.N: tool_use ids were found without tool_result blocks immediately after`:

- agent/runtime.py: on InterruptRequest during parallel tool_calls, flush already-collected ToolMessages into state before pausing so earlier tool_use blocks remain paired after resume.

- ui/tui/app.py: the approval handler iterated interrupts from a single get_state snapshot. When a resume surfaced another approval- required tool_use, the new interrupt went unprompted and the next keystroke orphaned the pending tool_use. Re-check state after every resume.

Fixes #40.