### PR TITLE
fix: add linux/amd64 platform to Docker builds for macOS/arm64

### DIFF
--- a/clearwing/sandbox/hunter_sandbox.py
+++ b/clearwing/sandbox/hunter_sandbox.py
@@ -15,6 +15,7 @@ import hashlib
 import json
 import logging
 import os
+import platform
 import shutil
 import tempfile
 
@@ -152,7 +153,7 @@ class HunterSandbox:
                 ",".join(sanitizers),
             )
             try:
-                client.images.build(path=build_dir, tag=tag, rm=True, forcerm=True)
+                client.images.build(path=build_dir, tag=tag, rm=True, forcerm=True, platform="linux/amd64")
             except Exception as e:
                 logger.warning("Sandbox image build failed: %s", e)
                 logger.debug("Sandbox image build failed", exc_info=True)

--- a/clearwing/sourcehunt/reveng_decompiler.py
+++ b/clearwing/sourcehunt/reveng_decompiler.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import os
+import platform
 import struct
 import tempfile
 from dataclasses import dataclass, field
@@ -225,7 +226,7 @@ class RevengSandbox:
 
             logger.info("Building reveng sandbox image %s", tag)
             try:
-                client.images.build(path=build_dir, tag=tag, rm=True, forcerm=True)
+                client.images.build(path=build_dir, tag=tag, rm=True, forcerm=True, platform="linux/amd64")
             except Exception as e:
                 logger.warning("Reveng image build failed: %s", e)
                 raise RuntimeError(f"Failed to build reveng image: {e}") from e


### PR DESCRIPTION
## Problem

On macOS/arm64, sourcehunt image builds fail because `ltrace` is not available in the Linux package repos when Docker builds without an explicit platform:

```
RuntimeError: Failed to build sandbox image: ... exit status 100
```

## Fix

Set `platform="linux/amd64"` on both `client.images.build()` calls:

- `clearwing/sandbox/hunter_sandbox.py` (line 156)
- `clearwing/sourcehunt/reveng_decompiler.py` (line 229)

This ensures Docker always builds for the Linux target, regardless of host OS. On Linux hosts this is a no-op; on macOS/arm64 it enables proper QEMU emulation via Docker Desktop.

## Testing

- macOS/arm64 with Docker Desktop: image builds succeed
- Linux/amd64: unchanged behavior (platform matches host)

Fixes #42