### PR TITLE
feat: swap scapy for libpnet-pyo3

### DIFF
--- a/clearwing/agent/tools/__init__.py
+++ b/clearwing/agent/tools/__init__.py
@@ -2,7 +2,7 @@
 
 Importing one tool subpackage should not initialize the entire scanning stack.
 Sourcehunt imports `clearwing.agent.tools.hunt`, and that path must stay free
-of OT/scapy side effects.
+of OT / raw-socket side effects.
 """
 
 from typing import Any

--- a/clearwing/core/config.py
+++ b/clearwing/core/config.py
@@ -75,9 +75,10 @@ class ScanConfig:
     target: str = ""
     ports: list = field(default_factory=lambda: list(range(1, 1025)))
     # Default to "connect" (TCP connect / nmap -sT): works without root on
-    # every OS. "syn" (raw-socket SYN scan via scapy) needs root + a route
-    # to a usable IP source; without it scapy silently drops every probe
-    # and the report looks empty. Users can opt back into SYN explicitly.
+    # every OS. "syn" (raw-socket SYN scan via libpnet_pyo3) needs root + a
+    # route to a usable IP source; without it every probe raises
+    # PermissionError and the report looks empty. Users can opt back into
+    # SYN explicitly.
     scan_type: str = "connect"
     threads: int = 100
     timeout: int = 1

--- a/clearwing/scanning/os_scanner.py
+++ b/clearwing/scanning/os_scanner.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import Any
 
-from scapy.all import IP, TCP, sr1
+import libpnet_pyo3
 
 logger = logging.getLogger(__name__)
 
@@ -48,19 +48,18 @@ class OSScanner:
     async def _passive_detect(self, target: str) -> str:
         """Passive OS detection based on TTL and window size."""
         try:
-            ip = IP(dst=target)
-            tcp = TCP(dport=80, flags="S")
-            pkt = ip / tcp
-
             resp = await asyncio.get_event_loop().run_in_executor(
-                None, lambda: sr1(pkt, timeout=self.timeout, verbose=0)
+                None,
+                lambda: libpnet_pyo3.tcp_sr1(
+                    dst=target, dport=80, flags="S", timeout=self.timeout
+                ),
             )
 
             if resp is None:
                 return "Unknown"
 
-            ttl = resp[IP].ttl
-            window = resp[TCP].window if resp.haslayer(TCP) else 0
+            ttl = resp.ttl
+            window = resp.window
 
             # Determine OS based on TTL
             os_name = self._guess_os_by_ttl(ttl)
@@ -87,17 +86,16 @@ class OSScanner:
         results = []
         for port, flags in probes:
             try:
-                ip = IP(dst=target)
-                tcp = TCP(dport=port, flags=flags)
-                pkt = ip / tcp
-
                 resp = await asyncio.get_event_loop().run_in_executor(
-                    None, lambda p=pkt: sr1(p, timeout=self.timeout, verbose=0)
+                    None,
+                    lambda p=port, f=flags: libpnet_pyo3.tcp_sr1(
+                        dst=target, dport=p, flags=f, timeout=self.timeout
+                    ),
                 )
 
-                if resp and resp.haslayer(IP) and resp.haslayer(TCP):
+                if resp is not None:
                     results.append(
-                        {"ttl": resp[IP].ttl, "window": resp[TCP].window, "flags": resp[TCP].flags}
+                        {"ttl": resp.ttl, "window": resp.window, "flags": resp.flags}
                     )
             except Exception:
                 logger.debug("OS probe failed for %s:%d", target, port, exc_info=True)

--- a/clearwing/scanning/port_scanner.py
+++ b/clearwing/scanning/port_scanner.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import Any
 
-from scapy.all import IP, TCP, sr1
+import libpnet_pyo3
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +16,7 @@ def _has_raw_socket_privilege() -> bool:
     but we don't try to probe capabilities — a false negative just means
     the user gets a warning that's actually wrong, which is recoverable.
     On Windows / platforms without ``os.geteuid`` we return True and let
-    scapy decide; we don't want to false-positive a warning there.
+    libpnet_pyo3 surface the privilege error itself.
     """
     geteuid = getattr(os, "geteuid", None)
     if geteuid is None:
@@ -114,10 +114,11 @@ class PortScanner:
         open_ports = []
 
         # Surface the most common silent-failure mode: scan_type='syn'
-        # uses scapy raw sockets, which on macOS/Linux require root
-        # (or CAP_NET_RAW). Without privilege scapy drops every probe
-        # silently and the report looks like "0 open ports". Warn once
-        # per scan so the user can re-run with sudo or scan_type='connect'.
+        # uses libpnet_pyo3 raw sockets, which on macOS/Linux require root
+        # (or CAP_NET_RAW). Without privilege every probe raises
+        # PermissionError and the report looks like "0 open ports". Warn
+        # once per scan so the user can re-run with sudo or switch to
+        # scan_type='connect'.
         if scan_type in ("syn", "fin", "ack", "xmas", "null") and not _has_raw_socket_privilege():
             logger.warning(
                 "scan_type=%r needs raw-socket privileges; this process is "
@@ -162,17 +163,18 @@ class PortScanner:
     async def _syn_scan(self, target: str, port: int) -> bool:
         """Perform SYN scan on a single port."""
         try:
-            ip = IP(dst=target)
-            tcp = TCP(dport=port, flags="S")
-            pkt = ip / tcp
-            resp = await asyncio.get_event_loop().run_in_executor(
-                None, lambda: sr1(pkt, timeout=self.timeout, verbose=0)
+            loop = asyncio.get_event_loop()
+            resp = await loop.run_in_executor(
+                None,
+                lambda: libpnet_pyo3.tcp_sr1(
+                    dst=target, dport=port, flags="S", timeout=self.timeout
+                ),
             )
-            if resp is not None and resp.haslayer(TCP) and resp.getlayer(TCP).flags == 0x12:
-                # Send RST to close the connection
-                rst_pkt = ip / TCP(dport=port, flags="R")
-                await asyncio.get_event_loop().run_in_executor(
-                    None, lambda: sr1(rst_pkt, timeout=1, verbose=0)
+            if resp is not None and resp.is_synack():
+                # Send RST to close the connection (fire-and-forget).
+                await loop.run_in_executor(
+                    None,
+                    lambda: libpnet_pyo3.tcp_send(dst=target, dport=port, flags="R"),
                 )
                 return True
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 
 dependencies = [
     # Core
-    "scapy>=2.5.0",
+    "libpnet-pyo3>=0.1.1",
     "aiohttp>=3.8.0",
     "pyyaml>=6.0",
     "rich>=13.0.0",

--- a/tests/test_scanners.py
+++ b/tests/test_scanners.py
@@ -47,7 +47,7 @@ class TestPortScanner:
 
         with caplog.at_level(logging.WARNING, logger="clearwing.scanning.port_scanner"):
             # Scan a single closed port on localhost so we exit fast
-            # regardless of whether scapy actually fires a packet.
+            # regardless of whether libpnet_pyo3 actually fires a packet.
             await scanner.scan("127.0.0.1", [1], scan_type="syn")
 
         warnings = [


### PR DESCRIPTION
## Summary

Replaces scapy (GPL-2.0) with [libpnet-pyo3](https://pypi.org/project/libpnet-pyo3) (MIT OR Apache-2.0) at the two `sr1` callsites we actually use. libpnet-pyo3 is a thin pyo3 binding over [libpnet](https://github.com/libpnet/libpnet); its `tcp_sr1` / `tcp_send` are drop-in equivalents for what we needed from scapy.

The swap is mechanical — same behavior, same privilege requirements (root / `CAP_NET_RAW`), same warning paths. Six files touched:

- `pyproject.toml`: `scapy>=2.5.0` → `libpnet-pyo3>=0.1.1`
- `clearwing/scanning/port_scanner.py`: `tcp_sr1` for the SYN probe, `tcp_send` (fire-and-forget) for the closing RST
- `clearwing/scanning/os_scanner.py`: `tcp_sr1` in both `_passive_detect` and `_active_detect`; `resp.ttl` / `resp.window` / `resp.flags` replace the scapy layer-accessor syntax
- `clearwing/core/config.py`, `clearwing/agent/tools/__init__.py`, `tests/test_scanners.py`: follow-on comment updates

## Why

- License: clearwing is MIT; scapy is GPL-2.0. The dep is runtime-only so this isn't strictly a license problem, but a permissive replacement is cleaner.
- Footprint: libpnet-pyo3 is a single pyo3 extension with no Python-side import side-effects (scapy registers protocols, configures logging, and pulls in cryptography stack on import).
- API surface: `tcp_sr1(dst, dport, flags, timeout)` is shorter than `sr1(IP(dst=...)/TCP(dport=...,flags=...), timeout=..., verbose=0)` and the `TcpResponse` returned has the fields the scanners actually read (`ttl`, `window`, `flags`, plus helpers like `is_synack()`, `is_rst()`).

## Compat notes

- Raw-socket privileges still required for `syn` / `fin` / `ack` / `xmas` / `null` scan types — the existing `_has_raw_socket_privilege()` warning is unchanged.
- `connect` scan type uses stdlib sockets and is unaffected.
- macOS: TCP raw-socket recv on macOS has historically been finicky (BPF works, raw socket may not). If we see this in practice, the fix is in libpnet-pyo3, not here.
- Historical references to scapy in `docs/CHANGELOG-v1.0.md` are left intact — they accurately describe past behavior.

## Test plan

- [ ] `pip install -e .` resolves `libpnet-pyo3` from PyPI
- [ ] Existing test suite passes: `pytest tests/test_scanners.py` (the non-root subset)
- [ ] Manual: `sudo clearwing scan --scan-type syn 127.0.0.1` returns sensible results
- [ ] Manual: unprivileged `clearwing scan --scan-type syn ...` emits the raw-socket warning
- [ ] Manual: `clearwing scan --scan-type connect ...` is unaffected