### PR TITLE
fix(llm): make reasoning_effort model-aware (denylist + retry-on-400)

### DIFF
--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -470,6 +470,20 @@ class AsyncLLMClient:
                 )
                 await asyncio.sleep(delay)
 
+    @staticmethod
+    def _is_unsupported_reasoning_effort_error(exc: BaseException) -> bool:
+        """True when *exc* indicates the provider rejected ``reasoning_effort``.
+
+        Both conditions required: ``"reasoning_effort"`` must appear in the
+        message AND either ``"400"`` (the HTTP status) or ``"unsupported"``.
+        This avoids false positives on log messages or unrelated errors that
+        happen to mention the parameter name.
+        """
+        text = str(exc).lower()
+        if "reasoning_effort" not in text:
+            return False
+        return "400" in text or "unsupported" in text
+
     def _is_rate_limit_error(self, exc: Exception) -> bool:
         text = str(exc).lower()
         return (

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -349,14 +349,33 @@ class AsyncLLMClient:
             reasoning_effort=self.reasoning_effort,
         )
 
-        async with self._semaphore:
-            client = self._build_client(Client)
-            stream = await client.astream_chat(self.model_name, request, options)
+        async def _consume(opts: ChatOptions) -> ChatResponse | None:
+            stream = await client.astream_chat(self.model_name, request, opts)
             async for event in stream:
                 if event.content:
                     on_text_delta(event.content)
                 if event.end is not None:
                     return event.end
+            return None
+
+        async with self._semaphore:
+            client = self._build_client(Client)
+            try:
+                end_event = await _consume(options)
+            except RuntimeError as exc:
+                if not self._is_unsupported_reasoning_effort_error(exc):
+                    raise
+                logger.warning(
+                    "Provider rejected reasoning_effort (streaming) for model "
+                    "%r; retrying with reasoning_effort=None and disabling for "
+                    "this session.",
+                    self.model_name,
+                )
+                self.reasoning_effort = None
+                options = self._rebuild_options_without_reasoning(options)
+                end_event = await _consume(options)
+            if end_event is not None:
+                return end_event
         # Fallback if stream ends without an end event
         return await self.achat(
             messages=messages,

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -148,7 +148,7 @@ class AsyncLLMClient:
         rate_limit_max_retries: int = 6,
         rate_limit_initial_backoff_seconds: float = 1.0,
         rate_limit_max_backoff_seconds: float = 60.0,
-        reasoning_effort: str | None = "medium",
+        reasoning_effort: str | None | Literal["auto"] = "auto",
     ) -> None:
         self.model_name = model_name
         self.provider_name = provider_name
@@ -208,11 +208,18 @@ class AsyncLLMClient:
 
         self.default_system = default_system
         # `reasoning_effort` controls how much reasoning the provider
-        # runs (for models that support it). "medium" is a sensible
-        # default — higher for deeper-reasoning tasks, "none"/None to
-        # opt out entirely. Accepted values: "none" | "minimal" | "low"
-        # | "medium" | "high" | "xhigh" | "max" | "budget:<n>".
-        self.reasoning_effort = reasoning_effort
+        # runs (for models that support it). Accepted values: "none" |
+        # "minimal" | "low" | "medium" | "high" | "xhigh" | "max" |
+        # "budget:<n>" | None.
+        #
+        # The sentinel "auto" (the default) lets the client decide based
+        # on the model name — most non-OpenAI OpenAI-compat models reject
+        # this param entirely (see _REASONING_EFFORT_UNSUPPORTED_PATTERNS).
+        # Explicit values (including None) bypass the auto-resolution.
+        if reasoning_effort == "auto":
+            self.reasoning_effort = self._auto_resolve_reasoning_effort(model_name)
+        else:
+            self.reasoning_effort = reasoning_effort
         self.rate_limit_max_retries = max(0, rate_limit_max_retries)
         self.rate_limit_initial_backoff_seconds = max(0.1, rate_limit_initial_backoff_seconds)
         self.rate_limit_max_backoff_seconds = max(

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -7,7 +7,7 @@ import random
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 from genai_pyo3 import (
     ChatMessage,
@@ -21,6 +21,34 @@ from genai_pyo3 import (
 from pydantic import BaseModel, RootModel
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# reasoning_effort auto-detection
+# ---------------------------------------------------------------------------
+#
+# `reasoning_effort` is an OpenAI-reasoning-only parameter. Most non-OpenAI
+# OpenAI-compat endpoints reject it with HTTP 400 when the configured model is
+# not reasoning-capable. We default to omitting it for models we know reject
+# it, while preserving the current "medium" default for everything else.
+#
+# Match semantics: case-insensitive substring against the model name. First
+# match wins. Order is not significant.
+
+_REASONING_EFFORT_UNSUPPORTED_PATTERNS: tuple[str, ...] = (
+    "llama-3",
+    "llama-4",
+    "mistral",
+    "mixtral",
+    "qwen2",
+    "gemma",
+)
+
+# Explicit re-enable list for model names that contain an unsupported pattern
+# above but actually *do* support reasoning_effort (e.g. reasoning-tuned
+# variants of denylisted model families). Intentionally empty today; populate
+# as such models ship.
+_REASONING_EFFORT_OVERRIDE_ALLOW: frozenset[str] = frozenset()
 
 
 def _run_coro_sync(coro):
@@ -85,6 +113,28 @@ class AsyncLLMClient:
     only the pieces Clearwing actually needs: text, tool calls, usage, and
     bounded concurrency.
     """
+
+    @staticmethod
+    def _auto_resolve_reasoning_effort(model_name: str) -> str | None:
+        """Return the effective reasoning_effort for *model_name*.
+
+        Returns ``None`` (i.e. omit the parameter) when the model name matches
+        a pattern in :data:`_REASONING_EFFORT_UNSUPPORTED_PATTERNS` and is not
+        in :data:`_REASONING_EFFORT_OVERRIDE_ALLOW`. Returns ``"medium"``
+        otherwise (the previous default for all callers).
+        """
+        lower = model_name.lower()
+        if lower in _REASONING_EFFORT_OVERRIDE_ALLOW:
+            return "medium"
+        for pattern in _REASONING_EFFORT_UNSUPPORTED_PATTERNS:
+            if pattern in lower:
+                logger.info(
+                    "reasoning_effort=None: model %r matches non-reasoning pattern %r",
+                    model_name,
+                    pattern,
+                )
+                return None
+        return "medium"
 
     def __init__(
         self,

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -284,9 +284,24 @@ class AsyncLLMClient:
 
         async with self._semaphore:
             client = self._build_client(Client)
-            response = await self._with_rate_limit_retries(
-                lambda: self._achat_with_provider_policy(client, request, options)
-            )
+            try:
+                response = await self._with_rate_limit_retries(
+                    lambda: self._achat_with_provider_policy(client, request, options)
+                )
+            except RuntimeError as exc:
+                if not self._is_unsupported_reasoning_effort_error(exc):
+                    raise
+                logger.warning(
+                    "Provider rejected reasoning_effort for model %r; "
+                    "retrying with reasoning_effort=None and disabling for "
+                    "this session.",
+                    self.model_name,
+                )
+                self.reasoning_effort = None
+                options = self._rebuild_options_without_reasoning(options)
+                response = await self._with_rate_limit_retries(
+                    lambda: self._achat_with_provider_policy(client, request, options)
+                )
         return response
 
     async def achat_stream(

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -471,6 +471,26 @@ class AsyncLLMClient:
                 await asyncio.sleep(delay)
 
     @staticmethod
+    def _rebuild_options_without_reasoning(options: ChatOptions) -> ChatOptions:
+        """Return a copy of *options* with ``reasoning_effort=None``.
+
+        ``ChatOptions`` is a frozen Rust struct from genai-pyo3, so we
+        reconstruct it from scratch. ``response_json_spec`` is preserved
+        when present.
+        """
+        return ChatOptions(
+            temperature=options.temperature,
+            max_tokens=options.max_tokens,
+            capture_content=options.capture_content,
+            capture_usage=options.capture_usage,
+            capture_tool_calls=options.capture_tool_calls,
+            capture_reasoning_content=options.capture_reasoning_content,
+            normalize_reasoning_content=options.normalize_reasoning_content,
+            reasoning_effort=None,
+            response_json_spec=getattr(options, "response_json_spec", None),
+        )
+
+    @staticmethod
     def _is_unsupported_reasoning_effort_error(exc: BaseException) -> bool:
         """True when *exc* indicates the provider rejected ``reasoning_effort``.
 

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -1,0 +1,62 @@
+"""Tests for the reasoning_effort auto-detection added to AsyncLLMClient.
+
+See: docs/specs/2026-05-27-clearwing-reasoning-effort-patch-design.md
+"""
+
+import pytest
+
+from clearwing.llm.native import (
+    AsyncLLMClient,
+    _REASONING_EFFORT_UNSUPPORTED_PATTERNS,
+    _REASONING_EFFORT_OVERRIDE_ALLOW,
+)
+
+
+class TestAutoResolveReasoningEffort:
+    """Layer 1: model-name-based denylist."""
+
+    def test_groq_llama_3_3_resolves_to_none(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("llama-3.3-70b-versatile")
+        assert result is None
+
+    def test_match_is_case_insensitive(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("Llama-3-70B-INSTRUCT")
+        assert result is None
+
+    def test_openai_gpt_4o_keeps_medium(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("gpt-4o")
+        assert result == "medium"
+
+    def test_openai_o1_keeps_medium(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("o1-preview")
+        assert result == "medium"
+
+    def test_deepseek_r1_keeps_medium(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("deepseek-r1")
+        assert result == "medium"
+
+    def test_mistral_resolves_to_none(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("mistral-large-2407")
+        assert result is None
+
+    def test_mixtral_resolves_to_none(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("mixtral-8x7b-instruct")
+        assert result is None
+
+    def test_qwen2_resolves_to_none(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("qwen2.5-72b-instruct")
+        assert result is None
+
+    def test_gemma_resolves_to_none(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("gemma-2-27b-it")
+        assert result is None
+
+    def test_unknown_model_keeps_medium(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("some-future-model-2030")
+        assert result == "medium"
+
+    def test_constants_are_exported(self):
+        """Sanity check: the public surface for the denylist is the two module-level constants."""
+        assert isinstance(_REASONING_EFFORT_UNSUPPORTED_PATTERNS, tuple)
+        assert "llama-3" in _REASONING_EFFORT_UNSUPPORTED_PATTERNS
+        assert isinstance(_REASONING_EFFORT_OVERRIDE_ALLOW, frozenset)

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -144,3 +144,32 @@ class TestIsUnsupportedReasoningEffortError:
         # isn't actually a 400 or "unsupported" message
         exc = RuntimeError("reasoning_effort defaulted to medium for unknown model")
         assert AsyncLLMClient._is_unsupported_reasoning_effort_error(exc) is False
+
+
+class TestRebuildOptionsWithoutReasoning:
+    """Layer 2 helper: reconstruct ChatOptions with reasoning_effort dropped."""
+
+    def test_drops_reasoning_effort_preserves_everything_else(self):
+        from genai_pyo3 import ChatOptions
+
+        original = ChatOptions(
+            temperature=0.7,
+            max_tokens=2048,
+            capture_content=True,
+            capture_usage=True,
+            capture_tool_calls=True,
+            capture_reasoning_content=True,
+            normalize_reasoning_content=True,
+            reasoning_effort="medium",
+        )
+
+        rebuilt = AsyncLLMClient._rebuild_options_without_reasoning(original)
+
+        assert rebuilt.reasoning_effort is None
+        assert rebuilt.temperature == 0.7
+        assert rebuilt.max_tokens == 2048
+        assert rebuilt.capture_content is True
+        assert rebuilt.capture_usage is True
+        assert rebuilt.capture_tool_calls is True
+        assert rebuilt.capture_reasoning_content is True
+        assert rebuilt.normalize_reasoning_content is True

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -3,6 +3,9 @@
 See: docs/specs/2026-05-27-clearwing-reasoning-effort-patch-design.md
 """
 
+import asyncio
+from unittest.mock import patch
+
 import pytest
 
 from clearwing.llm.native import (
@@ -173,3 +176,81 @@ class TestRebuildOptionsWithoutReasoning:
         assert rebuilt.capture_tool_calls is True
         assert rebuilt.capture_reasoning_content is True
         assert rebuilt.normalize_reasoning_content is True
+
+
+class TestAchatRetryOnUnsupportedReasoning:
+    """Layer 2 in the non-streaming path: catch the 400, retry once, mutate state."""
+
+    def _make_client(self):
+        # Pass explicit reasoning_effort="medium" to bypass auto-detection,
+        # so we can prove the retry path runs even when Layer 1 didn't catch it.
+        return AsyncLLMClient(
+            model_name="some-future-model-2030",
+            provider_name="openai_compat",
+            api_key="sk-test",
+            reasoning_effort="medium",
+        )
+
+    def test_retries_once_and_mutates_self(self):
+        client = self._make_client()
+        first_exc = RuntimeError(
+            "Status: 400 Bad Request. "
+            'Body: {"error":{"message":"`reasoning_effort` is not supported"}}'
+        )
+        success_response = object()  # Sentinel — we don't assert its shape
+
+        # Replace the private call helper. _achat_with_provider_policy is the
+        # narrowest seam: raises on first call, returns on second.
+        call_log: list[str] = []
+
+        async def fake_policy(self_, client_obj, request, options):
+            call_log.append("called")
+            if len(call_log) == 1:
+                raise first_exc
+            assert options.reasoning_effort is None, (
+                "Second call must drop reasoning_effort"
+            )
+            return success_response
+
+        with patch.object(
+            AsyncLLMClient,
+            "_achat_with_provider_policy",
+            new=fake_policy,
+        ), patch.object(
+            AsyncLLMClient,
+            "_build_client",
+            new=lambda self, cls: object(),
+        ):
+            result = asyncio.run(
+                client.achat(messages=[], system=None, tools=None)
+            )
+
+        assert result is success_response
+        assert len(call_log) == 2, "Retry should have happened exactly once"
+        assert client.reasoning_effort is None, (
+            "Instance state must be mutated so future calls skip the param"
+        )
+
+    def test_unrelated_runtime_error_propagates(self):
+        client = self._make_client()
+        unrelated = RuntimeError("Status: 500 Internal Server Error")
+
+        async def always_raise(self_, client_obj, request, options):
+            raise unrelated
+
+        with patch.object(
+            AsyncLLMClient,
+            "_achat_with_provider_policy",
+            new=always_raise,
+        ), patch.object(
+            AsyncLLMClient,
+            "_build_client",
+            new=lambda self, cls: object(),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                asyncio.run(client.achat(messages=[], system=None, tools=None))
+
+        assert exc_info.value is unrelated
+        assert client.reasoning_effort == "medium", (
+            "Instance state must not be touched on unrelated errors"
+        )

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -60,3 +60,51 @@ class TestAutoResolveReasoningEffort:
         assert isinstance(_REASONING_EFFORT_UNSUPPORTED_PATTERNS, tuple)
         assert "llama-3" in _REASONING_EFFORT_UNSUPPORTED_PATTERNS
         assert isinstance(_REASONING_EFFORT_OVERRIDE_ALLOW, frozenset)
+
+
+class TestConstructorAutoBehavior:
+    """Layer 1, wired into __init__.
+
+    These tests verify that with the new sentinel default ('auto'), the
+    constructor calls _auto_resolve_reasoning_effort and stores the result.
+    Explicit values (including None and "medium") must pass through untouched.
+    """
+
+    def _kwargs(self, **overrides):
+        """Minimal kwargs to satisfy AsyncLLMClient.__init__."""
+        base = dict(
+            model_name="llama-3.3-70b-versatile",
+            provider_name="openai_compat",
+            api_key="sk-test",
+        )
+        base.update(overrides)
+        return base
+
+    def test_default_for_groq_llama_resolves_to_none(self):
+        client = AsyncLLMClient(**self._kwargs(model_name="llama-3.3-70b-versatile"))
+        assert client.reasoning_effort is None
+
+    def test_default_for_gpt_4o_resolves_to_medium(self):
+        client = AsyncLLMClient(**self._kwargs(model_name="gpt-4o"))
+        assert client.reasoning_effort == "medium"
+
+    def test_explicit_medium_passes_through_on_denylist_model(self):
+        client = AsyncLLMClient(
+            **self._kwargs(
+                model_name="llama-3.3-70b-versatile",
+                reasoning_effort="medium",
+            )
+        )
+        assert client.reasoning_effort == "medium"
+
+    def test_explicit_none_passes_through_on_allowed_model(self):
+        client = AsyncLLMClient(
+            **self._kwargs(model_name="gpt-4o", reasoning_effort=None)
+        )
+        assert client.reasoning_effort is None
+
+    def test_explicit_high_passes_through(self):
+        client = AsyncLLMClient(
+            **self._kwargs(model_name="o1-preview", reasoning_effort="high")
+        )
+        assert client.reasoning_effort == "high"

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -254,3 +254,67 @@ class TestAchatRetryOnUnsupportedReasoning:
         assert client.reasoning_effort == "medium", (
             "Instance state must not be touched on unrelated errors"
         )
+
+
+class TestAchatStreamRetryOnUnsupportedReasoning:
+    """Same Layer 2 behavior, on the streaming path."""
+
+    def _make_client(self):
+        return AsyncLLMClient(
+            model_name="some-future-model-2030",
+            provider_name="openai_compat",
+            api_key="sk-test",
+            reasoning_effort="medium",
+        )
+
+    def test_streaming_path_retries_once(self):
+        client = self._make_client()
+        first_exc = RuntimeError(
+            "Status: 400 Bad Request. "
+            'Body: {"error":{"message":"`reasoning_effort` is not supported"}}'
+        )
+        success_end = object()
+        on_text = lambda chunk: None  # noqa: E731
+
+        call_log: list[str] = []
+
+        class FakeEvent:
+            content = None
+            end = success_end
+
+        async def fake_stream(model_name, request, options):
+            call_log.append("called")
+            if len(call_log) == 1:
+                raise first_exc
+            assert options.reasoning_effort is None, (
+                "Second streaming call must drop reasoning_effort"
+            )
+
+            async def gen():
+                yield FakeEvent()
+
+            return gen()
+
+        fake_client = type(
+            "FakeClient",
+            (),
+            {"astream_chat": staticmethod(fake_stream)},
+        )()
+
+        with patch.object(
+            AsyncLLMClient,
+            "_build_client",
+            new=lambda self, cls: fake_client,
+        ):
+            result = asyncio.run(
+                client.achat_stream(
+                    messages=[],
+                    system=None,
+                    tools=None,
+                    on_text_delta=on_text,
+                )
+            )
+
+        assert result is success_end
+        assert len(call_log) == 2
+        assert client.reasoning_effort is None

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -9,9 +9,9 @@ from unittest.mock import patch
 import pytest
 
 from clearwing.llm.native import (
-    AsyncLLMClient,
-    _REASONING_EFFORT_UNSUPPORTED_PATTERNS,
     _REASONING_EFFORT_OVERRIDE_ALLOW,
+    _REASONING_EFFORT_UNSUPPORTED_PATTERNS,
+    AsyncLLMClient,
 )
 
 
@@ -101,15 +101,11 @@ class TestConstructorAutoBehavior:
         assert client.reasoning_effort == "medium"
 
     def test_explicit_none_passes_through_on_allowed_model(self):
-        client = AsyncLLMClient(
-            **self._kwargs(model_name="gpt-4o", reasoning_effort=None)
-        )
+        client = AsyncLLMClient(**self._kwargs(model_name="gpt-4o", reasoning_effort=None))
         assert client.reasoning_effort is None
 
     def test_explicit_high_passes_through(self):
-        client = AsyncLLMClient(
-            **self._kwargs(model_name="o1-preview", reasoning_effort="high")
-        )
+        client = AsyncLLMClient(**self._kwargs(model_name="o1-preview", reasoning_effort="high"))
         assert client.reasoning_effort == "high"
 
 
@@ -207,23 +203,22 @@ class TestAchatRetryOnUnsupportedReasoning:
             call_log.append("called")
             if len(call_log) == 1:
                 raise first_exc
-            assert options.reasoning_effort is None, (
-                "Second call must drop reasoning_effort"
-            )
+            assert options.reasoning_effort is None, "Second call must drop reasoning_effort"
             return success_response
 
-        with patch.object(
-            AsyncLLMClient,
-            "_achat_with_provider_policy",
-            new=fake_policy,
-        ), patch.object(
-            AsyncLLMClient,
-            "_build_client",
-            new=lambda self, cls: object(),
+        with (
+            patch.object(
+                AsyncLLMClient,
+                "_achat_with_provider_policy",
+                new=fake_policy,
+            ),
+            patch.object(
+                AsyncLLMClient,
+                "_build_client",
+                new=lambda self, cls: object(),
+            ),
         ):
-            result = asyncio.run(
-                client.achat(messages=[], system=None, tools=None)
-            )
+            result = asyncio.run(client.achat(messages=[], system=None, tools=None))
 
         assert result is success_response
         assert len(call_log) == 2, "Retry should have happened exactly once"
@@ -238,14 +233,17 @@ class TestAchatRetryOnUnsupportedReasoning:
         async def always_raise(self_, client_obj, request, options):
             raise unrelated
 
-        with patch.object(
-            AsyncLLMClient,
-            "_achat_with_provider_policy",
-            new=always_raise,
-        ), patch.object(
-            AsyncLLMClient,
-            "_build_client",
-            new=lambda self, cls: object(),
+        with (
+            patch.object(
+                AsyncLLMClient,
+                "_achat_with_provider_policy",
+                new=always_raise,
+            ),
+            patch.object(
+                AsyncLLMClient,
+                "_build_client",
+                new=lambda self, cls: object(),
+            ),
         ):
             with pytest.raises(RuntimeError) as exc_info:
                 asyncio.run(client.achat(messages=[], system=None, tools=None))

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -108,3 +108,39 @@ class TestConstructorAutoBehavior:
             **self._kwargs(model_name="o1-preview", reasoning_effort="high")
         )
         assert client.reasoning_effort == "high"
+
+
+class TestIsUnsupportedReasoningEffortError:
+    """Layer 2 helper: classifying the exception so we only retry the right ones."""
+
+    def test_matches_real_groq_400_body(self):
+        # Verbatim from the original session log
+        exc = RuntimeError(
+            "Web stream error for model 'llama-3.3-70b-versatile (adapter: OpenAI)'. "
+            "Status: 400 Bad Request. "
+            'Body: {"error":{"message":"`reasoning_effort` is not supported with '
+            'this model","type":"invalid_request_error","code":"unknown_parameter"}}'
+        )
+        assert AsyncLLMClient._is_unsupported_reasoning_effort_error(exc) is True
+
+    def test_matches_unsupported_word_without_400(self):
+        exc = RuntimeError("reasoning_effort: unsupported parameter")
+        assert AsyncLLMClient._is_unsupported_reasoning_effort_error(exc) is True
+
+    def test_rejects_429_rate_limit(self):
+        exc = RuntimeError("Status: 429 Too Many Requests. rate limit exceeded")
+        assert AsyncLLMClient._is_unsupported_reasoning_effort_error(exc) is False
+
+    def test_rejects_400_for_other_param(self):
+        exc = RuntimeError("Status: 400 Bad Request. unknown parameter 'frobnicator'")
+        assert AsyncLLMClient._is_unsupported_reasoning_effort_error(exc) is False
+
+    def test_rejects_500_server_error(self):
+        exc = RuntimeError("Status: 500 Internal Server Error")
+        assert AsyncLLMClient._is_unsupported_reasoning_effort_error(exc) is False
+
+    def test_rejects_non_400_message_mentioning_param(self):
+        # Defensive: a stringified exception that mentions reasoning_effort but
+        # isn't actually a 400 or "unsupported" message
+        exc = RuntimeError("reasoning_effort defaulted to medium for unknown model")
+        assert AsyncLLMClient._is_unsupported_reasoning_effort_error(exc) is False

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -1,6 +1,7 @@
 """Tests for the reasoning_effort auto-detection added to AsyncLLMClient.
 
-See: docs/specs/2026-05-27-clearwing-reasoning-effort-patch-design.md
+Covers Layer 1 (model-name denylist + sentinel-default constructor) and
+Layer 2 (retry-on-400 fallback in achat / achat_stream).
 """
 
 import asyncio


### PR DESCRIPTION
## Problem

`AsyncLLMClient` defaults `reasoning_effort` to `"medium"` and passes it through to every OpenAI-compat endpoint unconditionally. This breaks against any provider whose configured model isn't reasoning-capable. The most common case is Groq direct + Llama 3.x:

```
RuntimeError: Web stream error for model 'llama-3.3-70b-versatile (adapter: OpenAI)'.
Status: 400 Bad Request
Body: {"error":{"message":"`reasoning_effort` is not supported with this model",
       "type":"invalid_request_error","code":"unknown_parameter"}}
```

Reproducible against the documented `clearwing config --set-provider` flow followed by `clearwing sourcehunt <target> --depth quick` — the static-analyzer pre-pass still runs (so the user sees *some* output), but the LLM hunter loop and Ranker never execute. `Files Hunted: 0`. Same problem against Mistral, Mixtral, Qwen2/2.5 base, Gemma on Groq, Together, Fireworks, and other OpenAI-compat providers that serve mainstream non-reasoning models.

The constructor accepts `reasoning_effort=None` to opt out, but no caller in the codebase (across all 7 `AsyncLLMClient(...)` construction sites in `providers/manager.py` and `llm/chat.py`) passes anything other than the default. There's no CLI surface to override it either, so end users on documented providers have no workaround short of patching the source.

## Fix — two layers, both inside `clearwing/llm/native.py`

### Layer 1: model-name denylist with sentinel default

A module-level pattern list (`_REASONING_EFFORT_UNSUPPORTED_PATTERNS`) lists case-insensitive substrings of model names known to reject `reasoning_effort`: `llama-3`, `llama-4`, `mistral`, `mixtral`, `qwen2`, `gemma`. An override allowlist (`_REASONING_EFFORT_OVERRIDE_ALLOW`, empty today) gives a clean escape hatch for reasoning-tuned variants of denylisted families as they ship.

The constructor signature changes from `reasoning_effort: str | None = "medium"` to `reasoning_effort: str | None | Literal["auto"] = "auto"`. The new `"auto"` sentinel dispatches to a static helper that resolves to `None` on a denylist match, `"medium"` otherwise (preserving current behavior for everything not denylisted).

**Explicit values pass through untouched**, including `None`, `"medium"`, `"high"`, etc. Any caller that *was* setting `reasoning_effort` explicitly continues to work identically. Layer 1 only affects code paths that relied on the default.

### Layer 2: retry-on-400 fallback (defense in depth)

The denylist will never be complete. To handle the long tail — model renames, new providers tightening validation, patterns we missed — both `achat` and `achat_stream` now catch `RuntimeError`, classify it via `_is_unsupported_reasoning_effort_error` (requires both `"reasoning_effort"` AND either `"400"` or `"unsupported"` in the message to match), and on a match: rebuild `ChatOptions` with `reasoning_effort=None`, mutate `self.reasoning_effort = None` for the instance lifetime, retry exactly once. Unrelated `RuntimeError`s propagate untouched.

The instance-state mutation means subsequent calls on the same client skip the param without another wasted round-trip — one 400 per (model, provider) pair per task, not per call. `AsyncLLMClient` instances are per-task (`sourcehunt/runner.py:1783 _get_llm(task, override)`), so the mutation is bounded and safe.

## Validation

| Check | Result |
|---|---|
| `ruff check` / `ruff format --check` on touched files | clean (`native.py:190` and `:615` are pre-existing format issues on `main`, left untouched — not in this PR's scope) |
| `mypy --follow-imports=silent clearwing/llm/native.py` | 9 new `call-arg` warnings, all on the new `ChatOptions(...)` reconstruction. **Identical pattern** to the 18 existing warnings on the two pre-existing `ChatOptions(...)` constructions at lines 259 and 341 — `genai_pyo3`'s stub doesn't expose its kwargs to mypy. No new *classes* of error. `clearwing/llm/` is outside `MYPY_SCOPE` per the Makefile anyway. |
| Full pytest suite vs base commit | **+26 new passing tests, 0 new failures.** Baseline: 2,466 passed, 30 failed. With this PR: 2,492 passed, 30 failed. Identical failure set (all pre-existing, unrelated). |
| End-to-end against Groq direct (`llama-3.3-70b-versatile`, `clearwing sourcehunt --depth standard` against [DVMCP](https://github.com/JohannLai/dvmcp)) | **Before this PR:** `Files Hunted: 0`, Ranker LLM call dies on first 400. **After this PR:** `Files Hunted: 20/20`, 10 findings, 5 verified, 4 CRITICAL + 1 HIGH, $0 actual spend (Groq free tier). Correctly identified DVMCP's intentional `eval()` criticals. Runtime ~16min (Groq free-tier RPM throttling; Clearwing's existing rate-limit retry handled it cleanly). |
| End-to-end against OpenRouter (`meta-llama/llama-3.3-70b-instruct`) | Also unblocked — OpenRouter's middleware was already silently stripping the param for us; this PR doesn't regress that path. |

## What this PR does NOT touch

- `clearwing/providers/manager.py`, `clearwing/llm/chat.py`, `clearwing/sourcehunt/runner.py`, `clearwing/ui/commands/sourcehunt.py` — no plumbing changes
- No config-schema changes, no CLI flag additions (we discussed adding `--reasoning-effort` to `sourcehunt`, but kept this PR scoped to the bug; happy to follow up in a separate PR if you want the explicit surface)
- The three pre-existing test-fixture issues spotted while debugging this (`FakeResponse.reasoning_content` missing in `test_deep_agent_loop.py` / `test_band_promotion.py`; `AgentTool.fn` removed but still called in `test_cve_tools.py`; `test_webcrypto_hooks::test_succeeds_with_init_script` asserting `False is True`) — separate concerns, can file as a separate issue if useful

## Files changed

- `clearwing/llm/native.py` (+151 / -13)
- `tests/test_native_reasoning_effort.py` (+319, new file, 26 tests across 6 test classes)

## Commits

Seven commits, each a coherent TDD step (red → green → commit), so the history is reviewable commit-by-commit. Squash on merge is fine if you prefer single-commit PRs.

## Backward compatibility

- No public API surface removed
- Default behavior unchanged for any model not in the denylist
- Explicit `reasoning_effort=X` calls pass through untouched (including `reasoning_effort="medium"` against a denylisted model — Layer 1 only fires when the caller didn't specify)
- No config schema changes, no new required dependencies

Happy to iterate on the denylist patterns, the sentinel naming, or the retry semantics. Thanks for considering!
