### PR TITLE
chore: bump genai-pyo3 pin to >=0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # Reporting
     "jinja2>=3.1.0",
     "reportlab>=4.0.0",
-    "genai-pyo3>=0.5.0",
+    "genai-pyo3>=0.6.0",
     "simple-term-menu>=1.6.0",
     "pydantic>=2.0.0",
     "docker>=7.0.0",


### PR DESCRIPTION
## Summary

Floor-bump `genai-pyo3` from `>=0.5.0` to `>=0.6.0`.

[genai-pyo3 0.6.0](https://pypi.org/project/genai-pyo3/0.6.0/) switches its underlying [rust-genai](https://github.com/jeremychone/rust-genai) dep from the `ropoctl/rust-genai` fork pin (which carried PR jeremychone/rust-genai#227, the openai_resp encrypted-reasoning round-trip) back to canonical upstream. That PR was merged to jeremychone/rust-genai on 2026-05-13, so the fork-only patch is now in main, and upstream has moved on through 0.6.x.

The pyo3 binding API didn't change; this is purely a refresh of what's underneath. No clearwing code changes needed.

## Test plan

- [ ] CI green (resolves `genai-pyo3>=0.6.0` from PyPI on install)
- [ ] Manual: `pip install -e . && python -c 'import genai_pyo3; print(genai_pyo3.__version__)'` prints `0.6.0` or newer