### PR TITLE
Fix Anthropic 400 on structured output: strip unsupported JSON-schema range keywords

### DIFF
--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -481,11 +481,38 @@ def _json_spec_from_model(
     description: str | None = None,
 ) -> JsonSpec:
     schema = schema_model.model_json_schema()
+    _strip_unsupported_schema_keywords(schema)
     return JsonSpec(
         name=name or _schema_name_for_model(schema_model),
         schema_json=json.dumps(schema),
         description=description,
     )
+
+
+# Anthropic's structured-output JSON-schema validator rejects numeric-range
+# keywords ("For 'integer' type, properties maximum, minimum are not
+# supported"). Pydantic emits these from Field(ge=, le=, gt=, lt=). Strip
+# them recursively so bounded-int fields (e.g. the ranker's 1..5 scores)
+# don't 400. The bounds are advisory for the model anyway; clamp post-parse
+# if strictness is required.
+_UNSUPPORTED_SCHEMA_KEYWORDS = (
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+)
+
+
+def _strip_unsupported_schema_keywords(node: Any) -> None:
+    if isinstance(node, dict):
+        for kw in _UNSUPPORTED_SCHEMA_KEYWORDS:
+            node.pop(kw, None)
+        for value in node.values():
+            _strip_unsupported_schema_keywords(value)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_unsupported_schema_keywords(item)
 
 
 def _schema_name_for_model(schema_model: type[BaseModel]) -> str:

--- a/tests/test_native_schema_compat.py
+++ b/tests/test_native_schema_compat.py
@@ -1,0 +1,47 @@
+"""Regression test: structured-output JSON schemas must not carry numeric-range
+keywords that Anthropic's validator rejects.
+
+Current Anthropic models 400 with "For 'integer' type, properties maximum,
+minimum are not supported" when a structured-output schema contains
+minimum/maximum (which Pydantic emits from Field(ge=, le=)). This killed the
+sourcehunt ranker (RankedFileScore uses 1..5 scores). Pure-logic test — no
+network, no real provider.
+"""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel, Field
+
+from clearwing.llm.native import _json_spec_from_model
+
+
+class _Scored(BaseModel):
+    path: str
+    surface: int = Field(ge=1, le=5)
+    influence: int = Field(ge=1, le=5)
+
+
+def test_json_spec_strips_numeric_range_keywords():
+    spec = _json_spec_from_model(_Scored, name="scored")
+    schema = json.loads(spec.schema_json)
+    props = schema["properties"]
+    for field in ("surface", "influence"):
+        assert "minimum" not in props[field]
+        assert "maximum" not in props[field]
+    # Non-range structure is preserved.
+    assert props["surface"]["type"] == "integer"
+    assert props["path"]["type"] == "string"
+
+
+def test_json_spec_strips_nested_and_array_bounds():
+    class Inner(BaseModel):
+        n: int = Field(ge=0, le=10)
+
+    class Outer(BaseModel):
+        items: list[Inner]
+
+    blob = _json_spec_from_model(Outer, name="outer").schema_json
+    assert "minimum" not in blob
+    assert "maximum" not in blob


### PR DESCRIPTION
Fixes #50.

## Problem

Anthropic's structured-output JSON-schema validator rejects numeric-range keywords (`minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`/`multipleOf`) on integers:

```
400 invalid_request_error: For 'integer' type, properties maximum, minimum are not supported
```

`_json_spec_from_model` serializes a Pydantic model's schema verbatim, and `RankedFileScore` uses `Field(ge=1, le=5)` for its `surface`/`influence` scores — which Pydantic emits as `{"type":"integer","minimum":1,"maximum":5}`. So the **sourcehunt ranker 400s on every call**, leaving 0 files ranked and 0 hunted against the Anthropic adapter.

## Fix

Recursively strip those unsupported keywords from the generated schema in `_json_spec_from_model` before handing it to `genai-pyo3`. The bounds are advisory for the model anyway (the ranker prompt already states the 1–5 range), and callers can clamp post-parse if strictness is wanted.

## Verification

- New unit tests in `tests/test_native_schema_compat.py` (top-level + nested/array bounds stripped, non-range structure preserved) — no network.
- `clearwing sourcehunt --depth standard` on a small planted-vuln C repo now ranks and hunts correctly (previously: "Ranker LLM call failed", 0 findings; after: both planted bugs found, one with an ASan crash reproduction).
