### PR TITLE
Express ranker 1..5 scores as Literal so Anthropic accepts the schema

### DIFF
--- a/clearwing/sourcehunt/ranker.py
+++ b/clearwing/sourcehunt/ranker.py
@@ -17,7 +17,7 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -29,12 +29,23 @@ from .state import FileTarget
 logger = logging.getLogger(__name__)
 
 
+# A 1..5 score. Expressed as a Literal (not Field(ge=1, le=5)) so the generated
+# JSON schema is `{"type": "integer", "enum": [1,2,3,4,5]}` rather than
+# minimum/maximum bounds — Anthropic's structured-output validator uses
+# constrained decoding and rejects numeric-range keywords, but supports (and
+# enforces) enums. Pydantic still validates the range on parse.
+Score = Annotated[
+    Literal[1, 2, 3, 4, 5],
+    Field(description="Integer score from 1 (lowest) to 5 (highest)."),
+]
+
+
 class RankedFileScore(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     path: str
-    surface: int = Field(ge=1, le=5)
-    influence: int = Field(ge=1, le=5)
+    surface: Score
+    influence: Score
     surface_rationale: str
     influence_rationale: str
 

--- a/tests/test_ranker_schema.py
+++ b/tests/test_ranker_schema.py
@@ -1,0 +1,55 @@
+"""The ranker's structured-output schema must be acceptable to Anthropic.
+
+Anthropic's structured-output validator uses constrained decoding and 400s with
+"For 'integer' type, properties maximum, minimum are not supported" when a
+schema carries numeric-range keywords. Pydantic emits those from
+Field(ge=, le=), so RankedFileScore's 1..5 scores must instead be expressed as
+a Literal (-> {"type": "integer", "enum": [...]}), which the validator supports
+and enforces. These are pure-logic tests — no network, no real provider.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from clearwing.llm.native import _json_spec_from_model
+from clearwing.sourcehunt.ranker import RankedFileScore
+
+_RANGE_KEYWORDS = ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf")
+
+
+def test_score_fields_serialize_as_enum_not_range() -> None:
+    # Exercise the real wire path (model -> JsonSpec), not just model_json_schema.
+    schema = json.loads(_json_spec_from_model(RankedFileScore, name="ranked").schema_json)
+    props = schema["properties"]
+    for field in ("surface", "influence"):
+        node = props[field]
+        assert node["enum"] == [1, 2, 3, 4, 5]
+        assert node["type"] == "integer"
+        assert not any(kw in node for kw in _RANGE_KEYWORDS)
+
+
+def test_no_range_keywords_anywhere_in_schema() -> None:
+    blob = _json_spec_from_model(RankedFileScore, name="ranked").schema_json
+    for kw in _RANGE_KEYWORDS:
+        assert kw not in blob
+
+
+def test_pydantic_still_enforces_the_1_to_5_range() -> None:
+    ok = RankedFileScore(
+        path="x.c", surface=5, influence=1, surface_rationale="r", influence_rationale="r"
+    )
+    assert ok.surface == 5 and ok.influence == 1
+
+    for bad in (0, 6):
+        with pytest.raises(ValidationError):
+            RankedFileScore(
+                path="x.c",
+                surface=bad,
+                influence=3,
+                surface_rationale="r",
+                influence_rationale="r",
+            )


### PR DESCRIPTION
Alternative fix for #50.

## Problem

Anthropic's structured-output validator uses constrained decoding and rejects numeric-range keywords (`minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum`/`multipleOf`) outright — `400: For 'integer' type, properties maximum, minimum are not supported`. `RankedFileScore` uses `Field(ge=1, le=5)`, which Pydantic serializes to `minimum`/`maximum`, so the sourcehunt ranker 400s on every call.

## Fix

Encode the constraint in the **type** rather than post-processing the JSON schema. A `Literal[1,2,3,4,5]` alias serializes natively to `{"type": "integer", "enum": [1,2,3,4,5]}` — which the validator *supports and enforces* via constrained decoding — and Pydantic still validates the range on parse. No schema-walking/keyword-stripping needed.

```python
Score = Annotated[Literal[1, 2, 3, 4, 5], Field(description="Integer score from 1 (lowest) to 5 (highest).")]
...
surface: Score
influence: Score
```

This is the only model in the codebase with numeric `Field` bounds, so it fully covers #50 without a generic sanitizer.

## vs #52

#52 fixes the same 400 by recursively stripping the range keywords from the generated schema. That works, but it (a) leaves the bound *advisory* — nothing stops the model emitting `7` — and (b) adds a JSON-schema post-processing pass. This approach keeps the constraint enforced (enum → constrained decoding) and is purely declarative. Supersedes #52 if we'd rather not carry the schema walker.

## Verification

- New `tests/test_ranker_schema.py`: the wire schema (via `_json_spec_from_model`) carries `enum: [1,2,3,4,5]` and no range keywords; Pydantic still rejects 0/6. No network.

Fixes #50.