### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS — required reviewers for clearwing.
+# Matched bottom-to-top; last matching pattern wins.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+# Global owners — requested for review on every PR.
+*       @ropoctl @ehartford


### PR DESCRIPTION
Adds `.github/CODEOWNERS` assigning **@ropoctl** and **@ehartford** as global code owners, so they're automatically requested for review on every PR.

Targets `master` (the canonical branch). Single global rule for now — easy to split into per-area/team ownership later if desired.