### PR TITLE
fix(sandbox): release docker client urllib3 pool in SandboxContainer.stop()

### DIFF
--- a/clearwing/sandbox/container.py
+++ b/clearwing/sandbox/container.py
@@ -395,6 +395,17 @@ class SandboxContainer:
 
         self._container = None
 
+        # Release the docker SDK's urllib3 connection pool. Without this,
+        # each SandboxContainer keeps its keep-alive unix-socket connections
+        # open for the rest of the process lifetime, leaking ~15 fd per
+        # Hunter session and eventually hitting `ulimit -n` on long scans.
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception:
+                logger.debug("Sandbox docker client close failed", exc_info=True)
+            self._client = None
+
     # --- Context manager ----------------------------------------------------
 
     def __enter__(self):


### PR DESCRIPTION
Fixes #68.

## Change

One-line behavior change in `SandboxContainer.stop()`: after the container is removed, close the docker SDK client so its urllib3 keep-alive pool (unix-socket connections to `/var/run/docker.sock`) is released.

```diff
--- a/clearwing/sandbox/container.py
+++ b/clearwing/sandbox/container.py
@@ -395,6 +395,17 @@ class SandboxContainer:

         self._container = None

+        # Release the docker SDK's urllib3 connection pool. Without this,
+        # each SandboxContainer keeps its keep-alive unix-socket connections
+        # open for the rest of the process lifetime, leaking ~15 fd per
+        # Hunter session and eventually hitting `ulimit -n` on long scans.
+        if self._client is not None:
+            try:
+                self._client.close()
+            except Exception:
+                logger.debug("Sandbox docker client close failed", exc_info=True)
+            self._client = None
+
     # --- Context manager ----------------------------------------------------
```

## Validation

Reproducer: scanning 2 files from FFmpeg's H.264 codec (`libavcodec/h264_slice.c` + `libavcodec/h264dec.h`) with `depth=standard --max-parallel 3`. `lsof -p $PID` sampled every 5 sec, type-bucketed.

**Without the fix:**

| Hunter completed | unix fd | total fd |
|---|---|---|
| 0 | 47 | 151 |
| 3 | **92** | **196** |

→ +15 unix fd per Hunter session, no decrease at session end.

**With the fix (`self._client.close()` added):**

| Hunter completed | unix fd | total fd |
|---|---|---|
| 0 | 47 | 151 |
| 1 (mid) | 48 | 151 |
| 1 (post-stop) | **41** | 145 |
| 2 | 48 | 151 |
| 3 | 47 | 151 |

→ unix fd stays in the 41–48 range across the whole run, with a clear drop right after each session ends. Cumulative leak is zero.

See #68 for the full incident report (212-file scan that hit fd exhaustion after 258 Hunter sessions, causing 65 files to terminate prematurely and all findings to be rejected by the Validator).

## Risk

- One-line addition in a `finally`-style cleanup path. The `try` swallows close errors and logs at DEBUG, so a misbehaving docker client cannot break `stop()`.
- No change to container lifecycle, exec semantics, or any caller.
