### PR TITLE
fix(cve-tools): make cve_fts content-storing so cve_search returns results

### DIFF
--- a/clearwing/agent/tools/data/cve_tools.py
+++ b/clearwing/agent/tools/data/cve_tools.py
@@ -43,7 +43,7 @@ def _create_schema(conn: sqlite3.Connection) -> None:
         CREATE INDEX IF NOT EXISTS idx_cve_date ON cve(date_published);
 
         CREATE VIRTUAL TABLE IF NOT EXISTS cve_fts USING fts5(
-            cve_id, description, affected_json, content=''
+            cve_id, description, affected_json
         );
     """)
 


### PR DESCRIPTION
Fixes #70.

## Change

One-line schema change in `_create_schema()`: drop `content=''` from the `cve_fts` declaration so the table stores its columns. The existing `JOIN cve c ON f.cve_id = c.cve_id` in `cve_search` then resolves to a non-NULL `cve_id` and returns rows.

```diff
--- a/clearwing/agent/tools/data/cve_tools.py
+++ b/clearwing/agent/tools/data/cve_tools.py
@@ -43,7 +43,7 @@ def _create_schema(conn: sqlite3.Connection) -> None:
         CREATE INDEX IF NOT EXISTS idx_cve_date ON cve(date_published);

         CREATE VIRTUAL TABLE IF NOT EXISTS cve_fts USING fts5(
-            cve_id, description, affected_json, content=''
+            cve_id, description, affected_json
         );
     """)
```

## Validation

Minimal in-memory reproducer: build a DB with the schema, insert one CVE row into both `cve` and `cve_fts`, then issue the exact `JOIN ... WHERE cve_fts MATCH` query that `cve_search` uses.

**Before the fix (current `main`, `content=''`):**

| query | rows |
|---|---|
| `SELECT c.cve_id FROM cve_fts f JOIN cve c ON f.cve_id = c.cve_id WHERE cve_fts MATCH 'openssl'` | **0** |
| `SELECT cve_id, description FROM cve_fts WHERE cve_fts MATCH 'openssl'` | 1 row, but `cve_id=None`, `description=None` |
| `SELECT cve_id FROM cve` | 1 (`CVE-2024-TEST`) |

→ FTS5 finds the match, but contentless tables return `NULL` for all retrieved columns, so the `JOIN` predicate `f.cve_id = c.cve_id` is always false → zero rows back to `cve_search`.

**After the fix (`content=''` removed):**

| query | rows |
|---|---|
| `SELECT c.cve_id FROM cve_fts f JOIN cve c ON f.cve_id = c.cve_id WHERE cve_fts MATCH 'openssl'` | **1** (`CVE-2024-TEST`) |
| `SELECT cve_id, description FROM cve_fts WHERE cve_fts MATCH 'openssl'` | 1 row, `cve_id='CVE-2024-TEST'`, `description='openssl heap overflow ...'` |

→ `cve_fts` rows now carry retrievable column values; `cve_search` returns matched CVEs as intended.

## Risk

- Schema-only change to the FTS5 virtual table; no Python/SQL caller has to change. `cve_lookup` (id direct lookup, different path) is unaffected.
- Storage cost: contentless FTS5 stores only the index, content-storing FTS5 stores both the index and a copy of the indexed columns. For the CVE corpus this is roughly +1.5x the FTS index size — small relative to the `cve` table itself.
- Existing DBs created on the old schema need to be rebuilt via `cve_db_update` (one-time; same path users already use to refresh CVE data).
