### PR TITLE
fix(llm): restore .aask compat shim on AsyncLLMClient and ChatModel

### DIFF
--- a/clearwing/llm/chat.py
+++ b/clearwing/llm/chat.py
@@ -235,6 +235,22 @@ class ChatModel:
             },
         )
 
+    async def aask(
+        self,
+        user: str,
+        system: str | None = None,
+        **_kwargs: Any,
+    ):
+        """Compat shim — three sourcehunt sites
+        (nday_filter / reveng_reconstructor / bench.crash_classifier)
+        call this positional/keyword signature. Delegates to the
+        underlying client's aask_text.
+        """
+        return await self._client.aask_text(
+            system=system or self.default_system,
+            user=user,
+        )
+
     async def ainvoke(self, messages: Any, on_text_delta: Callable[[str], None] | None = None) -> AIMessage:
         system, chat_messages = _coerce_chat_messages(messages)
         if on_text_delta is not None:

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -451,6 +451,21 @@ class AsyncLLMClient:
             response_schema_description=response_schema_description,
         )
 
+    async def aask(
+        self,
+        user: str,
+        system: str | None = None,
+        **_kwargs: Any,
+    ) -> ChatResponse:
+        """Compat shim — three sourcehunt sites
+        (nday_filter / reveng_reconstructor / bench.crash_classifier)
+        call this positional/keyword signature. Delegates to aask_text.
+        """
+        return await self.aask_text(
+            system=system or self.default_system,
+            user=user,
+        )
+
     async def aask_json(
         self,
         *,


### PR DESCRIPTION
Fixes #72.

## Change

Add a `.aask(user, system=None)` compat shim on both `AsyncLLMClient` and `ChatModel` that delegates to `aask_text(system=, user=)`. The three sourcehunt sites that call this signature (`nday_filter.py:154`, `reveng_reconstructor.py:128`, `crash_classifier.py:175`) immediately work; any caller already using `aask_text`/`aask_json` is unaffected.

```diff
--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -451,6 +451,21 @@ class AsyncLLMClient:
             response_schema_description=response_schema_description,
         )

+    async def aask(
+        self,
+        user: str,
+        system: str | None = None,
+        **_kwargs: Any,
+    ) -> ChatResponse:
+        """Compat shim — three sourcehunt sites
+        (nday_filter / reveng_reconstructor / bench.crash_classifier)
+        call this positional/keyword signature. Delegates to aask_text.
+        """
+        return await self.aask_text(
+            system=system or self.default_system,
+            user=user,
+        )
+
     async def aask_json(

--- a/clearwing/llm/chat.py
+++ b/clearwing/llm/chat.py
@@ -235,6 +235,22 @@ class ChatModel:
             },
         )

+    async def aask(
+        self,
+        user: str,
+        system: str | None = None,
+        **_kwargs: Any,
+    ):
+        """Compat shim — three sourcehunt sites
+        (nday_filter / reveng_reconstructor / bench.crash_classifier)
+        call this positional/keyword signature. Delegates to the
+        underlying client's aask_text.
+        """
+        return await self._client.aask_text(
+            system=system or self.default_system,
+            user=user,
+        )
+
     async def ainvoke(self, messages: Any, on_text_delta: Callable[[str], None] | None = None) -> AIMessage:
```

## Validation

**Static check** (the three callers' invocation signature against the shim):

```
nday_filter.py:154           → await self._llm.aask(user_msg, system=FILTER_SYSTEM_PROMPT, ...)
reveng_reconstructor.py:128  → await self._llm.aask(user_msg, system=RECONSTRUCTION_SYSTEM_PROMPT, ...)
crash_classifier.py:175      → await self._llm.aask(user_msg, system=CLASSIFIER_SYSTEM_PROMPT, ...)
```

All three pass `user` as the first positional arg and `system` as a keyword — exactly what the new `aask(user, system=None, **_kwargs)` shim accepts. Each caller then reads `response.first_text`, which both `aask_text` and `aask` (delegate) already return on the resulting `ChatResponse`.

**Symbol check** (the shim is actually on the classes, AST inspection):

```
AsyncLLMClient.aask exists: True   (sibling of aask_text / aask_json)
ChatModel.aask exists:      True   (sibling of invoke / ainvoke)
```

**Live trace of the bug** (before this patch):

The three `except Exception` branches silently catch the `AttributeError` and degrade to the seeded defaults:

- `nday_filter.py:166-169` → `for c in batch: c.exploitability = "POSSIBLY_EXPLOITABLE"`
- `reveng_reconstructor.py:133-135` → `return self._fallback_reconstruction(batch)`
- `crash_classifier.py:160-162` → `return classification` (tier untouched)

Unit tests miss the bug because they inject `AsyncMock`, which auto-vivifies `.aask` to return a coroutine-like — there is no signal in the test suite that the production path raises.

## Risk

- Two ~7-line additive methods. No existing call site is touched.
- Default-system resolution mirrors `aask_text` (`system or self.default_system`).
- Signature accepts `**_kwargs` so a caller passing extra keywords (e.g. `temperature=`) is forwarded gracefully (currently ignored — same as `aask_text` ignoring temperature when called without it). Can be tightened in a follow-up if upstream prefers an explicit signature.
- An alternative fix is to migrate the 3 callers to `aask_text(system=, user=)` directly — same outcome, slightly more churn (3 files touched instead of 2), and leaves no `.aask` API for any future caller that uses the same pattern.
