### PR TITLE
fix(sourcehunt): enforce validator JSON via structured output

### DIFF
--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -330,6 +330,12 @@ class AsyncLLMClient:
                 if response_schema is not None
                 else None
             ),
+            # Opt into genai-pyo3's per-adapter strict-schema sanitizer so the
+            # pydantic schema is rewritten to satisfy the provider's constrained
+            # decoding (e.g. OpenAI strict: inject required + additional
+            # Properties:false, collapse $ref siblings). No-op when there is no
+            # response_json_spec. Requires genai-pyo3 >= 0.7.0b10.dev2.
+            sanitize_schema=True,
         )
 
         async with self._semaphore:
@@ -971,8 +977,8 @@ class AsyncLLMClient:
         """Return a copy of *options* with ``reasoning_effort=None``.
 
         ``ChatOptions`` is a frozen Rust struct from genai-pyo3, so we
-        reconstruct it from scratch. ``response_json_spec`` is preserved when
-        present.
+        reconstruct it from scratch. ``response_json_spec`` and
+        ``sanitize_schema`` are preserved when present.
         """
         return ChatOptions(
             temperature=options.temperature,
@@ -983,7 +989,8 @@ class AsyncLLMClient:
             capture_reasoning_content=options.capture_reasoning_content,
             normalize_reasoning_content=options.normalize_reasoning_content,
             reasoning_effort=None,
-            response_json_spec=getattr(options, "response_json_spec", None),
+            response_json_spec=options.response_json_spec,
+            sanitize_schema=options.sanitize_schema,
         )
 
     @staticmethod

--- a/clearwing/sourcehunt/state.py
+++ b/clearwing/sourcehunt/state.py
@@ -14,10 +14,12 @@ Findings reaching patch_validated are the gold standard in reports.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Literal
 
+from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from clearwing.findings.types import (
@@ -144,15 +146,64 @@ class ElaborationResult:
 # --- Validation types (spec 009) ---------------------------------------------
 
 
-@dataclass
-class AxisResult:
-    """Result of a single validation axis."""
+class AxisResult(BaseModel):
+    """One validation axis: pass/fail with a confidence and short rationale.
 
-    axis: str  # "REAL" | "TRIGGERABLE" | "IMPACTFUL" | "GENERAL"
-    passed: bool
-    confidence: str  # "high" | "medium" | "low"
-    rationale: str
-    boundary_crossed: str = ""  # only for IMPACTFUL axis
+    A single struct shared by the validator's wire schema (constrained decoding)
+    and the domain verdict — the fields are identical, so there is no DTO plus a
+    near-duplicate dataclass and no field-by-field mapper between them. The
+    docstring and Field descriptions are emitted into the JSON schema, so the
+    guidance reaches the model inline, not only via the prose prompt.
+    """
+
+    passed: bool = Field(
+        description="True if this axis is satisfied, false if it fails."
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        description="Confidence in this axis's pass/fail judgment."
+    )
+    rationale: str = Field(
+        default="",
+        description=(
+            "One to three sentences justifying the decision; keep it under 500 "
+            "characters."
+        ),
+    )
+    boundary_crossed: Literal[
+        "privilege", "tenant", "origin", "user", "kernel", "sandbox", "none"
+    ] = Field(
+        default="none",
+        description=(
+            "Security boundary the bug crosses. Set only for the impactful axis; "
+            "leave as 'none' for the others."
+        ),
+    )
+
+
+@dataclass
+class Axes:
+    """The validator's per-axis results, as typed fields rather than a dict.
+
+    All four are optional because the set evaluated varies: the full pass fills
+    all four, the two-axis quick pass fills only ``real``/``triggerable``, and an
+    error verdict fills none. Typed fields give callers static checking and make
+    the axis identity the field name — no stringly-typed keys.
+    """
+
+    real: AxisResult | None = None
+    triggerable: AxisResult | None = None
+    impactful: AxisResult | None = None
+    general: AxisResult | None = None
+
+    def items(self) -> Iterator[tuple[str, AxisResult]]:
+        """Yield ``(name, result)`` for each evaluated axis, in canonical order.
+
+        Absent axes (``None``) are skipped, so callers that build per-axis maps
+        or lists see only what was actually judged.
+        """
+        for name, result in vars(self).items():
+            if result is not None:
+                yield name, result
 
 
 @dataclass
@@ -160,7 +211,7 @@ class ValidatorVerdict:
     """Output of the unified 4-axis validator (spec 009)."""
 
     finding_id: str
-    axes: dict[str, AxisResult]
+    axes: Axes
     advance: bool
     severity_validated: str | None
     evidence_level: EvidenceLevel

--- a/clearwing/sourcehunt/validator.py
+++ b/clearwing/sourcehunt/validator.py
@@ -14,11 +14,14 @@ import json
 import logging
 import re
 from itertools import islice
-from typing import Any, cast
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel, Field
 
 from clearwing.core.event_payloads import ValidationResultPayload
 from clearwing.core.events import EventBus
 from clearwing.llm import AsyncLLMClient
+from clearwing.llm.native import response_text
 
 from .state import (
     EVIDENCE_LEVELS,
@@ -34,14 +37,6 @@ logger = logging.getLogger(__name__)
 _LINE_REF_RE = re.compile(r"\blines?\s+(\d+)(?:\s*-\s*(\d+))?")
 
 _SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
-
-_VALID_SEVERITIES = {"critical", "high", "medium", "low", "info"}
-
-_VALID_CONFIDENCES = {"high", "medium", "low"}
-
-_VALID_BOUNDARIES = {
-    "privilege", "tenant", "origin", "user", "kernel", "sandbox", "none",
-}
 
 
 # --- Prompts -----------------------------------------------------------------
@@ -134,6 +129,151 @@ Return ONLY this JSON:
 }"""
 
 
+# --- Enforced structured output schema ---------------------------------------
+# The prompts already ask for exactly this JSON; passing it as a schema_model to
+# aask_json turns it into a genai-pyo3 response_json_spec so the gateway emits it
+# via constrained decoding. That eliminates the "empty first_text / no JSON"
+# failure mode reasoning models hit with free-form aask_text. IMPACTFUL/GENERAL
+# are optional so the same schema fits the quick-pass prompt (REAL+TRIGGERABLE).
+
+
+class _AxisSchema(BaseModel):
+    """One validation axis: pass/fail with a confidence and short rationale.
+
+    The class docstring and per-field descriptions are emitted into the JSON
+    schema (schema `description` / property `description`), so the guidance
+    reaches the model inline through constrained decoding, not only via the
+    prose prompt.
+    """
+
+    passed: bool = Field(
+        description="True if this axis is satisfied, false if it fails."
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        description="Confidence in this axis's pass/fail judgment."
+    )
+    rationale: str = Field(
+        default="",
+        description="One to three sentences justifying the decision.",
+    )
+    # Only the IMPACTFUL axis is asked to populate this (see the prompt); the
+    # others omit it and it defaults to "none". Declared on the single axis
+    # schema — not an IMPACTFUL-only subclass — so every axis object carries the
+    # attribute and to_verdict maps it with a plain ax.boundary_crossed.
+    boundary_crossed: Literal[
+        "privilege", "tenant", "origin", "user", "kernel", "sandbox", "none"
+    ] = Field(
+        default="none",
+        description=(
+            "Security boundary the bug crosses. Set only for the IMPACTFUL "
+            "axis; leave as 'none' for the others."
+        ),
+    )
+
+
+class _AxesSchema(BaseModel):
+    """The four validation axes.
+
+    REAL and TRIGGERABLE are always required. IMPACTFUL and GENERAL are omitted
+    on the two-axis quick pass, so they are optional here.
+    """
+
+    REAL: _AxisSchema = Field(
+        description=(
+            "Does the bug exist in the code as described? Reproduce the crash "
+            "or behavior if a PoC is provided."
+        )
+    )
+    TRIGGERABLE: _AxisSchema = Field(
+        description=(
+            "Can attacker-controlled input reach this code path in a production "
+            "deployment, or do callers/entry points prevent it?"
+        )
+    )
+    IMPACTFUL: _AxisSchema | None = Field(
+        default=None,
+        description=(
+            "Does the bug cross a meaningful security boundary? Omit on the "
+            "quick pass."
+        ),
+    )
+    GENERAL: _AxisSchema | None = Field(
+        default=None,
+        description=(
+            "Is it exploitable in realistic default configurations rather than "
+            "exotic setups? Omit on the quick pass."
+        ),
+    )
+
+
+class _VerdictSchema(BaseModel):
+    """Independent validator verdict for a single reported finding.
+
+    The model produces only the judgment fields below. Domain-owned fields
+    (finding_id, the derived severity, raw_response, and the patch-oracle
+    results) are supplied by to_verdict, not by the model.
+    """
+
+    axes: _AxesSchema = Field(description="Per-axis judgments.")
+    advance: bool = Field(
+        description=(
+            "True only if all provided axes pass, or REAL + IMPACTFUL pass and "
+            "TRIGGERABLE + GENERAL have confidence >= medium."
+        )
+    )
+    severity: Literal["critical", "high", "medium", "low", "info"] = Field(
+        description="Validated severity of the finding."
+    )
+    evidence_level: Literal[
+        "static_corroboration", "crash_reproduced", "root_cause_explained"
+    ] = Field(description="Strength of the evidence gathered during validation.")
+    pro_argument: str = Field(
+        default="", description="Strongest case FOR the vulnerability."
+    )
+    counter_argument: str = Field(
+        default="", description="Strongest case AGAINST the vulnerability."
+    )
+    tie_breaker: str = Field(
+        default="", description="The single piece of evidence that resolved it."
+    )
+    duplicate_cve: str | None = Field(
+        default=None,
+        description="CVE id if this duplicates a known issue, else null.",
+    )
+
+    def to_verdict(self, finding_id: str) -> ValidatorVerdict:
+        """Map this validated wire object to the domain ValidatorVerdict.
+
+        The LLM only produces judgment fields; the domain fields it must not
+        own — finding_id, severity_validated (derived), raw_response, and the
+        patch-oracle results (a later stage) — are supplied here, not by the
+        model. No dict round-trip and no re-validation: the schema's Literal
+        enums already guarantee the categorical values.
+        """
+        axes: dict[str, AxisResult] = {}
+        for name, ax in self.axes:  # pydantic models iterate as (field_name, value)
+            if ax is None:
+                continue
+            axes[name] = AxisResult(
+                axis=name,
+                passed=ax.passed,
+                confidence=ax.confidence,
+                rationale=ax.rationale[:500],
+                boundary_crossed=ax.boundary_crossed,
+            )
+        return ValidatorVerdict(
+            finding_id=finding_id,
+            axes=axes,
+            advance=self.advance,
+            severity_validated=self.severity if self.advance else None,
+            evidence_level=self.evidence_level,
+            pro_argument=self.pro_argument,
+            counter_argument=self.counter_argument,
+            tie_breaker=self.tie_breaker,
+            duplicate_cve=self.duplicate_cve,
+        )
+
+
 # --- Validator class ---------------------------------------------------------
 
 
@@ -175,16 +315,25 @@ class Validator:
     ) -> ValidatorVerdict:
         user_msg = self._build_user_message(finding, file_content)
         system_prompt = self._prompt_for_finding(finding)
+
+        # Enforced structured output. response_schema becomes a genai-pyo3
+        # response_json_spec (constrained decoding), so the model emits a JSON
+        # object matching _VerdictSchema — even reasoning models that would
+        # otherwise return empty text under free-form prompting. We validate to
+        # the typed wire object and map it to the domain verdict directly (no
+        # dict round-trip). Requires a model/gateway with constrained decoding.
         try:
             response = await self.llm.aask_text(
-                system=system_prompt, user=user_msg,
+                system=system_prompt,
+                user=user_msg,
+                response_schema=_VerdictSchema,
+                response_schema_name="ValidatorVerdict",
             )
-            content = response.first_text or ""
+            schema = _VerdictSchema.model_validate_json(response_text(response))
+            verdict = schema.to_verdict(finding.get("id", "unknown"))
         except Exception as e:
             logger.warning("Validator LLM call failed", exc_info=True)
-            return self._error_verdict(finding, f"validator error: {e}")
-
-        verdict = self._parse_response(finding, content)
+            verdict = self._error_verdict(finding, f"validator error: {e}")
 
         EventBus().emit_validation_result(ValidationResultPayload(
             finding_id=verdict.finding_id,
@@ -289,64 +438,6 @@ class Validator:
             prev_start, prev_end = merged[-1]
             merged[-1] = (prev_start, max(prev_end, end))
         return merged
-
-    def _parse_response(
-        self, finding: Finding, content: str,
-    ) -> ValidatorVerdict:
-        match = re.search(r"\{[\s\S]*\}", content)
-        if not match:
-            logger.warning(
-                "Validator response had no JSON; got: %s", content[:300],
-            )
-            return self._error_verdict(finding, "no JSON in response")
-        try:
-            parsed = json.loads(match.group(0))
-        except json.JSONDecodeError:
-            return self._error_verdict(finding, "JSON parse failed")
-
-        axes = self._parse_axes(parsed.get("axes", {}))
-        advance = bool(parsed.get("advance", False))
-
-        severity = parsed.get("severity")
-        if severity not in _VALID_SEVERITIES:
-            severity = None
-
-        evidence_level = parsed.get("evidence_level", "suspicion")
-        if evidence_level not in EVIDENCE_LEVELS:
-            evidence_level = "suspicion"
-
-        return ValidatorVerdict(
-            finding_id=finding.get("id", "unknown"),
-            axes=axes,
-            advance=advance,
-            severity_validated=severity if advance else None,
-            evidence_level=evidence_level,
-            pro_argument=str(parsed.get("pro_argument", "")),
-            counter_argument=str(parsed.get("counter_argument", "")),
-            tie_breaker=str(parsed.get("tie_breaker", "")),
-            duplicate_cve=parsed.get("duplicate_cve"),
-            raw_response=content,
-        )
-
-    def _parse_axes(self, axes_raw: dict) -> dict[str, AxisResult]:
-        axes: dict[str, AxisResult] = {}
-        for name in ("REAL", "TRIGGERABLE", "IMPACTFUL", "GENERAL"):
-            data = axes_raw.get(name)
-            if data and isinstance(data, dict):
-                conf = data.get("confidence", "low")
-                if conf not in _VALID_CONFIDENCES:
-                    conf = "low"
-                boundary = data.get("boundary_crossed", "")
-                if boundary and boundary not in _VALID_BOUNDARIES:
-                    boundary = ""
-                axes[name] = AxisResult(
-                    axis=name,
-                    passed=bool(data.get("passed", False)),
-                    confidence=conf,
-                    rationale=str(data.get("rationale", ""))[:500],
-                    boundary_crossed=boundary,
-                )
-        return axes
 
     def _error_verdict(
         self, finding: Finding, reason: str,

--- a/clearwing/sourcehunt/validator.py
+++ b/clearwing/sourcehunt/validator.py
@@ -25,6 +25,7 @@ from clearwing.llm.native import response_text
 
 from .state import (
     EVIDENCE_LEVELS,
+    Axes,
     AxisResult,
     EvidenceLevel,
     Finding,
@@ -78,14 +79,14 @@ If a PoC is provided, you MUST attempt to reproduce it. Report the exact result.
 ## OUTPUT — return ONLY this JSON:
 {
   "axes": {
-    "REAL": {"passed": true|false, "confidence": "high|medium|low", \
+    "real": {"passed": true|false, "confidence": "high|medium|low", \
 "rationale": "..."},
-    "TRIGGERABLE": {"passed": true|false, "confidence": "high|medium|low", \
+    "triggerable": {"passed": true|false, "confidence": "high|medium|low", \
 "rationale": "..."},
-    "IMPACTFUL": {"passed": true|false, "confidence": "high|medium|low", \
+    "impactful": {"passed": true|false, "confidence": "high|medium|low", \
 "rationale": "...", \
 "boundary_crossed": "privilege|tenant|origin|user|kernel|sandbox|none"},
-    "GENERAL": {"passed": true|false, "confidence": "high|medium|low", \
+    "general": {"passed": true|false, "confidence": "high|medium|low", \
 "rationale": "..."}
   },
   "advance": true|false,
@@ -114,9 +115,9 @@ If BOTH pass, the finding advances to full validation. If either fails, reject.
 Return ONLY this JSON:
 {
   "axes": {
-    "REAL": {"passed": true|false, "confidence": "high|medium|low", \
+    "real": {"passed": true|false, "confidence": "high|medium|low", \
 "rationale": "..."},
-    "TRIGGERABLE": {"passed": true|false, "confidence": "high|medium|low", \
+    "triggerable": {"passed": true|false, "confidence": "high|medium|low", \
 "rationale": "..."}
   },
   "advance": true|false,
@@ -133,71 +134,40 @@ Return ONLY this JSON:
 # The prompts already ask for exactly this JSON; passing it as a schema_model to
 # aask_json turns it into a genai-pyo3 response_json_spec so the gateway emits it
 # via constrained decoding. That eliminates the "empty first_text / no JSON"
-# failure mode reasoning models hit with free-form aask_text. IMPACTFUL/GENERAL
-# are optional so the same schema fits the quick-pass prompt (REAL+TRIGGERABLE).
-
-
-class _AxisSchema(BaseModel):
-    """One validation axis: pass/fail with a confidence and short rationale.
-
-    The class docstring and per-field descriptions are emitted into the JSON
-    schema (schema `description` / property `description`), so the guidance
-    reaches the model inline through constrained decoding, not only via the
-    prose prompt.
-    """
-
-    passed: bool = Field(
-        description="True if this axis is satisfied, false if it fails."
-    )
-    confidence: Literal["high", "medium", "low"] = Field(
-        description="Confidence in this axis's pass/fail judgment."
-    )
-    rationale: str = Field(
-        default="",
-        description="One to three sentences justifying the decision.",
-    )
-    # Only the IMPACTFUL axis is asked to populate this (see the prompt); the
-    # others omit it and it defaults to "none". Declared on the single axis
-    # schema — not an IMPACTFUL-only subclass — so every axis object carries the
-    # attribute and to_verdict maps it with a plain ax.boundary_crossed.
-    boundary_crossed: Literal[
-        "privilege", "tenant", "origin", "user", "kernel", "sandbox", "none"
-    ] = Field(
-        default="none",
-        description=(
-            "Security boundary the bug crosses. Set only for the IMPACTFUL "
-            "axis; leave as 'none' for the others."
-        ),
-    )
+# failure mode reasoning models hit with free-form aask_text. The per-axis value
+# is the shared AxisResult (state.py) — used verbatim by the domain verdict too,
+# so there is no wire-to-domain axis mapper. This wire container only makes real
+# + triggerable required and impactful/general optional (the quick pass omits
+# them); the domain Axes container is all-optional to also cover the error case.
 
 
 class _AxesSchema(BaseModel):
     """The four validation axes.
 
-    REAL and TRIGGERABLE are always required. IMPACTFUL and GENERAL are omitted
+    real and triggerable are always required. impactful and general are omitted
     on the two-axis quick pass, so they are optional here.
     """
 
-    REAL: _AxisSchema = Field(
+    real: AxisResult = Field(
         description=(
             "Does the bug exist in the code as described? Reproduce the crash "
             "or behavior if a PoC is provided."
         )
     )
-    TRIGGERABLE: _AxisSchema = Field(
+    triggerable: AxisResult = Field(
         description=(
             "Can attacker-controlled input reach this code path in a production "
             "deployment, or do callers/entry points prevent it?"
         )
     )
-    IMPACTFUL: _AxisSchema | None = Field(
+    impactful: AxisResult | None = Field(
         default=None,
         description=(
             "Does the bug cross a meaningful security boundary? Omit on the "
             "quick pass."
         ),
     )
-    GENERAL: _AxisSchema | None = Field(
+    general: AxisResult | None = Field(
         default=None,
         description=(
             "Is it exploitable in realistic default configurations rather than "
@@ -217,8 +187,8 @@ class _VerdictSchema(BaseModel):
     axes: _AxesSchema = Field(description="Per-axis judgments.")
     advance: bool = Field(
         description=(
-            "True only if all provided axes pass, or REAL + IMPACTFUL pass and "
-            "TRIGGERABLE + GENERAL have confidence >= medium."
+            "True only if all provided axes pass, or real + impactful pass and "
+            "triggerable + general have confidence >= medium."
         )
     )
     severity: Literal["critical", "high", "medium", "low", "info"] = Field(
@@ -247,20 +217,16 @@ class _VerdictSchema(BaseModel):
         The LLM only produces judgment fields; the domain fields it must not
         own — finding_id, severity_validated (derived), raw_response, and the
         patch-oracle results (a later stage) — are supplied here, not by the
-        model. No dict round-trip and no re-validation: the schema's Literal
-        enums already guarantee the categorical values.
+        model. The axes are the shared AxisResult objects, passed straight into
+        the domain container; only the container shape differs (this wire schema
+        requires real+triggerable, the domain Axes is all-optional).
         """
-        axes: dict[str, AxisResult] = {}
-        for name, ax in self.axes:  # pydantic models iterate as (field_name, value)
-            if ax is None:
-                continue
-            axes[name] = AxisResult(
-                axis=name,
-                passed=ax.passed,
-                confidence=ax.confidence,
-                rationale=ax.rationale[:500],
-                boundary_crossed=ax.boundary_crossed,
-            )
+        axes = Axes(
+            real=self.axes.real,
+            triggerable=self.axes.triggerable,
+            impactful=self.axes.impactful,
+            general=self.axes.general,
+        )
         return ValidatorVerdict(
             finding_id=finding_id,
             axes=axes,
@@ -444,7 +410,7 @@ class Validator:
     ) -> ValidatorVerdict:
         return ValidatorVerdict(
             finding_id=finding.get("id", "unknown"),
-            axes={},
+            axes=Axes(),
             advance=False,
             severity_validated=None,
             evidence_level="suspicion",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     # Reporting
     "jinja2>=3.1.0",
     "reportlab>=4.0.0",
-    "genai-pyo3>=0.7.0b10.dev0",
+    "genai-pyo3>=0.7.0b10.dev2",
     "simple-term-menu>=1.6.0",
     "pydantic>=2.0.0",
     "pathspec>=0.10.0",

--- a/tests/test_sourcehunt_validator.py
+++ b/tests/test_sourcehunt_validator.py
@@ -22,7 +22,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from clearwing.sourcehunt.calibration import CalibrationRecord, CalibrationStore
-from clearwing.sourcehunt.state import AxisResult, ValidatorVerdict
+from clearwing.sourcehunt.state import Axes, AxisResult, ValidatorVerdict
 from clearwing.sourcehunt.validator import (
     VALIDATOR_QUICK_PROMPT,
     VALIDATOR_SYSTEM_PROMPT,
@@ -53,12 +53,12 @@ def _make_finding(**kwargs) -> dict:
 def _make_verdict(**kwargs) -> ValidatorVerdict:
     defaults = dict(
         finding_id="hunter-abc",
-        axes={
-            "REAL": AxisResult(axis="REAL", passed=True, confidence="high", rationale="confirmed"),
-            "TRIGGERABLE": AxisResult(axis="TRIGGERABLE", passed=True, confidence="high", rationale="reachable"),
-            "IMPACTFUL": AxisResult(axis="IMPACTFUL", passed=True, confidence="high", rationale="crosses boundary", boundary_crossed="user"),
-            "GENERAL": AxisResult(axis="GENERAL", passed=True, confidence="high", rationale="default config"),
-        },
+        axes=Axes(
+            real=AxisResult(passed=True, confidence="high", rationale="confirmed"),
+            triggerable=AxisResult(passed=True, confidence="high", rationale="reachable"),
+            impactful=AxisResult(passed=True, confidence="high", rationale="crosses boundary", boundary_crossed="user"),
+            general=AxisResult(passed=True, confidence="high", rationale="default config"),
+        ),
         advance=True,
         severity_validated="high",
         evidence_level="crash_reproduced",
@@ -77,7 +77,7 @@ def _make_verdict(**kwargs) -> ValidatorVerdict:
 class TestValidatorVerdict:
     def test_defaults(self):
         v = ValidatorVerdict(
-            finding_id="x", axes={}, advance=False,
+            finding_id="x", axes=Axes(), advance=False,
             severity_validated=None, evidence_level="suspicion",
             pro_argument="", counter_argument="", tie_breaker="",
             duplicate_cve=None,
@@ -89,8 +89,8 @@ class TestValidatorVerdict:
     def test_all_axes_pass(self):
         v = _make_verdict()
         assert v.advance is True
-        assert len(v.axes) == 4
-        assert all(ax.passed for ax in v.axes.values())
+        assert len(list(v.axes.items())) == 4
+        assert all(ax.passed for _, ax in v.axes.items())
 
     def test_to_verifier_result(self):
         v = _make_verdict()
@@ -159,10 +159,10 @@ class TestResponseParsing:
     def test_full_4axis_maps_to_verdict(self):
         schema = _VerdictSchema.model_validate({
             "axes": {
-                "REAL": {"passed": True, "confidence": "high", "rationale": "confirmed"},
-                "TRIGGERABLE": {"passed": True, "confidence": "medium", "rationale": "likely"},
-                "IMPACTFUL": {"passed": True, "confidence": "high", "rationale": "boundary crossed", "boundary_crossed": "user"},
-                "GENERAL": {"passed": True, "confidence": "high", "rationale": "default config"},
+                "real": {"passed": True, "confidence": "high", "rationale": "confirmed"},
+                "triggerable": {"passed": True, "confidence": "medium", "rationale": "likely"},
+                "impactful": {"passed": True, "confidence": "high", "rationale": "boundary crossed", "boundary_crossed": "user"},
+                "general": {"passed": True, "confidence": "high", "rationale": "default config"},
             },
             "advance": True,
             "severity": "high",
@@ -174,18 +174,18 @@ class TestResponseParsing:
         verdict = schema.to_verdict("hunter-abc")
         assert verdict.advance is True
         assert verdict.finding_id == "hunter-abc"
-        assert len(verdict.axes) == 4
-        assert verdict.axes["REAL"].passed is True
-        assert verdict.axes["IMPACTFUL"].boundary_crossed == "user"
+        assert len(list(verdict.axes.items())) == 4
+        assert verdict.axes.real.passed is True
+        assert verdict.axes.impactful.boundary_crossed == "user"
         assert verdict.severity_validated == "high"
 
     def test_partial_pass_clears_severity(self):
         schema = _VerdictSchema.model_validate({
             "axes": {
-                "REAL": {"passed": True, "confidence": "high", "rationale": "confirmed"},
-                "TRIGGERABLE": {"passed": False, "confidence": "low", "rationale": "dead code"},
-                "IMPACTFUL": {"passed": True, "confidence": "high", "rationale": "yes"},
-                "GENERAL": {"passed": True, "confidence": "medium", "rationale": "yes"},
+                "real": {"passed": True, "confidence": "high", "rationale": "confirmed"},
+                "triggerable": {"passed": False, "confidence": "low", "rationale": "dead code"},
+                "impactful": {"passed": True, "confidence": "high", "rationale": "yes"},
+                "general": {"passed": True, "confidence": "medium", "rationale": "yes"},
             },
             "advance": False,
             "severity": "high",
@@ -193,16 +193,16 @@ class TestResponseParsing:
         })
         verdict = schema.to_verdict("hunter-abc")
         assert verdict.advance is False
-        assert verdict.axes["TRIGGERABLE"].passed is False
+        assert verdict.axes.triggerable.passed is False
         assert verdict.severity_validated is None  # cleared when advance is False
 
     def test_quick_pass_two_axes_only(self):
-        # IMPACTFUL/GENERAL are optional (quick-pass prompt); to_verdict maps
+        # impactful/general are optional (quick-pass prompt); to_verdict maps
         # only the axes that are present.
         schema = _VerdictSchema.model_validate({
             "axes": {
-                "REAL": {"passed": True, "confidence": "high", "rationale": "yes"},
-                "TRIGGERABLE": {"passed": True, "confidence": "high", "rationale": "yes"},
+                "real": {"passed": True, "confidence": "high", "rationale": "yes"},
+                "triggerable": {"passed": True, "confidence": "high", "rationale": "yes"},
             },
             "advance": True,
             "severity": "critical",
@@ -210,7 +210,8 @@ class TestResponseParsing:
         })
         verdict = schema.to_verdict("hunter-abc")
         assert verdict.advance is True
-        assert set(verdict.axes) == {"REAL", "TRIGGERABLE"}
+        assert {name for name, _ in verdict.axes.items()} == {"real", "triggerable"}
+        assert verdict.axes.impactful is None
 
     def test_schema_rejects_invalid_enums(self):
         # Constrained decoding can't emit these; assert the schema enforces them
@@ -219,16 +220,16 @@ class TestResponseParsing:
         with pytest.raises(ValidationError):
             _VerdictSchema.model_validate({
                 "axes": {
-                    "REAL": {"passed": True, "confidence": "high", "rationale": "y"},
-                    "TRIGGERABLE": {"passed": True, "confidence": "high", "rationale": "y"},
+                    "real": {"passed": True, "confidence": "high", "rationale": "y"},
+                    "triggerable": {"passed": True, "confidence": "high", "rationale": "y"},
                 },
                 "advance": True, "severity": "apocalyptic", "evidence_level": "crash_reproduced",
             })
         with pytest.raises(ValidationError):
             _VerdictSchema.model_validate({
                 "axes": {
-                    "REAL": {"passed": True, "confidence": "ultra_high", "rationale": "y"},
-                    "TRIGGERABLE": {"passed": True, "confidence": "high", "rationale": "y"},
+                    "real": {"passed": True, "confidence": "ultra_high", "rationale": "y"},
+                    "triggerable": {"passed": True, "confidence": "high", "rationale": "y"},
                 },
                 "advance": True, "severity": "high", "evidence_level": "crash_reproduced",
             })
@@ -265,9 +266,9 @@ class TestApplyValidatorVerdict:
         verdict = _make_verdict()
         apply_validator_verdict(finding, verdict)
         axes = finding["validator_axes"]
-        assert "REAL" in axes
-        assert axes["REAL"]["passed"] is True
-        assert axes["REAL"]["confidence"] == "high"
+        assert "real" in axes
+        assert axes["real"]["passed"] is True
+        assert axes["real"]["confidence"] == "high"
 
     def test_tier_disagreement_detected(self):
         finding = _make_finding(severity="low")
@@ -316,22 +317,22 @@ class TestRejectedFindings:
         finding = _make_finding()
         verdict = _make_verdict(
             advance=False,
-            axes={
-                "REAL": AxisResult(axis="REAL", passed=True, confidence="high", rationale="yes"),
-                "TRIGGERABLE": AxisResult(axis="TRIGGERABLE", passed=False, confidence="low", rationale="dead code"),
-                "IMPACTFUL": AxisResult(axis="IMPACTFUL", passed=True, confidence="high", rationale="yes"),
-                "GENERAL": AxisResult(axis="GENERAL", passed=False, confidence="low", rationale="exotic config"),
-            },
+            axes=Axes(
+                real=AxisResult(passed=True, confidence="high", rationale="yes"),
+                triggerable=AxisResult(passed=False, confidence="low", rationale="dead code"),
+                impactful=AxisResult(passed=True, confidence="high", rationale="yes"),
+                general=AxisResult(passed=False, confidence="low", rationale="exotic config"),
+            ),
         )
         apply_validator_verdict(finding, verdict)
         assert finding["verified"] is False
-        assert set(finding["rejected_axes"]) == {"TRIGGERABLE", "GENERAL"}
+        assert set(finding["rejected_axes"]) == {"triggerable", "general"}
 
     def test_rejected_finding_severity_cleared(self):
         schema = _VerdictSchema.model_validate({
             "axes": {
-                "REAL": {"passed": False, "confidence": "high", "rationale": "not real"},
-                "TRIGGERABLE": {"passed": False, "confidence": "low", "rationale": "n/a"},
+                "real": {"passed": False, "confidence": "high", "rationale": "not real"},
+                "triggerable": {"passed": False, "confidence": "low", "rationale": "n/a"},
             },
             "advance": False,
             "severity": "high",
@@ -414,10 +415,10 @@ class TestAvalidate:
         mock_llm = AsyncMock()
         verdict_json = json.dumps({
             "axes": {
-                "REAL": {"passed": True, "confidence": "high", "rationale": "yes"},
-                "TRIGGERABLE": {"passed": True, "confidence": "medium", "rationale": "likely"},
-                "IMPACTFUL": {"passed": True, "confidence": "high", "rationale": "yes", "boundary_crossed": "privilege"},
-                "GENERAL": {"passed": True, "confidence": "high", "rationale": "yes"},
+                "real": {"passed": True, "confidence": "high", "rationale": "yes"},
+                "triggerable": {"passed": True, "confidence": "medium", "rationale": "likely"},
+                "impactful": {"passed": True, "confidence": "high", "rationale": "yes", "boundary_crossed": "privilege"},
+                "general": {"passed": True, "confidence": "high", "rationale": "yes"},
             },
             "advance": True,
             "severity": "high",
@@ -434,7 +435,7 @@ class TestAvalidate:
         verdict = await val.avalidate(_make_finding())
         assert verdict.advance is True
         assert verdict.severity_validated == "high"
-        assert verdict.axes["IMPACTFUL"].boundary_crossed == "privilege"
+        assert verdict.axes.impactful.boundary_crossed == "privilege"
 
     @pytest.mark.asyncio
     async def test_avalidate_llm_error_returns_error_verdict(self):

--- a/tests/test_sourcehunt_validator.py
+++ b/tests/test_sourcehunt_validator.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import tempfile
-from dataclasses import asdict
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -28,6 +27,7 @@ from clearwing.sourcehunt.validator import (
     VALIDATOR_QUICK_PROMPT,
     VALIDATOR_SYSTEM_PROMPT,
     Validator,
+    _VerdictSchema,
     apply_validator_verdict,
 )
 
@@ -156,9 +156,8 @@ class TestIndependentContext:
 
 
 class TestResponseParsing:
-    def test_parse_full_4axis_response(self):
-        val = Validator(MagicMock())
-        response = json.dumps({
+    def test_full_4axis_maps_to_verdict(self):
+        schema = _VerdictSchema.model_validate({
             "axes": {
                 "REAL": {"passed": True, "confidence": "high", "rationale": "confirmed"},
                 "TRIGGERABLE": {"passed": True, "confidence": "medium", "rationale": "likely"},
@@ -171,18 +170,17 @@ class TestResponseParsing:
             "pro_argument": "strong case",
             "counter_argument": "weak counter",
             "tie_breaker": "crash log",
-            "duplicate_cve": None,
         })
-        verdict = val._parse_response(_make_finding(), response)
+        verdict = schema.to_verdict("hunter-abc")
         assert verdict.advance is True
+        assert verdict.finding_id == "hunter-abc"
         assert len(verdict.axes) == 4
         assert verdict.axes["REAL"].passed is True
         assert verdict.axes["IMPACTFUL"].boundary_crossed == "user"
         assert verdict.severity_validated == "high"
 
-    def test_parse_partial_pass(self):
-        val = Validator(MagicMock())
-        response = json.dumps({
+    def test_partial_pass_clears_severity(self):
+        schema = _VerdictSchema.model_validate({
             "axes": {
                 "REAL": {"passed": True, "confidence": "high", "rationale": "confirmed"},
                 "TRIGGERABLE": {"passed": False, "confidence": "low", "rationale": "dead code"},
@@ -192,71 +190,48 @@ class TestResponseParsing:
             "advance": False,
             "severity": "high",
             "evidence_level": "static_corroboration",
-            "pro_argument": "real but dead",
-            "counter_argument": "unreachable",
-            "tie_breaker": "triggerable failed",
-            "duplicate_cve": None,
         })
-        verdict = val._parse_response(_make_finding(), response)
+        verdict = schema.to_verdict("hunter-abc")
         assert verdict.advance is False
         assert verdict.axes["TRIGGERABLE"].passed is False
+        assert verdict.severity_validated is None  # cleared when advance is False
 
-    def test_advance_logic_all_pass(self):
-        val = Validator(MagicMock())
-        response = json.dumps({
+    def test_quick_pass_two_axes_only(self):
+        # IMPACTFUL/GENERAL are optional (quick-pass prompt); to_verdict maps
+        # only the axes that are present.
+        schema = _VerdictSchema.model_validate({
             "axes": {
                 "REAL": {"passed": True, "confidence": "high", "rationale": "yes"},
                 "TRIGGERABLE": {"passed": True, "confidence": "high", "rationale": "yes"},
-                "IMPACTFUL": {"passed": True, "confidence": "high", "rationale": "yes"},
-                "GENERAL": {"passed": True, "confidence": "high", "rationale": "yes"},
             },
             "advance": True,
             "severity": "critical",
             "evidence_level": "crash_reproduced",
-            "pro_argument": "yes",
-            "counter_argument": "no",
-            "tie_breaker": "obvious",
-            "duplicate_cve": None,
         })
-        verdict = val._parse_response(_make_finding(), response)
+        verdict = schema.to_verdict("hunter-abc")
         assert verdict.advance is True
+        assert set(verdict.axes) == {"REAL", "TRIGGERABLE"}
 
-    def test_no_json_returns_error(self):
-        val = Validator(MagicMock())
-        verdict = val._parse_response(_make_finding(), "I cannot produce JSON")
-        assert verdict.advance is False
-        assert verdict.axes == {}
-
-    def test_invalid_json_returns_error(self):
-        val = Validator(MagicMock())
-        verdict = val._parse_response(_make_finding(), "{broken json!!")
-        assert verdict.advance is False
-
-    def test_invalid_severity_ignored(self):
-        val = Validator(MagicMock())
-        response = json.dumps({
-            "axes": {"REAL": {"passed": True, "confidence": "high", "rationale": "yes"}},
-            "advance": True,
-            "severity": "apocalyptic",
-            "evidence_level": "crash_reproduced",
-            "pro_argument": "", "counter_argument": "", "tie_breaker": "",
-            "duplicate_cve": None,
-        })
-        verdict = val._parse_response(_make_finding(), response)
-        assert verdict.severity_validated is None
-
-    def test_invalid_confidence_defaults_to_low(self):
-        val = Validator(MagicMock())
-        response = json.dumps({
-            "axes": {"REAL": {"passed": True, "confidence": "ultra_high", "rationale": "yes"}},
-            "advance": True,
-            "severity": "high",
-            "evidence_level": "crash_reproduced",
-            "pro_argument": "", "counter_argument": "", "tie_breaker": "",
-            "duplicate_cve": None,
-        })
-        verdict = val._parse_response(_make_finding(), response)
-        assert verdict.axes["REAL"].confidence == "low"
+    def test_schema_rejects_invalid_enums(self):
+        # Constrained decoding can't emit these; assert the schema enforces them
+        # (so we never have to defensively re-validate downstream).
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            _VerdictSchema.model_validate({
+                "axes": {
+                    "REAL": {"passed": True, "confidence": "high", "rationale": "y"},
+                    "TRIGGERABLE": {"passed": True, "confidence": "high", "rationale": "y"},
+                },
+                "advance": True, "severity": "apocalyptic", "evidence_level": "crash_reproduced",
+            })
+        with pytest.raises(ValidationError):
+            _VerdictSchema.model_validate({
+                "axes": {
+                    "REAL": {"passed": True, "confidence": "ultra_high", "rationale": "y"},
+                    "TRIGGERABLE": {"passed": True, "confidence": "high", "rationale": "y"},
+                },
+                "advance": True, "severity": "high", "evidence_level": "crash_reproduced",
+            })
 
 
 # --- apply_validator_verdict tests -------------------------------------------
@@ -352,19 +327,17 @@ class TestRejectedFindings:
         assert finding["verified"] is False
         assert set(finding["rejected_axes"]) == {"TRIGGERABLE", "GENERAL"}
 
-    def test_rejected_finding_severity_cleared_at_parse(self):
-        val = Validator(MagicMock())
-        response = json.dumps({
+    def test_rejected_finding_severity_cleared(self):
+        schema = _VerdictSchema.model_validate({
             "axes": {
                 "REAL": {"passed": False, "confidence": "high", "rationale": "not real"},
+                "TRIGGERABLE": {"passed": False, "confidence": "low", "rationale": "n/a"},
             },
             "advance": False,
             "severity": "high",
             "evidence_level": "static_corroboration",
-            "pro_argument": "", "counter_argument": "", "tie_breaker": "",
-            "duplicate_cve": None,
         })
-        verdict = val._parse_response(_make_finding(), response)
+        verdict = schema.to_verdict("hunter-abc")
         assert verdict.severity_validated is None
 
 
@@ -439,8 +412,7 @@ class TestAvalidate:
     @pytest.mark.asyncio
     async def test_avalidate_parses_response(self):
         mock_llm = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.first_text = json.dumps({
+        verdict_json = json.dumps({
             "axes": {
                 "REAL": {"passed": True, "confidence": "high", "rationale": "yes"},
                 "TRIGGERABLE": {"passed": True, "confidence": "medium", "rationale": "likely"},
@@ -453,8 +425,9 @@ class TestAvalidate:
             "pro_argument": "strong",
             "counter_argument": "weak",
             "tie_breaker": "crash",
-            "duplicate_cve": None,
         })
+        mock_response = MagicMock()
+        mock_response.first_text = verdict_json
         mock_llm.aask_text = AsyncMock(return_value=mock_response)
 
         val = Validator(mock_llm)


### PR DESCRIPTION
## What & why

The validator asked the model for a JSON verdict but never **enforced** it — reasoning models that emitted prose or wrapped the JSON slipped past a regex scrape and dropped real findings. This PR requires **structured output** end-to-end and makes it work on the strict-decoding gateways we actually run against.

### 1. Enforce structured output (`619f9c8`)
- Pass a pydantic wire schema (`_VerdictSchema` / `_AxisSchema` / `_AxesSchema`) as the response schema so genai-pyo3 enforces it via constrained decoding.
- `to_verdict()` maps the validated **typed** object straight to the domain `ValidatorVerdict` — no dict round-trip, no re-validation. The model owns only judgment fields; `finding_id`, derived severity, and `raw_response` are supplied by us.
- Categorical fields stay `Literal` (inline enums, Anthropic-safe, zero coercion). `REAL`/`TRIGGERABLE` required; `IMPACTFUL`/`GENERAL` optional so one schema also fits the two-axis quick pass.
- Iterate the axes schema (no hardcoded name tuple); fold `boundary_crossed` onto the single axis schema (removes a `getattr`); docstrings + `Field(description=...)` so guidance travels in the schema.
- Drop the free-form/regex fallback — models must support constrained decoding.

### 2. Wire in the strict-schema sanitizer (`8924f42`)
OpenAI strict structured outputs (the `openai_resp` gateways) reject pydantic schemas: every object needs `additionalProperties:false` + `required`=all keys, `\$ref` may carry no siblings, and `default` is disallowed — so requests **400'd** ("`required` … Missing 'GENERAL'").

[genai-pyo3 `0.7.0b10.dev2`](https://github.com/ropoctl/genai-pyo3) adds an opt-in `ChatOptions.sanitize_schema` flag that rewrites the schema per adapter before sending. This PR sets it on the structured-output `ChatOptions` (and preserves it across the reasoning-effort rebuild) and bumps the pin to `>=0.7.0b10.dev2`.

## Verification
- `ruff` clean; 63 tests pass (`test_sourcehunt_validator`, `test_native_reasoning_effort`).
- **Proven end-to-end**: `AsyncLLMClient.aask_text(response_schema=_VerdictSchema)` against a gpt-5.4 `openai_resp` gateway returns a valid parsed verdict — the same request 400s with the flag off.