### PR TITLE
feat(sourcehunt): structured traces, LLM refactor, and model-agnostic validation

### DIFF
--- a/clearwing/agent/tools/hunt/deep_agent.py
+++ b/clearwing/agent/tools/hunt/deep_agent.py
@@ -111,7 +111,11 @@ def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:
         ),
         NativeToolSpec(
             name="read_file",
-            description="Read lines from a file in the container.",
+            description=(
+                "Read lines from a file in the container. "
+                "Parameters: path (required), offset (line offset, default 0), "
+                "limit (max lines, default 2000). No other parameters exist."
+            ),
             schema={
                 "type": "object",
                 "properties": {

--- a/clearwing/agent/tools/hunt/deep_agent.py
+++ b/clearwing/agent/tools/hunt/deep_agent.py
@@ -42,6 +42,11 @@ def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:
     """Build the deep agent tool set: execute, read_file, write_file,
     plus the shared reporting + findings-pool tools.
     """
+    # Deep hunters read source via read_file/execute (cat/sed/grep), not the
+    # constrained read_source_file that populates ctx.files_read. Mark the
+    # context so the reporting guard doesn't reject every trace step for a
+    # file it never saw a read_source_file call for.
+    ctx.agent_mode = "deep"
 
     def execute(command: str, timeout: int = 300, **_: object) -> dict:
         if ctx.sandbox is None:

--- a/clearwing/agent/tools/hunt/discovery.py
+++ b/clearwing/agent/tools/hunt/discovery.py
@@ -156,6 +156,7 @@ def build_discovery_tools(ctx: HunterContext) -> list:
             rel = _normalize_path(ctx.repo_path, path)
         except ValueError as e:
             return f"Error: {e}"
+        ctx.files_read.add(rel)
         host_path = os.path.join(ctx.repo_path, rel)
         try:
             with open(host_path, encoding="utf-8", errors="replace") as f:

--- a/clearwing/agent/tools/hunt/discovery.py
+++ b/clearwing/agent/tools/hunt/discovery.py
@@ -262,15 +262,30 @@ def build_discovery_tools(ctx: HunterContext) -> list:
     return [
         NativeToolSpec(
             name="read_source_file",
-            description="Read a repo-relative source file and return up to 500 lines.",
+            description=(
+                "Read a repo-relative source file. Returns up to 500 lines. "
+                "Use start_line/end_line to read a specific range."
+            ),
             schema={
                 "type": "object",
                 "properties": {
-                    "path": {"type": "string"},
-                    "start_line": {"type": "integer", "default": 1},
-                    "end_line": {"type": "integer", "default": -1},
+                    "path": {
+                        "type": "string",
+                        "description": "Repo-relative file path, e.g. 'src/foo.c'",
+                    },
+                    "start_line": {
+                        "type": "integer",
+                        "default": 1,
+                        "description": "First line to read (1-indexed)",
+                    },
+                    "end_line": {
+                        "type": "integer",
+                        "default": -1,
+                        "description": "Last line to read (-1 means start_line + 500)",
+                    },
                 },
                 "required": ["path"],
+                "additionalProperties": False,
             },
             handler=read_source_file,
         ),
@@ -280,9 +295,18 @@ def build_discovery_tools(ctx: HunterContext) -> list:
             schema={
                 "type": "object",
                 "properties": {
-                    "dir_path": {"type": "string", "default": "."},
-                    "max_depth": {"type": "integer", "default": 2},
+                    "dir_path": {
+                        "type": "string",
+                        "default": ".",
+                        "description": "Directory to list (repo-relative)",
+                    },
+                    "max_depth": {
+                        "type": "integer",
+                        "default": 2,
+                        "description": "Maximum directory depth to recurse",
+                    },
                 },
+                "additionalProperties": False,
             },
             handler=list_source_tree,
         ),
@@ -292,11 +316,23 @@ def build_discovery_tools(ctx: HunterContext) -> list:
             schema={
                 "type": "object",
                 "properties": {
-                    "pattern": {"type": "string"},
-                    "path": {"type": "string", "default": "."},
-                    "file_glob": {"type": "string", "default": ""},
+                    "pattern": {
+                        "type": "string",
+                        "description": "Regex pattern to search for",
+                    },
+                    "path": {
+                        "type": "string",
+                        "default": ".",
+                        "description": "Directory or file to search in (repo-relative)",
+                    },
+                    "file_glob": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Glob filter for filenames, e.g. '*.c'",
+                    },
                 },
                 "required": ["pattern"],
+                "additionalProperties": False,
             },
             handler=grep_source,
         ),
@@ -306,9 +342,13 @@ def build_discovery_tools(ctx: HunterContext) -> list:
             schema={
                 "type": "object",
                 "properties": {
-                    "symbol": {"type": "string"},
+                    "symbol": {
+                        "type": "string",
+                        "description": "Symbol name to search for references to",
+                    },
                 },
                 "required": ["symbol"],
+                "additionalProperties": False,
             },
             handler=find_callers,
         ),

--- a/clearwing/agent/tools/hunt/reporting.py
+++ b/clearwing/agent/tools/hunt/reporting.py
@@ -47,7 +47,12 @@ def build_reporting_tools(ctx: HunterContext) -> list:
             code_snippet: Exact code from read_source_file (do NOT fabricate).
             note: Free-form reasoning — role, taint state, assumptions.
         """
-        if file not in ctx.files_read:
+        # The files_read set is only populated by the constrained
+        # read_source_file tool. Deep hunters read via read_file/execute
+        # (cat/sed/grep), so files_read is not authoritative there — enforcing
+        # it would reject every trace step. Skip the guard in deep mode;
+        # downstream validators independently re-verify the assembled trace.
+        if ctx.agent_mode != "deep" and file not in ctx.files_read:
             return (
                 f"ERROR: file '{file}' has not been read yet. "
                 "Call read_source_file first."
@@ -96,7 +101,7 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         algorithm: str = "",
         crypto_attack_class: str = "",
         key_material_exposed: str = "",
-        trace_summary: str = "",
+        trace: dict | None = None,
         **_: object,
     ) -> str:
         """Record a finding into the hunter's state.
@@ -104,8 +109,9 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         The hunter MUST call this tool to report a vulnerability. Findings
         are appended to ctx.findings and surfaced via the hunter's output.
 
-        If trace steps have been recorded via record_trace_step, they are
-        consumed and attached as a structured vulnerability_trace.
+        The `trace` argument is the authoritative vulnerability_trace stored
+        on the finding. Steps streamed via record_trace_step are live-panel
+        telemetry only and are NOT persisted here.
 
         Args:
             file: Repo-relative file path where the finding lives.
@@ -127,17 +133,38 @@ def build_reporting_tools(ctx: HunterContext) -> list:
             crypto_attack_class: Attack class (e.g. timing_side_channel,
                 parameter_validation, nonce_reuse, padding_oracle).
             key_material_exposed: Description of key material at risk.
-            trace_summary: One-line summary of the dataflow trace.
+            trace: Authoritative dataflow trace as {"steps": [...],
+                "summary": "..."}, ordered from attacker-controlled entry to
+                the vulnerable sink. Each step is
+                {file, line, function?, code_snippet?, note?}.
         """
-        # Consume accumulated trace steps into a VulnerabilityTrace
-        trace_dict = None
-        if ctx.trace_steps:
-            trace = VulnerabilityTrace(
-                steps=list(ctx.trace_steps),
-                summary=trace_summary,
+        # Build the authoritative VulnerabilityTrace from the explicit `trace`
+        # argument. Steps streamed via record_trace_step are live-panel
+        # telemetry only — record_finding does NOT harvest them, so the model
+        # must assemble and pass the full trace here.
+        if not trace or not trace.get("steps"):
+            return (
+                "ERROR: record_finding requires a `trace` argument with at "
+                "least one step — an ordered path from attacker-controlled "
+                "entry to the vulnerable sink. Steps you streamed via "
+                "record_trace_step are shown live but are NOT stored. "
+                'Assemble and pass the full trace: trace={"steps": [{"file": '
+                '..., "line": ..., "note": "ENTRY: ..."}, ...], "summary": "..."}.'
             )
-            trace_dict = trace.model_dump()
-            ctx.trace_steps.clear()
+        try:
+            vuln_trace = VulnerabilityTrace(
+                steps=[TraceStep(**s) for s in trace["steps"]],
+                summary=trace.get("summary", ""),
+            )
+        except Exception as exc:
+            return (
+                f"ERROR: invalid trace ({exc}). Each step needs at least "
+                "`file` and `line`; optional `function`, `code_snippet`, `note`."
+            )
+        trace_dict = vuln_trace.model_dump()
+        # Reset the live-panel accumulator so the next finding's streamed trace
+        # starts fresh (these steps were never persisted onto the finding).
+        ctx.trace_steps.clear()
 
         finding = Finding(
             id=f"hunter-{uuid.uuid4().hex[:8]}",
@@ -246,10 +273,62 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                     "algorithm": {"type": "string", "default": ""},
                     "crypto_attack_class": {"type": "string", "default": ""},
                     "key_material_exposed": {"type": "string", "default": ""},
-                    "trace_summary": {
-                        "type": "string",
-                        "description": "One-line summary of the dataflow trace",
-                        "default": "",
+                    "trace": {
+                        "type": "object",
+                        "description": (
+                            "Authoritative dataflow trace: an ordered path from "
+                            "attacker-controlled entry to the vulnerable sink. "
+                            "Stored on the finding and independently re-verified. "
+                            "Steps streamed via record_trace_step are live-only "
+                            "and are NOT persisted."
+                        ),
+                        "properties": {
+                            "steps": {
+                                "type": "array",
+                                "description": (
+                                    "Ordered steps from entry to sink; include at "
+                                    "least one ENTRY step and one SINK step."
+                                ),
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "file": {
+                                            "type": "string",
+                                            "description": "Repo-relative file path",
+                                        },
+                                        "line": {
+                                            "type": "integer",
+                                            "description": "1-indexed line number",
+                                        },
+                                        "function": {
+                                            "type": "string",
+                                            "default": "",
+                                        },
+                                        "code_snippet": {
+                                            "type": "string",
+                                            "default": "",
+                                        },
+                                        "note": {
+                                            "type": "string",
+                                            "description": (
+                                                "Role (ENTRY/PROPAGATION/CONDITION/"
+                                                "SINK), taint state, assumptions"
+                                            ),
+                                            "default": "",
+                                        },
+                                    },
+                                    "required": ["file", "line"],
+                                    "additionalProperties": False,
+                                },
+                            },
+                            "summary": {
+                                "type": "string",
+                                "description": "One-line dataflow summary",
+                                "default": "",
+                            },
+                        },
+                        "required": ["steps"],
+                        "additionalProperties": False,
                     },
                 },
                 "required": [
@@ -259,6 +338,7 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                     "severity",
                     "cwe",
                     "description",
+                    "trace",
                 ],
                 "additionalProperties": False,
             },

--- a/clearwing/agent/tools/hunt/reporting.py
+++ b/clearwing/agent/tools/hunt/reporting.py
@@ -1,16 +1,21 @@
-"""Finding-reporting tool for the source-hunt hunter.
+"""Finding-reporting and trace-building tools for the source-hunt hunter.
 
-A single tool, `record_finding`, that the hunter calls to surface a
-vulnerability into `ctx.findings`. This is where hunter-emitted hits
-become `clearwing.findings.Finding` dataclass instances — the canonical
-shape consumed by the sourcehunt verifier, exploiter, patcher, and
-reporter stages downstream.
+Two tools:
+  - `record_trace_step`: incrementally build a vulnerability trace as
+    the hunter explores code. Steps accumulate on ctx.trace_steps.
+  - `record_finding`: surface a vulnerability into ctx.findings, consuming
+    any accumulated trace steps into a VulnerabilityTrace.
+
+This is where hunter-emitted hits become `clearwing.findings.Finding`
+dataclass instances — the canonical shape consumed by the sourcehunt
+verifier, exploiter, patcher, and reporter stages downstream.
 """
 
 from __future__ import annotations
 
 import uuid
 
+from clearwing.findings.types import TraceStep, VulnerabilityTrace
 from clearwing.llm import NativeToolSpec
 from clearwing.sourcehunt.state import Finding
 
@@ -18,7 +23,44 @@ from .sandbox import HunterContext
 
 
 def build_reporting_tools(ctx: HunterContext) -> list:
-    """Build the single finding-reporter tool for a hunter session."""
+    """Build the finding-reporter and trace-step tools for a hunter session."""
+
+    def record_trace_step(
+        file: str,
+        line: int,
+        function: str = "",
+        code_snippet: str = "",
+        note: str = "",
+        **_: object,
+    ) -> str:
+        """Record one step in the vulnerability trace being built.
+
+        Call this AS YOU READ CODE to build an incremental path from
+        attacker input to vulnerable sink. The code_snippet MUST come
+        from a prior read_source_file result.
+
+        Args:
+            file: Repo-relative file path.
+            line: 1-indexed line number.
+            function: Enclosing function name.
+            code_snippet: Exact code from read_source_file (do NOT fabricate).
+            note: Free-form reasoning — role, taint state, assumptions.
+        """
+        if file not in ctx.files_read:
+            return (
+                f"ERROR: file '{file}' has not been read yet. "
+                "Call read_source_file first."
+            )
+        step = TraceStep(
+            file=file,
+            line=line,
+            function=function,
+            code_snippet=code_snippet,
+            note=note,
+        )
+        ctx.trace_steps.append(step)
+        n = len(ctx.trace_steps)
+        return f"Trace step {n} recorded: {file}:{line} ({function or 'unknown'})"
 
     def record_finding(
         file: str,
@@ -36,12 +78,16 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         algorithm: str = "",
         crypto_attack_class: str = "",
         key_material_exposed: str = "",
+        trace_summary: str = "",
         **_: object,
     ) -> str:
         """Record a finding into the hunter's state.
 
         The hunter MUST call this tool to report a vulnerability. Findings
         are appended to ctx.findings and surfaced via the hunter's output.
+
+        If trace steps have been recorded via record_trace_step, they are
+        consumed and attached as a structured vulnerability_trace.
 
         Args:
             file: Repo-relative file path where the finding lives.
@@ -63,7 +109,18 @@ def build_reporting_tools(ctx: HunterContext) -> list:
             crypto_attack_class: Attack class (e.g. timing_side_channel,
                 parameter_validation, nonce_reuse, padding_oracle).
             key_material_exposed: Description of key material at risk.
+            trace_summary: One-line summary of the dataflow trace.
         """
+        # Consume accumulated trace steps into a VulnerabilityTrace
+        trace_dict = None
+        if ctx.trace_steps:
+            trace = VulnerabilityTrace(
+                steps=list(ctx.trace_steps),
+                summary=trace_summary,
+            )
+            trace_dict = trace.model_dump()
+            ctx.trace_steps.clear()
+
         finding = Finding(
             id=f"hunter-{uuid.uuid4().hex[:8]}",
             file=file,
@@ -84,14 +141,60 @@ def build_reporting_tools(ctx: HunterContext) -> list:
             algorithm=algorithm or None,
             crypto_attack_class=crypto_attack_class or None,
             key_material_exposed=key_material_exposed or None,
+            vulnerability_trace=trace_dict,
         )
         ctx.findings.append(finding)
+        trace_msg = f", trace={len(trace_dict['steps'])} steps" if trace_dict else ""
         return (
             f"Finding recorded: {finding_type} at {file}:{line_number} "
-            f"(severity={severity}, evidence_level={evidence_level})"
+            f"(severity={severity}, evidence_level={evidence_level}{trace_msg})"
         )
 
     return [
+        NativeToolSpec(
+            name="record_trace_step",
+            description=(
+                "Record one step in a vulnerability trace. Call this AS YOU "
+                "READ CODE to build an incremental path from attacker input "
+                "to vulnerable sink. The code_snippet MUST be copied from a "
+                "prior read_source_file result."
+            ),
+            schema={
+                "type": "object",
+                "properties": {
+                    "file": {
+                        "type": "string",
+                        "description": "Repo-relative file path",
+                    },
+                    "line": {
+                        "type": "integer",
+                        "description": "1-indexed line number",
+                    },
+                    "function": {
+                        "type": "string",
+                        "description": "Enclosing function name",
+                        "default": "",
+                    },
+                    "code_snippet": {
+                        "type": "string",
+                        "description": (
+                            "Exact code from read_source_file (do NOT fabricate)"
+                        ),
+                        "default": "",
+                    },
+                    "note": {
+                        "type": "string",
+                        "description": (
+                            "Free-form: role (entry/propagation/condition/sink), "
+                            "taint state, assumptions, reasoning"
+                        ),
+                        "default": "",
+                    },
+                },
+                "required": ["file", "line"],
+            },
+            handler=record_trace_step,
+        ),
         NativeToolSpec(
             name="record_finding",
             description="Record a verified or suspected finding into the hunter state.",
@@ -113,6 +216,11 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                     "algorithm": {"type": "string", "default": ""},
                     "crypto_attack_class": {"type": "string", "default": ""},
                     "key_material_exposed": {"type": "string", "default": ""},
+                    "trace_summary": {
+                        "type": "string",
+                        "description": "One-line summary of the dataflow trace",
+                        "default": "",
+                    },
                 },
                 "required": [
                     "file",
@@ -124,5 +232,5 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                 ],
             },
             handler=record_finding,
-        )
+        ),
     ]

--- a/clearwing/agent/tools/hunt/reporting.py
+++ b/clearwing/agent/tools/hunt/reporting.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import uuid
 
+from clearwing.core.events import EventBus, EventType
 from clearwing.findings.types import TraceStep, VulnerabilityTrace
 from clearwing.llm import NativeToolSpec
 from clearwing.sourcehunt.state import Finding
@@ -60,7 +61,24 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         )
         ctx.trace_steps.append(step)
         n = len(ctx.trace_steps)
-        return f"Trace step {n} recorded: {file}:{line} ({function or 'unknown'})"
+        EventBus().emit(EventType.TRACE_STEP, {
+            "hunter_target": ctx.file_path,
+            "file": file,
+            "line": line,
+            "function": function,
+            "note": note,
+            "step_number": n,
+        })
+        # Echo the full accumulated trace back into the conversation so the
+        # growing dataflow path stays part of the message sequence the model
+        # reasons over before calling record_finding.
+        lines = [f"Trace step {n} recorded. Trace so far ({n} step(s)):"]
+        for i, s in enumerate(ctx.trace_steps, 1):
+            loc = f"{s.file}:{s.line}"
+            fn = f" {s.function}()" if s.function else ""
+            note_str = f" — {s.note}" if s.note else ""
+            lines.append(f"  {i}. {loc}{fn}{note_str}")
+        return "\n".join(lines)
 
     def record_finding(
         file: str,
@@ -144,6 +162,17 @@ def build_reporting_tools(ctx: HunterContext) -> list:
             vulnerability_trace=trace_dict,
         )
         ctx.findings.append(finding)
+        EventBus().emit(EventType.FINDING_RECORDED, {
+            "file": file,
+            "line_number": line_number,
+            "finding_type": finding_type,
+            "severity": severity,
+            "cwe": cwe,
+            "description": description,
+            "confidence": confidence,
+            "evidence_level": evidence_level,
+            "hunter_target": ctx.file_path,
+        })
         trace_msg = f", trace={len(trace_dict['steps'])} steps" if trace_dict else ""
         return (
             f"Finding recorded: {finding_type} at {file}:{line_number} "
@@ -192,6 +221,7 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                     },
                 },
                 "required": ["file", "line"],
+                "additionalProperties": False,
             },
             handler=record_trace_step,
         ),
@@ -230,6 +260,7 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                     "cwe",
                     "description",
                 ],
+                "additionalProperties": False,
             },
             handler=record_finding,
         ),

--- a/clearwing/agent/tools/hunt/sandbox.py
+++ b/clearwing/agent/tools/hunt/sandbox.py
@@ -30,6 +30,8 @@ class HunterContext:
     repo_path: str  # absolute host path
     sandbox: SandboxContainer | None = None  # primary sandbox; set by hunt loop
     findings: list[Finding] = field(default_factory=list)
+    trace_steps: list = field(default_factory=list)  # accumulator for TraceStep dicts
+    files_read: set = field(default_factory=set)  # files accessed via read_source_file
     file_path: str | None = None  # the file this hunter is scoped to
     session_id: str | None = None
     specialist: str = "general"  # "general" | "memory_safety" | "logic_auth" | "propagation"

--- a/clearwing/agent/tools/hunt/sandbox.py
+++ b/clearwing/agent/tools/hunt/sandbox.py
@@ -32,6 +32,7 @@ class HunterContext:
     findings: list[Finding] = field(default_factory=list)
     trace_steps: list = field(default_factory=list)  # accumulator for TraceStep dicts
     files_read: set = field(default_factory=set)  # files accessed via read_source_file
+    agent_mode: str = "constrained"  # "constrained" | "deep"; deep reads via shell so files_read is not authoritative
     file_path: str | None = None  # the file this hunter is scoped to
     session_id: str | None = None
     specialist: str = "general"  # "general" | "memory_safety" | "logic_auth" | "propagation"

--- a/clearwing/core/events.py
+++ b/clearwing/core/events.py
@@ -42,6 +42,9 @@ class EventType(enum.Enum):
     DISCLOSURE_UPDATE = "disclosure_update"
     BENCHMARK_PROGRESS = "benchmark_progress"
     EVAL_PROGRESS = "eval_progress"
+    FINDING_RECORDED = "finding_recorded"
+    HUNTER_STATUS = "hunter_status"
+    TRACE_STEP = "trace_step"
 
 
 class EventBus:

--- a/clearwing/findings/types.py
+++ b/clearwing/findings/types.py
@@ -16,6 +16,8 @@ import warnings
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
+from pydantic import BaseModel, Field
+
 logger = logging.getLogger(__name__)
 
 Severity = Literal["critical", "high", "medium", "low", "info"]
@@ -77,6 +79,30 @@ def evidence_compare(a: EvidenceLevel, b: EvidenceLevel) -> int:
 def evidence_at_or_above(level: EvidenceLevel, threshold: EvidenceLevel) -> bool:
     """True if `level` is at least as strong as `threshold`."""
     return _EVIDENCE_RANK[level] >= _EVIDENCE_RANK[threshold]
+
+
+# --- Vulnerability trace types (v0.5) ----------------------------------------
+
+
+class TraceStep(BaseModel):
+    """One step in a hunter-authored vulnerability trace.
+
+    Each step represents a location the hunter READ and reasoned about,
+    forming a chain from attacker input to vulnerable sink.
+    """
+
+    file: str  # repo-relative path
+    line: int  # 1-indexed line number
+    function: str = ""  # enclosing function name
+    code_snippet: str = ""  # MUST be from read_source_file
+    note: str = ""  # free-form: role, taint state, assumptions, reasoning
+
+
+class VulnerabilityTrace(BaseModel):
+    """Ordered sequence of TraceSteps from entry to impact."""
+
+    steps: list[TraceStep] = Field(default_factory=list)
+    summary: str = ""  # one-line dataflow summary
 
 
 # --- The unified Finding ----------------------------------------------------
@@ -181,6 +207,9 @@ class Finding:
 
     # Extensible payload — v0.2/v0.3 seams, retro-hunt fields, etc.
     extra: dict[str, Any] = field(default_factory=dict)
+
+    # Structured vulnerability trace (v0.5)
+    vulnerability_trace: dict | None = None
 
     # --- Post-init validation ------------------------------------------------
 

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -100,6 +100,10 @@ def call_logging_enabled() -> bool:
     return _LOG_CALLS
 
 
+# Set to True once the litellm asyncio exception handler has been installed
+# on the running event loop, so _import_litellm never wraps it a second time.
+_litellm_loop_handler_installed: bool = False
+
 # ---------------------------------------------------------------------------
 # reasoning_effort auto-detection
 # ---------------------------------------------------------------------------
@@ -119,6 +123,7 @@ _REASONING_EFFORT_UNSUPPORTED_PATTERNS: tuple[str, ...] = (
     "mixtral",
     "qwen2",
     "gemma",
+    "glm",
 )
 
 # Explicit re-enable list for model names that contain an unsupported pattern
@@ -349,6 +354,13 @@ class AsyncLLMClient:
             rate_limit_max_backoff_seconds,
         )
         self._semaphore = asyncio.Semaphore(max(1, max_concurrency))
+        # Python-native backend flag: set CLEARWING_LLM_BACKEND=python to route
+        # through litellm instead of genai-pyo3. OAuth providers are always
+        # handled by the genai path regardless (credential refresh lives there).
+        self._use_python_backend: bool = (
+            os.environ.get("CLEARWING_LLM_BACKEND", "").lower() == "python"
+            and self.provider_name not in ("openai_codex", "anthropic_oauth")
+        )
 
     async def achat(
         self,
@@ -415,7 +427,7 @@ class AsyncLLMClient:
         async with self._semaphore:
             client = self._build_client(Client)
             try:
-                response = await self._with_rate_limit_retries(
+                response, cost = await self._with_rate_limit_retries(
                     lambda: self._achat_with_provider_policy(client, request, options)
                 )
             except Exception as exc:
@@ -437,7 +449,7 @@ class AsyncLLMClient:
                 )
                 self.reasoning_effort = None
                 options = self._rebuild_options_without_reasoning(options)
-                response = await self._with_rate_limit_retries(
+                response, cost = await self._with_rate_limit_retries(
                     lambda: self._achat_with_provider_policy(client, request, options)
                 )
         usage = getattr(response, "usage", None)
@@ -517,6 +529,13 @@ class AsyncLLMClient:
             reasoning_effort=self.reasoning_effort,
         )
 
+        t0 = time.perf_counter()
+        if self._use_python_backend:
+            async with self._semaphore:
+                response = await self._achat_stream_python_backend(request, options, on_text_delta)
+            self._log_request(response, time.perf_counter() - t0)
+            return response
+
         async with self._semaphore:
             client = self._build_client(Client)
 
@@ -556,6 +575,7 @@ class AsyncLLMClient:
                 else:
                     raise
             if end_event is not None:
+                self._log_request(end_event, time.perf_counter() - t0)
                 return end_event
         # Fallback if stream ends without an end event
         return await self.achat(
@@ -689,6 +709,8 @@ class AsyncLLMClient:
         request: ChatRequest,
         options: ChatOptions,
     ) -> ChatResponse:
+        if self._use_python_backend:
+            return await self._achat_python_backend(request, options)
         # openai_resp / openai_codex (the Responses API + ChatGPT gateway)
         # require `stream=true` on the wire, so they go through
         # `achat_via_stream`: it streams internally and returns a fully
@@ -716,6 +738,200 @@ class AsyncLLMClient:
                 exc,
             )
             return await self._openai_chat_http_fallback(request, options)
+
+    # ------------------------------------------------------------------
+    # Python-native backend (litellm)
+    # ------------------------------------------------------------------
+
+    def _litellm_model_string(self) -> str:
+        """Convert (provider_name, model_name) to litellm's routing format."""
+        model = self.model_name
+        if "/" in model:
+            return model
+        prefix_map = {
+            "anthropic": "anthropic",
+            "gemini": "gemini",
+            "google": "gemini",
+            "groq": "groq",
+            "openai": "openai",
+        }
+        prefix = prefix_map.get(self.provider_name, "openai")
+        return f"{prefix}/{model}"
+
+    def _litellm_messages(self, request: ChatRequest) -> list[dict[str, Any]]:
+        """Convert a ChatRequest's messages + system into litellm message dicts."""
+        out: list[dict[str, Any]] = []
+        if request.system:
+            out.append({"role": "system", "content": request.system})
+        for msg in request.messages():
+            d: dict[str, Any] = {"role": msg.role, "content": msg.content or ""}
+            if msg.tool_calls:
+                d["tool_calls"] = [
+                    {
+                        "id": tc.call_id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.fn_name,
+                            "arguments": json.dumps(tc.fn_arguments),
+                        },
+                    }
+                    for tc in msg.tool_calls
+                ]
+            if msg.tool_response_call_id:
+                d["tool_call_id"] = msg.tool_response_call_id
+            out.append(d)
+        return out
+
+    def _litellm_tool(self, tool: Tool) -> dict[str, Any]:
+        try:
+            parameters = json.loads(tool.schema_json or "{}")
+        except json.JSONDecodeError:
+            parameters = {"type": "object", "properties": {}}
+        return {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description or "",
+                "parameters": parameters,
+            },
+        }
+
+    def _litellm_base_kwargs(
+        self, request: ChatRequest, options: ChatOptions
+    ) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {
+            "model": self._litellm_model_string(),
+            "messages": self._litellm_messages(request),
+            "api_key": self.api_key or None,
+            "api_base": self.base_url or None,
+        }
+        if options.temperature is not None:
+            kwargs["temperature"] = options.temperature
+        if options.max_tokens is not None:
+            kwargs["max_tokens"] = options.max_tokens
+        if self.reasoning_effort and self.provider_name == "anthropic":
+            # Claude uses thinking blocks, not reasoning_effort.
+            # temperature=1 is required by Anthropic when thinking is enabled.
+            kwargs["thinking"] = {"type": "enabled", "budget_tokens": 8000}
+            kwargs.setdefault("temperature", 1)
+        elif (
+            self.reasoning_effort
+            and self.reasoning_effort != "auto"
+            and self.provider_name in ("openai", "openai_resp")
+        ):
+            kwargs["reasoning_effort"] = self.reasoning_effort
+        if request.tools:
+            kwargs["tools"] = [self._litellm_tool(t) for t in request.tools]
+            kwargs["tool_choice"] = "auto"
+        if options.response_json_spec is not None:
+            kwargs["response_format"] = self._openai_response_format(options.response_json_spec)
+        return kwargs
+
+    @staticmethod
+    def _import_litellm():
+        try:
+            import litellm  # noqa: PLC0415
+        except ImportError as exc:
+            raise RuntimeError(
+                "CLEARWING_LLM_BACKEND=python requires 'litellm'. "
+                "Install with: pip install 'clearwing[python-llm]'"
+            ) from exc
+        # Suppress litellm's verbose per-call INFO logging.
+        litellm.suppress_debug_info = True
+        litellm.verbose = False
+        litellm.set_verbose = False
+        litellm.callbacks = []
+        litellm.success_callback = []
+        litellm.failure_callback = []
+        litellm._async_success_callback = []
+        litellm._async_failure_callback = []
+        # Enable cost tracking so completion_cost() has pricing data populated.
+        litellm.return_response_headers = True
+        logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+        logging.getLogger("LiteLLM Router").setLevel(logging.WARNING)
+        logging.getLogger("LiteLLM Proxy").setLevel(logging.WARNING)
+        # litellm's LoggingWorker creates a background asyncio Task that it
+        # never cancels, causing two noisy-but-harmless messages on teardown:
+        #   RuntimeWarning: coroutine '...' was never awaited
+        #   ERROR: Task was destroyed but it is pending!
+        # Suppress both by installing a loop exception handler that drops
+        # context entries originating from litellm's LoggingWorker, and a
+        # warnings filter for the unawaited-coroutine variant.
+        import warnings  # noqa: PLC0415
+        warnings.filterwarnings(
+            "ignore",
+            message="coroutine '.*async_success_handler' was never awaited",
+            category=RuntimeWarning,
+        )
+        global _litellm_loop_handler_installed
+        if not _litellm_loop_handler_installed:
+            try:
+                loop = asyncio.get_event_loop()
+                _prev = loop.get_exception_handler()
+
+                def _handler(lp, ctx):
+                    task = ctx.get("task")
+                    if task is not None and "LoggingWorker" in repr(task):
+                        return
+                    if "LoggingWorker" in str(ctx.get("message", "")):
+                        return
+                    if _prev is not None:
+                        _prev(lp, ctx)
+                    else:
+                        lp.default_exception_handler(ctx)
+
+                loop.set_exception_handler(_handler)
+                _litellm_loop_handler_installed = True
+            except RuntimeError:
+                pass  # no running loop yet — will install on first actual call
+        return litellm
+
+    async def _achat_python_backend(
+        self, request: ChatRequest, options: ChatOptions
+    ) -> ChatResponse:
+        litellm = self._import_litellm()
+        kwargs = self._litellm_base_kwargs(request, options)
+        response = await litellm.acompletion(**kwargs)
+        return self._chat_response_from_openai_payload(response.model_dump())
+
+    async def _achat_stream_python_backend(
+        self,
+        request: ChatRequest,
+        options: ChatOptions,
+        on_text_delta: Callable[[str], None] | None,
+    ) -> ChatResponse:
+        litellm = self._import_litellm()
+        kwargs = self._litellm_base_kwargs(request, options)
+        kwargs["stream"] = True
+        content_parts: list[str] = []
+        tool_call_parts: dict[int, dict[str, Any]] = {}
+        usage: dict[str, Any] | None = None
+
+        response = await litellm.acompletion(**kwargs)
+        async for chunk in response:
+            chunk_dict = chunk.model_dump() if hasattr(chunk, "model_dump") else chunk
+            if chunk_dict.get("usage"):
+                usage = chunk_dict["usage"]
+            choices = chunk_dict.get("choices") or []
+            if not choices:
+                continue
+            delta = choices[0].get("delta") or {}
+            text = delta.get("content")
+            if text:
+                content_parts.append(text)
+                if on_text_delta:
+                    on_text_delta(text)
+            raw_tool_calls = delta.get("tool_calls")
+            if raw_tool_calls:
+                self._merge_openai_tool_call_deltas(tool_call_parts, raw_tool_calls)
+
+        return self._chat_response_from_parts(
+            text="".join(content_parts),
+            reasoning_content=None,
+            tool_calls=self._finalize_openai_tool_calls(tool_call_parts),
+            usage=usage,
+            provider_model=self._litellm_model_string(),
+        )
 
     def _should_try_openai_http_fallback(self, exc: Exception) -> bool:
         if self.provider_name != "openai" or not self.base_url:
@@ -890,8 +1106,12 @@ class AsyncLLMClient:
         content_parts: list[str] = []
         reasoning_parts: list[str] = []
         tool_call_parts: dict[int, dict[str, Any]] = {}
+        # Responses API SSE: keyed by output_index
+        resp_tool_parts: dict[int, dict[str, Any]] = {}
         usage: dict[str, Any] | None = None
         provider_model = self.model_name
+        is_responses_api = False
+        final_response: dict[str, Any] | None = None
 
         async for raw_line in resp.content:
             line = raw_line.decode("utf-8", errors="replace").strip()
@@ -904,6 +1124,36 @@ class AsyncLLMClient:
                 chunk = json.loads(data)
             except json.JSONDecodeError:
                 logger.debug("Skipping malformed OpenAI SSE chunk: %r", data)
+                continue
+
+            event_type = chunk.get("type") or ""
+            if event_type.startswith("response."):
+                is_responses_api = True
+                if event_type == "response.done":
+                    final_response = chunk.get("response") or chunk
+                elif event_type == "response.output_text.delta":
+                    text = chunk.get("delta") or ""
+                    if text:
+                        content_parts.append(text)
+                        if on_text_delta:
+                            on_text_delta(text)
+                elif event_type == "response.output_item.added":
+                    item = chunk.get("item") or {}
+                    if item.get("type") == "function_call":
+                        idx = int(chunk.get("output_index") or 0)
+                        resp_tool_parts[idx] = {
+                            "call_id": item.get("call_id") or item.get("id") or "",
+                            "fn_name": item.get("name") or "",
+                            "arguments": item.get("arguments") or "",
+                        }
+                elif event_type == "response.function_call_arguments.delta":
+                    idx = int(chunk.get("output_index") or 0)
+                    acc = resp_tool_parts.setdefault(idx, {"call_id": chunk.get("call_id") or "", "fn_name": "", "arguments": ""})
+                    acc["arguments"] += chunk.get("delta") or ""
+                elif event_type == "response.function_call_arguments.done":
+                    idx = int(chunk.get("output_index") or 0)
+                    acc = resp_tool_parts.setdefault(idx, {"call_id": chunk.get("call_id") or "", "fn_name": "", "arguments": ""})
+                    acc["arguments"] = chunk.get("arguments") or acc["arguments"]
                 continue
 
             provider_model = chunk.get("model") or provider_model
@@ -921,6 +1171,25 @@ class AsyncLLMClient:
                     reasoning_parts.append(reasoning)
                 self._merge_openai_tool_call_deltas(tool_call_parts, delta.get("tool_calls"))
 
+        if is_responses_api:
+            if final_response:
+                return self._chat_response_from_responses_payload(final_response)
+            tool_calls = [
+                {
+                    "call_id": part["call_id"],
+                    "fn_name": part["fn_name"],
+                    "fn_arguments": self._parse_openai_tool_arguments(part["arguments"]),
+                }
+                for part in (v for _, v in sorted(resp_tool_parts.items()))
+            ]
+            return self._chat_response_from_parts(
+                text="".join(content_parts),
+                reasoning_content=None,
+                tool_calls=tool_calls,
+                usage=usage,
+                provider_model=provider_model,
+            )
+
         return self._chat_response_from_parts(
             text="".join(content_parts),
             reasoning_content="".join(reasoning_parts) or None,
@@ -930,6 +1199,8 @@ class AsyncLLMClient:
         )
 
     def _chat_response_from_openai_payload(self, payload: dict[str, Any]) -> ChatResponse:
+        if "output" in payload or payload.get("object") == "response":
+            return self._chat_response_from_responses_payload(payload)
         choice = (payload.get("choices") or [{}])[0]
         message = choice.get("message") or {}
         text = self._extract_openai_message_text(message.get("content"))
@@ -938,6 +1209,37 @@ class AsyncLLMClient:
         return self._chat_response_from_parts(
             text=text,
             reasoning_content=reasoning_content,
+            tool_calls=tool_calls,
+            usage=payload.get("usage"),
+            provider_model=payload.get("model") or self.model_name,
+        )
+
+    def _chat_response_from_responses_payload(self, payload: dict[str, Any]) -> ChatResponse:
+        """Parse an OpenAI Responses API (non-streaming) payload into ChatResponse."""
+        text_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+        for item in payload.get("output") or []:
+            item_type = item.get("type")
+            if item_type == "message":
+                for part in item.get("content") or []:
+                    part_type = part.get("type")
+                    if part_type in ("output_text", "text"):
+                        text_parts.append(part.get("text") or "")
+                    elif part_type in ("reasoning", "thinking"):
+                        reasoning_parts.append(part.get("text") or part.get("thinking") or "")
+            elif item_type == "function_call":
+                tool_calls.append({
+                    "call_id": item.get("call_id") or item.get("id") or "",
+                    "fn_name": item.get("name") or "",
+                    "fn_arguments": self._parse_openai_tool_arguments(item.get("arguments")),
+                })
+            elif item_type == "reasoning":
+                for summary in item.get("summary") or []:
+                    reasoning_parts.append(summary.get("text") or "")
+        return self._chat_response_from_parts(
+            text="".join(text_parts),
+            reasoning_content="".join(reasoning_parts) or None,
             tool_calls=tool_calls,
             usage=payload.get("usage"),
             provider_model=payload.get("model") or self.model_name,
@@ -1123,6 +1425,32 @@ class AsyncLLMClient:
         if "reasoning_effort" not in text:
             return False
         return "400" in text or "unsupported" in text
+
+    def _log_request(self, response: ChatResponse, elapsed: float) -> None:
+        usage = response.usage
+        prompt = getattr(usage, "prompt_tokens", None)
+        completion = getattr(usage, "completion_tokens", None)
+        total = getattr(usage, "total_tokens", None)
+        cost: float | None = None
+        if prompt is not None and completion is not None:
+            try:
+                import litellm as _ll  # noqa: PLC0415
+                cost = _ll.completion_cost(
+                    model=self.model_name,
+                    prompt_tokens=prompt,
+                    completion_tokens=completion,
+                )
+            except Exception:
+                pass
+        logger.info(
+            "llm request model=%s elapsed=%.3fs prompt_tokens=%s completion_tokens=%s total_tokens=%s cost=%s",
+            self.model_name,
+            elapsed,
+            prompt,
+            completion,
+            total,
+            f"${cost:.6f}" if cost is not None else "n/a",
+        )
 
     def _is_rate_limit_error(self, exc: Exception) -> bool:
         text = str(exc).lower()

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -787,6 +787,34 @@ Web frameworks have many legitimate idioms that look dangerous. When in doubt, c
 """
 
 
+TRACE_BUILDING_INSTRUCTIONS = """
+## Building a Vulnerability Trace
+
+As you investigate, call `record_trace_step` at each key location in the
+dataflow AFTER reading the code with `read_source_file`. This builds a
+structured trace that downstream validation can independently verify.
+
+Workflow:
+1. read_source_file → find attacker-controlled entry point
+2. record_trace_step(file, line, function, code_snippet, note="ENTRY: ...")
+3. read_source_file → follow the tainted data through calls/assignments
+4. record_trace_step(..., note="PROPAGATION: tainted var X flows to ...")
+5. record_trace_step(..., note="CONDITION: check Y is bypassed because ...")
+6. record_trace_step(..., note="SINK: vulnerable operation on tainted data")
+7. record_finding(..., trace_summary="attacker-controlled X flows to Y unchecked")
+
+Rules:
+- code_snippet in each trace step MUST come from a read_source_file result.
+  Do not paraphrase or reconstruct from memory.
+- Note should describe: what role this step plays, what data is tainted,
+  and what assumptions must hold for execution to reach this point.
+- Assumptions must be consistent with your PoC inputs. If your trace says
+  "field==2" but your PoC sets "field=1", you have a contradiction —
+  resolve it before calling record_finding.
+- Record at least one ENTRY step and one SINK step before record_finding.
+"""
+
+
 _SPECIALIST_PROMPTS = {
     "general": GENERAL_HUNTER_PROMPT,
     "memory_safety": MEMORY_SAFETY_HUNTER_PROMPT,
@@ -836,7 +864,7 @@ def _build_hunter_prompt(
         seeded_crash_block=seeded_crash_block,
         semgrep_hints_block=semgrep_hints_block,
     )
-    return prompt + HUNTER_EXECUTION_RULES
+    return prompt + HUNTER_EXECUTION_RULES + TRACE_BUILDING_INSTRUCTIONS
 
 
 def _build_propagation_prompt(file_target: FileTarget) -> str:
@@ -1031,6 +1059,7 @@ def _build_unconstrained_prompt(
             prompt += "\n" + POOL_ACCESS_BLOCK.format(count=count)
 
     prompt += "\n" + SELF_CHECK
+    prompt += "\n" + TRACE_BUILDING_INSTRUCTIONS
 
     return prompt
 
@@ -1156,7 +1185,7 @@ def _build_subsystem_prompt(
             ep_lines.append(f"  ... and {len(subsystem.entry_points) - 20} more")
         entry_points_block = "\n".join(ep_lines) + "\n"
 
-    return SUBSYSTEM_HUNT_PROMPT.format(
+    prompt = SUBSYSTEM_HUNT_PROMPT.format(
         subsystem_name=subsystem.name,
         project_name=project_name,
         file_count=len(subsystem.files),
@@ -1166,6 +1195,7 @@ def _build_subsystem_prompt(
         existing_findings_block=existing_findings_block,
         entry_points_block=entry_points_block,
     )
+    return prompt + TRACE_BUILDING_INSTRUCTIONS
 
 
 def build_subsystem_hunter_agent(

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -24,6 +24,7 @@ from clearwing.agent.tools.hunt import (
     build_hunter_tools,
     build_propagation_auditor_tools,
 )
+from clearwing.core.events import EventBus, EventType
 from clearwing.llm import AsyncLLMClient, ChatMessage, NativeToolSpec, ToolCall
 from clearwing.observability.telemetry import CostTracker
 from clearwing.sandbox.container import SandboxContainer
@@ -815,6 +816,36 @@ Rules:
 """
 
 
+DEEP_TRACE_INSTRUCTIONS = """
+## Building a Vulnerability Trace
+
+As you investigate, call `record_trace_step` at each key location in the
+dataflow AFTER reading the code with `read_file`. Each step you record is
+echoed back into this conversation, so the growing trace stays part of the
+message sequence you can reason over before submitting a finding. Downstream
+validation independently re-checks the assembled trace.
+
+Workflow:
+1. read_file → find attacker-controlled entry point
+2. record_trace_step(file, line, function, code_snippet, note="ENTRY: ...")
+3. read_file → follow the tainted data through calls/assignments
+4. record_trace_step(..., note="PROPAGATION: tainted var X flows to ...")
+5. record_trace_step(..., note="CONDITION: check Y is bypassed because ...")
+6. record_trace_step(..., note="SINK: vulnerable operation on tainted data")
+7. record_finding(..., trace_summary="attacker-controlled X flows to Y unchecked")
+
+Rules:
+- code_snippet in each trace step MUST come from a read_file result. Do not
+  paraphrase or reconstruct from memory.
+- Note should describe: what role this step plays, what data is tainted, and
+  what assumptions must hold for execution to reach this point.
+- Assumptions must be consistent with your PoC inputs. If your trace says
+  "field==2" but your PoC sets "field=1", resolve the contradiction before
+  calling record_finding.
+- Record at least one ENTRY step and one SINK step before record_finding.
+"""
+
+
 _SPECIALIST_PROMPTS = {
     "general": GENERAL_HUNTER_PROMPT,
     "memory_safety": MEMORY_SAFETY_HUNTER_PROMPT,
@@ -886,7 +917,7 @@ Tools:
 - execute(command): Run any shell command. gcc, gdb, strace, valgrind, make are all available.
 - read_file(path): Read a file from the container.
 - write_file(path, contents): Write a file in the container.
-- think(notes): Record your reasoning (visible in the audit trail).
+- record_trace_step(file, line, function, code_snippet, note): Record one step in the vulnerability dataflow trace as you read code. Build the trace incrementally from attacker entry to sink.
 - record_finding(...): Submit a vulnerability finding with severity, CWE, evidence level, and description.
 
 Project: {project_name}
@@ -995,7 +1026,7 @@ def _build_deep_agent_prompt(
         if count > 0:
             prompt += "\n" + POOL_ACCESS_BLOCK.format(count=count)
 
-    return prompt
+    return prompt + DEEP_TRACE_INSTRUCTIONS
 
 
 def _build_unconstrained_prompt(
@@ -1380,6 +1411,12 @@ class NativeHunter:
             )
 
             last_assistant_text = response.first_text or ""
+            if last_assistant_text:
+                EventBus().emit(EventType.HUNTER_STATUS, {
+                    "hunter_target": self.ctx.file_path,
+                    "text": last_assistant_text,
+                    "step": step,
+                })
             tool_calls_in_response = response.tool_calls
             if tool_calls_in_response:
                 messages.append(
@@ -1503,6 +1540,47 @@ class NativeHunter:
             arguments = tool_call.fn_arguments
             if not isinstance(arguments, dict):
                 arguments = {}
+            # Strip hallucinated/mangled keys the model may emit (XML noise,
+            # invented params). Only pass keys declared in the tool schema.
+            allowed_keys = set(tool.schema.get("properties", {}).keys()) if tool.schema else None
+            if allowed_keys is not None:
+                arguments = {k: v for k, v in arguments.items() if k in allowed_keys}
+            # Reject calls missing required params (model emitted empty/partial args).
+            # Return an error string so the model can self-correct on next turn.
+            required = set(tool.schema.get("required", [])) if tool.schema else set()
+            missing = required - set(arguments.keys())
+            if missing:
+                logger.info(
+                    "Hunter tool %s missing required args %s for %s (retry expected)",
+                    tool_call.fn_name,
+                    sorted(missing),
+                    self.ctx.file_path,
+                )
+                return {
+                    "error": f"missing required arguments: {', '.join(sorted(missing))}. "
+                    f"Required: {', '.join(sorted(required))}. Please retry with all required params."
+                }
+            sandbox_id = (
+                self.ctx.sandbox.short_id if self.ctx.sandbox else None
+            )
+            if tool_call.fn_name in ("read_source_file", "read_file"):
+                offset = arguments.get("offset", 0)
+                limit = arguments.get("limit", 500)
+                EventBus().emit(EventType.TOOL_START, {
+                    "tool_name": tool_call.fn_name,
+                    "file": arguments.get("path", ""),
+                    "start_line": arguments.get("start_line", offset + 1),
+                    "end_line": arguments.get("end_line", offset + limit),
+                    "hunter_target": self.ctx.file_path,
+                    "sandbox_id": sandbox_id,
+                })
+            elif tool_call.fn_name == "execute":
+                EventBus().emit(EventType.TOOL_START, {
+                    "tool_name": "execute",
+                    "command": arguments.get("command", ""),
+                    "hunter_target": self.ctx.file_path,
+                    "sandbox_id": sandbox_id,
+                })
             return await tool.ainvoke(arguments)
         except Exception as exc:
             logger.warning(

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -792,27 +792,43 @@ TRACE_BUILDING_INSTRUCTIONS = """
 ## Building a Vulnerability Trace
 
 As you investigate, call `record_trace_step` at each key location in the
-dataflow AFTER reading the code with `read_source_file`. This builds a
-structured trace that downstream validation can independently verify.
+dataflow AFTER reading the code with `read_source_file`. These streamed
+steps are echoed back and shown live for visibility — they are NOT stored
+on the finding.
+
+When you submit the finding you MUST pass the complete, authoritative trace
+as the `trace` argument to `record_finding`. That is what gets stored and
+independently re-verified. record_finding does NOT harvest your streamed
+steps — assemble the full trace explicitly.
 
 Workflow:
 1. read_source_file → find attacker-controlled entry point
-2. record_trace_step(file, line, function, code_snippet, note="ENTRY: ...")
+2. record_trace_step(file, line, function, code_snippet, note="ENTRY: ...")   # live only
 3. read_source_file → follow the tainted data through calls/assignments
-4. record_trace_step(..., note="PROPAGATION: tainted var X flows to ...")
-5. record_trace_step(..., note="CONDITION: check Y is bypassed because ...")
-6. record_trace_step(..., note="SINK: vulnerable operation on tainted data")
-7. record_finding(..., trace_summary="attacker-controlled X flows to Y unchecked")
+4. record_trace_step(..., note="PROPAGATION: tainted var X flows to ...")      # live only
+5. record_trace_step(..., note="SINK: vulnerable operation on tainted data")   # live only
+6. record_finding(
+     ...,
+     trace={
+       "steps": [
+         {"file": "...", "line": 12, "function": "...", "code_snippet": "...", "note": "ENTRY: ..."},
+         {"file": "...", "line": 40, "function": "...", "code_snippet": "...", "note": "PROPAGATION: ..."},
+         {"file": "...", "line": 88, "function": "...", "code_snippet": "...", "note": "SINK: ..."}
+       ],
+       "summary": "attacker-controlled X flows to Y unchecked"
+     }
+   )
 
 Rules:
-- code_snippet in each trace step MUST come from a read_source_file result.
-  Do not paraphrase or reconstruct from memory.
-- Note should describe: what role this step plays, what data is tainted,
+- code_snippet in each step MUST come from a read_source_file result. Do
+  not paraphrase or reconstruct from memory.
+- note should describe: what role this step plays, what data is tainted,
   and what assumptions must hold for execution to reach this point.
 - Assumptions must be consistent with your PoC inputs. If your trace says
   "field==2" but your PoC sets "field=1", you have a contradiction —
   resolve it before calling record_finding.
-- Record at least one ENTRY step and one SINK step before record_finding.
+- The `trace` passed to record_finding must contain at least one ENTRY step
+  and one SINK step.
 """
 
 
@@ -820,29 +836,44 @@ DEEP_TRACE_INSTRUCTIONS = """
 ## Building a Vulnerability Trace
 
 As you investigate, call `record_trace_step` at each key location in the
-dataflow AFTER reading the code with `read_file`. Each step you record is
-echoed back into this conversation, so the growing trace stays part of the
-message sequence you can reason over before submitting a finding. Downstream
-validation independently re-checks the assembled trace.
+dataflow AFTER reading the code with `read_file`. Each step is echoed back
+into this conversation and shown live, so the growing trace stays part of
+the message sequence you reason over. These streamed steps are for
+visibility only — they are NOT stored on the finding.
+
+When you submit the finding you MUST pass the complete, authoritative trace
+as the `trace` argument to `record_finding`. That is what gets stored and
+independently re-verified. record_finding does NOT harvest your streamed
+steps — assemble the full trace explicitly.
 
 Workflow:
 1. read_file → find attacker-controlled entry point
-2. record_trace_step(file, line, function, code_snippet, note="ENTRY: ...")
+2. record_trace_step(file, line, function, code_snippet, note="ENTRY: ...")   # live only
 3. read_file → follow the tainted data through calls/assignments
-4. record_trace_step(..., note="PROPAGATION: tainted var X flows to ...")
-5. record_trace_step(..., note="CONDITION: check Y is bypassed because ...")
-6. record_trace_step(..., note="SINK: vulnerable operation on tainted data")
-7. record_finding(..., trace_summary="attacker-controlled X flows to Y unchecked")
+4. record_trace_step(..., note="PROPAGATION: tainted var X flows to ...")      # live only
+5. record_trace_step(..., note="SINK: vulnerable operation on tainted data")   # live only
+6. record_finding(
+     ...,
+     trace={
+       "steps": [
+         {"file": "...", "line": 12, "function": "...", "code_snippet": "...", "note": "ENTRY: ..."},
+         {"file": "...", "line": 40, "function": "...", "code_snippet": "...", "note": "PROPAGATION: ..."},
+         {"file": "...", "line": 88, "function": "...", "code_snippet": "...", "note": "SINK: ..."}
+       ],
+       "summary": "attacker-controlled X flows to Y unchecked"
+     }
+   )
 
 Rules:
-- code_snippet in each trace step MUST come from a read_file result. Do not
+- code_snippet in each step MUST come from a read_file result. Do not
   paraphrase or reconstruct from memory.
-- Note should describe: what role this step plays, what data is tainted, and
+- note should describe: what role this step plays, what data is tainted, and
   what assumptions must hold for execution to reach this point.
 - Assumptions must be consistent with your PoC inputs. If your trace says
   "field==2" but your PoC sets "field=1", resolve the contradiction before
   calling record_finding.
-- Record at least one ENTRY step and one SINK step before record_finding.
+- The `trace` passed to record_finding must contain at least one ENTRY step
+  and one SINK step.
 """
 
 
@@ -1039,6 +1070,7 @@ def _build_unconstrained_prompt(
     entry_point: Any = None,
     seed_context: str | None = None,
     findings_pool: Any = None,
+    agent_mode: str = "constrained",
 ) -> str:
     """Build the unconstrained discovery prompt for any agent mode."""
     seed_parts: list[str] = []
@@ -1090,7 +1122,13 @@ def _build_unconstrained_prompt(
             prompt += "\n" + POOL_ACCESS_BLOCK.format(count=count)
 
     prompt += "\n" + SELF_CHECK
-    prompt += "\n" + TRACE_BUILDING_INSTRUCTIONS
+    # Deep mode reads via read_file/execute; the constrained instructions gate
+    # tracing on read_source_file (which deep hunters don't have), so route the
+    # deep path to the read_file-aware variant.
+    prompt += "\n" + (
+        DEEP_TRACE_INSTRUCTIONS if agent_mode == "deep"
+        else TRACE_BUILDING_INSTRUCTIONS
+    )
 
     return prompt
 
@@ -1790,6 +1828,7 @@ def build_hunter_agent(
             entry_point=entry_point,
             seed_context=seed_context,
             findings_pool=findings_pool,
+            agent_mode=agent_mode,
         )
         if agent_mode == "deep":
             tools = build_deep_agent_tools(ctx)

--- a/clearwing/sourcehunt/pool.py
+++ b/clearwing/sourcehunt/pool.py
@@ -485,12 +485,28 @@ class HunterPool:
                     budget_remaining=max(0.0, budget - spent),
                 ))
 
-                if result.status == "completed" and self.config.findings_pool is not None:
+                if result.status == "completed" and result.findings:
                     for f in cast(list[Finding], result.findings):
-                        try:
-                            await self.config.findings_pool.add(f)
-                        except Exception:
-                            logger.debug("findings_pool.add failed", exc_info=True)
+                        trace = f.get("vulnerability_trace")
+                        trace_chain = ""
+                        if trace and trace.get("steps"):
+                            trace_chain = " | " + " -> ".join(
+                                f"{s.get('file', '?')}:{s.get('function') or '?'}"
+                                for s in trace["steps"]
+                            )
+                        logger.info(
+                            "Finding: %s:%s [%s] %.40s%s",
+                            f.get("file", "?"),
+                            f.get("line_number", "?"),
+                            f.get("severity", "?"),
+                            f.get("description", "") or "",
+                            trace_chain,
+                        )
+                        if self.config.findings_pool is not None:
+                            try:
+                                await self.config.findings_pool.add(f)
+                            except Exception:
+                                logger.debug("findings_pool.add failed", exc_info=True)
 
                 if result.status == "completed":
                     next_band = promotion_decision(

--- a/clearwing/sourcehunt/pool.py
+++ b/clearwing/sourcehunt/pool.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
 from clearwing.core.event_payloads import HuntProgressPayload
-from clearwing.core.events import EventBus
+from clearwing.core.events import EventBus, EventType
 from clearwing.runners.parallel.executor import (
     TargetResult,
 )

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -504,6 +504,40 @@ class SourceHuntRunner:
             return "deep"
         return "standard"
 
+    def _global_spent_usd(self) -> float:
+        """Process-wide LLM spend so far — the figure the live panel shows.
+
+        native._record_call bumps a running total on every chat (independent
+        of --live), so this is always accurate. --budget only sizes the
+        per-file HunterPool; the subsystem hunt, variant loop, exploit and
+        elaboration phases each spend from their own budgets. Reading the
+        global total lets us treat --budget as a soft ceiling across ALL
+        phases instead of just the pool.
+        """
+        from clearwing.llm import native
+        from clearwing.observability.telemetry import CostTracker
+
+        stats = native.recent_call_stats()
+        totals = stats["totals"]
+        recent = stats["recent"]
+        model = recent[-1]["model"] if recent else None
+        if not model:
+            return 0.0
+        return CostTracker.estimate_cost(
+            totals.get("input_tokens") or 0,
+            totals.get("output_tokens") or 0,
+            model,
+            totals.get("cached_tokens") or 0,
+        )
+
+    def _over_budget(self) -> bool:
+        """True when --budget was set and process-wide spend has reached it.
+
+        Soft cap: phases already running can overshoot, but new discretionary
+        phases (and further per-finding iterations) are skipped once tripped.
+        """
+        return bool(self.budget_usd) and self._global_spent_usd() >= self.budget_usd
+
     @property
     def _shard_entry_points(self) -> bool:
         if self._shard_entry_points_override is not None:
@@ -833,7 +867,12 @@ class SourceHuntRunner:
             # 3.7. Subsystem hunt (spec 006)
             subsystems_hunted = 0
             subsystem_spent = 0.0
-            if self._enable_subsystem_hunt and hunter_llm is not None:
+            if self._enable_subsystem_hunt and hunter_llm is not None and self._over_budget():
+                logger.info(
+                    "Subsystem hunt skipped: budget $%.2f exhausted ($%.2f spent)",
+                    self.budget_usd, self._global_spent_usd(),
+                )
+            elif self._enable_subsystem_hunt and hunter_llm is not None:
                 from .subsystem import (
                     SubsystemHuntConfig,
                     SubsystemHuntRunner as SubsysRunner,
@@ -869,13 +908,27 @@ class SourceHuntRunner:
                             "  %s (%d files, priority=%.2f)",
                             st.name, len(st.files), st.priority,
                         )
+                    # Bound the whole subsystem phase to whatever --budget is
+                    # left, split evenly across targets, so 3 subsystems can't
+                    # each burn the internal $100 default ($300 total) past the
+                    # budget the user set. Falls back to the explicit override /
+                    # $100 default only when no --budget is in play.
+                    if self.budget_usd:
+                        remaining = max(0.0, self.budget_usd - self._global_spent_usd())
+                        per_subsystem_budget = remaining / len(subsystem_targets)
+                        if self._subsystem_budget_usd:
+                            per_subsystem_budget = min(
+                                per_subsystem_budget, self._subsystem_budget_usd,
+                            )
+                    else:
+                        per_subsystem_budget = self._subsystem_budget_usd or 100.0
                     subsys_runner = SubsysRunner(SubsystemHuntConfig(
                         subsystems=subsystem_targets,
                         repo_path=repo_path,
                         sandbox_factory=self.sandbox_factory,
                         llm=hunter_llm,
                         max_parallel=self._subsystem_max_parallel,
-                        budget_per_subsystem_usd=self._subsystem_budget_usd or 100.0,
+                        budget_per_subsystem_usd=per_subsystem_budget,
                         findings_pool=findings_pool,
                         session_id_prefix=f"{self._session_id}-subsys",
                         sandbox_manager=self._sandbox_manager,
@@ -969,7 +1022,7 @@ class SourceHuntRunner:
             #       match as a new suspicion-level finding linked back to the
             #       original. v0.3 scope: we surface the matches in the report;
             #       we don't re-spawn hunters on each match (that's a v1.0 pass).
-            if self.enable_variant_loop and verified:
+            if self.enable_variant_loop and verified and not self._over_budget():
                 variant_llm = self._get_native_client("verifier", self.verifier_llm)
                 if variant_llm is not None:
                     try:
@@ -1094,6 +1147,13 @@ class SourceHuntRunner:
                             ),
                         )
                         for finding in eligible:
+                            if self._over_budget():
+                                logger.info(
+                                    "Exploit phase halted: budget $%.2f "
+                                    "exhausted ($%.2f spent)",
+                                    self.budget_usd, self._global_spent_usd(),
+                                )
+                                break
                             try:
                                 exploit_result = await agentic.aattempt(finding)
                                 apply_exploiter_result(finding, exploit_result)
@@ -1126,7 +1186,7 @@ class SourceHuntRunner:
 
             # 5.25. Stage 1.5: Exploit elaboration (autonomous, opt-in).
             elaborated: list[Finding] = []
-            if self.enable_elaboration and exploited:
+            if self.enable_elaboration and exploited and not self._over_budget():
                 from .elaboration import (
                     ElaborationAgent,
                     prioritize_for_elaboration,
@@ -1153,6 +1213,13 @@ class SourceHuntRunner:
                             ),
                         )
                         for finding in targets:
+                            if self._over_budget():
+                                logger.info(
+                                    "Elaboration halted: budget $%.2f "
+                                    "exhausted ($%.2f spent)",
+                                    self.budget_usd, self._global_spent_usd(),
+                                )
+                                break
                             try:
                                 elab_result = await elab_agent.aattempt(finding)
                                 if elab_result.elaborated:
@@ -1170,7 +1237,7 @@ class SourceHuntRunner:
             # 5.5. v0.3: Auto-patch mode (opt-in).
             # The verify-by-recompile gate is MANDATORY — a patch is only marked
             # `validated` if we actually applied it, rebuilt, and re-ran the PoC.
-            if self.enable_auto_patch and verified:
+            if self.enable_auto_patch and verified and not self._over_budget():
                 patcher_llm = self._get_native_client("sourcehunt_exploit", self.exploiter_llm)
                 if patcher_llm is not None:
                     try:

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -944,6 +944,31 @@ def handle(cli, args):
         f"budget={_format_budget(args.budget)}[/bold blue]"
     )
 
+    # Wire EventBus → console/logger for live feedback.
+    # When --live is active, Rich Live owns the terminal — use logging so
+    # messages scroll above the pinned panel. Otherwise print directly.
+    from ...core.events import EventBus, EventType
+
+    bus = EventBus()
+    _live_logger = logging.getLogger("clearwing.sourcehunt.live")
+    _live_logger.setLevel(logging.INFO)
+
+    def _on_finding(data):
+        if not isinstance(data, dict):
+            return
+        sev = (data.get("severity") or "info").upper()
+        file = data.get("file", "?")
+        line = data.get("line_number", "?")
+        desc = (data.get("description") or "")[:120]
+        msg = f"FINDING [{sev}] {file}:{line} — {desc}"
+        _live_logger.info(msg)
+
+    def _on_tool_start(data):
+        pass  # reads are shown in the LLM activity panel only
+
+    bus.subscribe(EventType.FINDING_RECORDED, _on_finding)
+    bus.subscribe(EventType.TOOL_START, _on_tool_start)
+
     try:
         result = runner.run()
     except KeyboardInterrupt:
@@ -952,6 +977,9 @@ def handle(cli, args):
     except (ValueError, RuntimeError) as exc:
         cli.console.print(f"[red]Error: {exc}[/red]")
         sys.exit(1)
+    finally:
+        bus.unsubscribe(EventType.FINDING_RECORDED, _on_finding)
+        bus.unsubscribe(EventType.TOOL_START, _on_tool_start)
 
     # Summary
     cli.console.print("\n[bold]Sourcehunt complete[/bold]")

--- a/clearwing/ui/llm_activity.py
+++ b/clearwing/ui/llm_activity.py
@@ -11,6 +11,7 @@ same console.
 from __future__ import annotations
 
 import logging
+from collections import deque
 from collections.abc import Iterator
 from contextlib import contextmanager
 
@@ -25,6 +26,15 @@ from rich.text import Text
 
 from clearwing.llm import native
 from clearwing.observability.telemetry import CostTracker
+
+# Ring buffer of recent read_file / read_source_file events (populated by EventBus)
+_recent_reads: deque[dict] = deque(maxlen=8)
+# Ring buffer of recent hunter status messages (model narration)
+_recent_status: deque[dict] = deque(maxlen=6)
+# Ring buffer of recent trace steps
+_recent_traces: deque[dict] = deque(maxlen=6)
+# Ring buffer of recent execute commands
+_recent_execs: deque[dict] = deque(maxlen=6)
 
 
 def _fmt_tokens(n: int | None) -> str:
@@ -69,11 +79,18 @@ def _build_panel(budget_usd: float | None = None) -> Panel:
     model = recent[-1]["model"] if recent else None
     spent = _cost_usd(totals, model)
 
+    cached = totals.get("cached_tokens") or 0
+    total_in = totals["input_tokens"] or 0
+    cache_pct = (cached / total_in * 100) if total_in > 0 else 0
+
     header = Text.assemble(
         ("calls ", "dim"),
         (f"{totals['calls']}", "bold"),
         ("  ·  in ", "dim"),
-        (_fmt_tokens(totals["input_tokens"]), "bold cyan"),
+        (_fmt_tokens(total_in), "bold cyan"),
+        ("  ·  cached ", "dim"),
+        (_fmt_tokens(cached), "bold magenta"),
+        (f" ({cache_pct:.0f}%)", "dim magenta"),
         ("  ·  out ", "dim"),
         (_fmt_tokens(totals["output_tokens"]), "bold green"),
         ("  ·  ", "dim"),
@@ -100,20 +117,27 @@ def _build_panel(budget_usd: float | None = None) -> Panel:
     table.add_column("at", justify="right")
     table.add_column("time", justify="right")
     table.add_column("in", justify="right")
+    table.add_column("cache", justify="right")
     table.add_column("out", justify="right")
     table.add_column("$", justify="right")
     table.add_column("tc", justify="right")
     table.add_column("", justify="right")
 
     if not recent:
-        table.add_row("[dim]waiting for first call…[/dim]", "", "", "", "", "", "", "")
+        table.add_row("[dim]waiting for first call…[/dim]", "", "", "", "", "", "", "", "")
     for call in recent:
         cost = _fmt_usd(_cost_usd(call, call["model"])) if call["ok"] else ""
+        call_cached = call.get("cached_tokens") or 0
+        call_in = call.get("input_tokens") or 0
+        cache_str = _fmt_tokens(call_cached) if call_cached else ""
+        if call_cached and call_in:
+            cache_str += f" ({call_cached * 100 // call_in}%)"
         table.add_row(
             call["model"],
             call.get("ts", ""),
             _fmt_ms(call["elapsed_ms"]),
             _fmt_tokens(call["input_tokens"]),
+            cache_str,
             _fmt_tokens(call["output_tokens"]),
             cost,
             str(call["tool_calls"]),
@@ -122,6 +146,78 @@ def _build_panel(budget_usd: float | None = None) -> Panel:
 
     renderables.append(Rule(style="dim"))
     renderables.append(table)
+
+    if _recent_reads:
+        renderables.append(Rule(style="dim"))
+        reads_table = Table(
+            box=None, show_header=True, header_style="dim", pad_edge=False, padding=(0, 2),
+        )
+        reads_table.add_column("hunter")
+        reads_table.add_column("sandbox")
+        reads_table.add_column("file")
+        reads_table.add_column("lines", justify="right")
+        for rd in _recent_reads:
+            hunter = rd.get("hunter_target", "?")
+            sandbox = rd.get("sandbox_id") or ""
+            file = rd.get("file", "?")
+            start = rd.get("start_line", 1)
+            end = rd.get("end_line", -1)
+            lines = f"{start}-{end}" if end != -1 else f"{start}+"
+            reads_table.add_row(
+                f"[dim]{hunter}[/dim]",
+                f"[dim yellow]{sandbox}[/dim yellow]",
+                file,
+                lines,
+            )
+        renderables.append(reads_table)
+
+    if _recent_execs:
+        renderables.append(Rule(style="dim"))
+        for ex in _recent_execs:
+            hunter = ex.get("hunter_target", "?")
+            sandbox = ex.get("sandbox_id") or "?"
+            cmd = (ex.get("command") or "")[:100]
+            renderables.append(
+                Text.assemble(
+                    (f"[{hunter}] ", "dim cyan"),
+                    (f"{sandbox} ", "dim yellow"),
+                    (f"$ {cmd}", "bold"),
+                )
+            )
+
+    if _recent_traces:
+        renderables.append(Rule(style="dim"))
+        for tr in _recent_traces:
+            hunter = tr.get("hunter_target", "?")
+            file = tr.get("file", "?")
+            line = tr.get("line", "?")
+            func = tr.get("function") or "?"
+            note = (tr.get("note") or "")[:80]
+            n = tr.get("step_number", "?")
+            renderables.append(
+                Text.assemble(
+                    (f"[{hunter}] ", "dim cyan"),
+                    (f"trace#{n} ", "bold magenta"),
+                    (f"{file}:{line} ", ""),
+                    (f"({func}) ", "dim"),
+                    (note, "italic"),
+                )
+            )
+
+    if _recent_status:
+        renderables.append(Rule(style="dim"))
+        for st in _recent_status:
+            hunter = st.get("hunter_target", "?")
+            text = st.get("text", "")
+            # Truncate to first newline or 120 chars
+            first_line = text.split("\n", 1)[0][:120]
+            if first_line:
+                renderables.append(
+                    Text.assemble(
+                        (f"[{hunter}] ", "dim cyan"),
+                        (first_line, ""),
+                    )
+                )
 
     return Panel(
         Group(*renderables),
@@ -159,6 +255,36 @@ def llm_activity_panel(
         yield
         return
 
+    from clearwing.core.events import EventBus, EventType
+
+    bus = EventBus()
+
+    def _on_read(data):
+        if not isinstance(data, dict):
+            return
+        if data.get("tool_name") in ("read_source_file", "read_file"):
+            _recent_reads.append(data)
+        elif data.get("tool_name") == "execute":
+            _recent_execs.append(data)
+        else:
+            tool = data.get("tool_name") or data.get("tool", "?")
+            hunter = data.get("hunter_target") or data.get("args", {}).get("hunter_target", "")
+            logging.getLogger("clearwing.sourcehunt.live").info(
+                "[%s] tool: %s", hunter or "agent", tool,
+            )
+
+    def _on_status(data):
+        if isinstance(data, dict) and data.get("text"):
+            _recent_status.append(data)
+
+    def _on_trace(data):
+        if isinstance(data, dict):
+            _recent_traces.append(data)
+
+    bus.subscribe(EventType.TOOL_START, _on_read)
+    bus.subscribe(EventType.HUNTER_STATUS, _on_status)
+    bus.subscribe(EventType.TRACE_STEP, _on_trace)
+
     console = console or Console(stderr=True)
 
     root = logging.getLogger()
@@ -179,5 +305,12 @@ def llm_activity_panel(
         with live_display:
             yield
     finally:
+        bus.unsubscribe(EventType.TOOL_START, _on_read)
+        bus.unsubscribe(EventType.HUNTER_STATUS, _on_status)
+        bus.unsubscribe(EventType.TRACE_STEP, _on_trace)
+        _recent_reads.clear()
+        _recent_status.clear()
+        _recent_traces.clear()
+        _recent_execs.clear()
         root.handlers = saved_handlers
         root.setLevel(saved_level)

--- a/clearwing/ui/tui/app.py
+++ b/clearwing/ui/tui/app.py
@@ -118,6 +118,7 @@ class ClearwingApp(App):
         bus.subscribe(EventType.DISCLOSURE_UPDATE, self._on_bus_disclosure_update)
         bus.subscribe(EventType.BENCHMARK_PROGRESS, self._on_bus_benchmark_progress)
         bus.subscribe(EventType.EVAL_PROGRESS, self._on_bus_eval_progress)
+        bus.subscribe(EventType.FINDING_RECORDED, self._on_bus_finding_recorded)
 
     def on_unmount(self) -> None:
         """Unsubscribe from EventBus before the app tears down."""
@@ -137,6 +138,7 @@ class ClearwingApp(App):
         bus.unsubscribe(EventType.DISCLOSURE_UPDATE, self._on_bus_disclosure_update)
         bus.unsubscribe(EventType.BENCHMARK_PROGRESS, self._on_bus_benchmark_progress)
         bus.unsubscribe(EventType.EVAL_PROGRESS, self._on_bus_eval_progress)
+        bus.unsubscribe(EventType.FINDING_RECORDED, self._on_bus_finding_recorded)
 
     # ------------------------------------------------------------------
     # Event handlers — bridge from background threads into the TUI
@@ -191,6 +193,9 @@ class ClearwingApp(App):
 
     def _on_bus_eval_progress(self, data):
         self._safe_call_from_thread(self._handle_eval_progress, data)
+
+    def _on_bus_finding_recorded(self, data):
+        self._safe_call_from_thread(self._handle_finding_recorded, data)
 
     # ------------------------------------------------------------------
     # Actual UI update methods (run on the Textual event loop thread)
@@ -270,6 +275,9 @@ class ClearwingApp(App):
 
     def _handle_eval_progress(self, data):
         self.query_one(ProgressPanel).update_eval(data)
+
+    def _handle_finding_recorded(self, data):
+        self.query_one(ActivityFeed).add_finding(data)
 
     # ------------------------------------------------------------------
     # Agent loop — runs as a Textual worker in the background

--- a/clearwing/ui/tui/components/activity_feed.py
+++ b/clearwing/ui/tui/components/activity_feed.py
@@ -29,7 +29,16 @@ class ActivityFeed(RichLog):
 
     def add_tool_start(self, tool_name: str, data: dict) -> None:
         """Add a tool-start indicator to the feed."""
-        self.write(Text(f">>> Running: {tool_name}", style="dim cyan"))
+        if tool_name == "read_source_file" and isinstance(data, dict):
+            file = data.get("file", "?")
+            start = data.get("start_line", 1)
+            end = data.get("end_line", -1)
+            range_str = f":{start}-{end}" if end != -1 else f":{start}"
+            hunter = data.get("hunter_target", "")
+            prefix = f"[{hunter}] " if hunter else ""
+            self.write(Text(f"  {prefix}reading {file}{range_str}", style="dim cyan"))
+        else:
+            self.write(Text(f">>> Running: {tool_name}", style="dim cyan"))
 
     def add_tool_result(self, tool_name: str, data: dict) -> None:
         """Add a rendered tool result to the feed."""
@@ -48,6 +57,26 @@ class ActivityFeed(RichLog):
             f"[VALIDATOR] {fid}: {axes_str} \u2192 {outcome} (severity={sev})",
             style="bold cyan" if payload.get("advance") else "dim yellow",
         ))
+
+    def add_finding(self, finding: dict) -> None:
+        """Add a finding banner to the feed."""
+        severity = finding.get("severity", "info")
+        sev_style = {
+            "critical": "bold red",
+            "high": "red",
+            "medium": "yellow",
+            "low": "cyan",
+            "info": "dim white",
+        }.get(severity, "white")
+        file = finding.get("file", "?")
+        line = finding.get("line_number", "?")
+        desc = (finding.get("description") or "")[:120]
+        panel = Panel(
+            Text(f"{file}:{line}\n{desc}", style=sev_style),
+            title=f"FINDING [{severity.upper()}]",
+            border_style=sev_style,
+        )
+        self.write(panel)
 
     def add_flag(self, flag: str, context: str) -> None:
         """Add a prominent flag-found banner to the feed."""

--- a/evaluations/ffmpeg.sh
+++ b/evaluations/ffmpeg.sh
@@ -16,11 +16,13 @@ CASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUN_HOME="$CASE_DIR/.clearwing-home-$$"
 RUN_TRACE="$CASE_DIR/trajectories-$$"
 
+TARGET="../FFmpeg/"
+
 mkdir -p "$RUN_HOME" "$RUN_TRACE"
 
 CLEARWING_HOME="$RUN_HOME" \
 CLEARWING_SOURCEHUNT_TRACE_DIR="$RUN_TRACE" \
-clearwing sourcehunt ./working-directory \
+clearwing sourcehunt $TARGET \
     --base-url "$BASE_URL" \
     --api-key "$API_KEY" \
     --model "$1" \

--- a/evaluations/ffmpeg.sh
+++ b/evaluations/ffmpeg.sh
@@ -31,7 +31,13 @@ clearwing sourcehunt ./working-directory \
     --elaborate-pipeline \
     --exploit \
     --campaign-hint "integer overflows and type mismatches in media codec parsers" \
+    --subsystem libavcodec \
+    --subsystem libavutil \
+    --subsystem libavformat \
     --no-mechanism-memory \
+    --budget 50 \
+    --tier-split 60/35/5 \
+    --gvisor \
     --max-parallel 8 \
     --format json \
     --live \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,3 +203,8 @@ module = [
 ]
 disallow_untyped_defs = true
 warn_unused_ignores = true
+
+[dependency-groups]
+dev = [
+    "ruff>=0.15.10",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,13 @@ dependencies = [
     "tree-sitter-javascript>=0.21.0",
     "tree-sitter-go>=0.21.0",
     "tree-sitter-rust>=0.21.0",
+    "uv>=0.11.26",
+    "litellm>=1.90.2",
+    "instructor>=1.15.4",
 ]
 
 [project.optional-dependencies]
+python-llm = ["litellm>=1.50", "instructor>=1.4"]
 metasploit = ["pymetasploit3>=1.0.0"]
 browser = ["playwright>=1.40.0"]
 vector = [

--- a/tests/test_sourcehunt_hunter.py
+++ b/tests/test_sourcehunt_hunter.py
@@ -674,6 +674,13 @@ class TestRecordFinding:
                 "description": "memcpy with unchecked length",
                 "code_snippet": "memcpy(frame, input, input_len);",
                 "evidence_level": "static_corroboration",
+                "trace": {
+                    "steps": [
+                        {"file": "src/codec_a.c", "line": 3, "note": "ENTRY: input"},
+                        {"file": "src/codec_a.c", "line": 9, "note": "SINK: memcpy"},
+                    ],
+                    "summary": "input flows to memcpy unchecked",
+                },
             }
         )
         assert "Finding recorded" in msg
@@ -687,6 +694,8 @@ class TestRecordFinding:
         assert f["seeded_from_crash"] is False
         assert f["hunter_session_id"] == "sess-123"
         assert f["id"].startswith("hunter-")
+        assert f["vulnerability_trace"]["summary"] == "input flows to memcpy unchecked"
+        assert len(f["vulnerability_trace"]["steps"]) == 2
 
     def test_seeded_from_crash_flag(self):
         ctx = HunterContext(
@@ -704,10 +713,57 @@ class TestRecordFinding:
                 "severity": "high",
                 "cwe": "CWE-416",
                 "description": "y",
+                "trace": {"steps": [{"file": "x.c", "line": 1, "note": "SINK: uaf"}]},
             }
         )
         assert ctx.findings[0]["seeded_from_crash"] is True
         assert ctx.findings[0]["discovered_by"] == "hunter:memory_safety"
+
+    def test_trace_required_and_authoritative(self):
+        """record_finding rejects a missing trace and persists the explicit
+        one; steps streamed via record_trace_step are NOT harvested."""
+        ctx = HunterContext(
+            repo_path=str(FIXTURE_C_PROPAGATION),
+            specialist="general",
+        )
+        tools = build_hunter_tools(ctx)
+        record = next(t for t in tools if t.name == "record_finding")
+        step = next(t for t in tools if t.name == "record_trace_step")
+
+        base = {
+            "file": "x.c",
+            "line_number": 1,
+            "finding_type": "oob",
+            "severity": "high",
+            "cwe": "CWE-787",
+            "description": "z",
+        }
+
+        # Missing trace -> instructive error, nothing recorded.
+        msg = record.invoke(dict(base))
+        assert msg.startswith("ERROR")
+        assert ctx.findings == []
+
+        # A streamed step fills the live accumulator but is not persisted.
+        # (constrained mode gates record_trace_step on files_read.)
+        ctx.files_read.add("x.c")
+        step.invoke({"file": "x.c", "line": 1, "note": "ENTRY: streamed"})
+        assert len(ctx.trace_steps) == 1
+
+        # Explicit trace is authoritative; streamed steps are discarded.
+        record.invoke(
+            {
+                **base,
+                "trace": {
+                    "steps": [{"file": "x.c", "line": 42, "note": "SINK: explicit"}],
+                    "summary": "explicit path",
+                },
+            }
+        )
+        vt = ctx.findings[0]["vulnerability_trace"]
+        assert len(vt["steps"]) == 1
+        assert vt["steps"][0]["line"] == 42
+        assert ctx.trace_steps == []  # accumulator reset
 
 
 # --- Sanitizer / rg parsing helpers -----------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -714,6 +714,11 @@ vector = [
     { name = "sentence-transformers" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.8.0" },
@@ -766,6 +771,9 @@ requires-dist = [
     { name = "websockets", specifier = ">=11.0" },
 ]
 provides-extras = ["python-llm", "metasploit", "browser", "vector", "dev", "docs", "all"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.15.10" }]
 
 [[package]]
 name = "click"

--- a/uv.lock
+++ b/uv.lock
@@ -12,9 +12,6 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'linux'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -642,8 +639,10 @@ dependencies = [
     { name = "docker" },
     { name = "fastapi" },
     { name = "genai-pyo3" },
+    { name = "instructor" },
     { name = "jinja2" },
     { name = "libpnet-pyo3" },
+    { name = "litellm" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -664,6 +663,7 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "tree-sitter-python" },
     { name = "tree-sitter-rust" },
+    { name = "uv" },
     { name = "uvicorn" },
     { name = "websockets" },
 ]
@@ -706,6 +706,10 @@ docs = [
 metasploit = [
     { name = "pymetasploit3" },
 ]
+python-llm = [
+    { name = "instructor" },
+    { name = "litellm" },
+]
 vector = [
     { name = "sentence-transformers" },
 ]
@@ -722,8 +726,12 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "genai-pyo3", specifier = ">=0.7.0b10.dev2" },
+    { name = "instructor", specifier = ">=1.15.4" },
+    { name = "instructor", marker = "extra == 'python-llm'", specifier = ">=1.4" },
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "libpnet-pyo3", specifier = ">=0.1.2" },
+    { name = "litellm", specifier = ">=1.90.2" },
+    { name = "litellm", marker = "extra == 'python-llm'", specifier = ">=1.50" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.4.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
@@ -753,10 +761,11 @@ requires-dist = [
     { name = "tree-sitter-python", specifier = ">=0.21.0" },
     { name = "tree-sitter-rust", specifier = ">=0.21.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "uv", specifier = ">=0.11.26" },
     { name = "uvicorn", specifier = ">=0.20.0" },
     { name = "websockets", specifier = ">=11.0" },
 ]
-provides-extras = ["metasploit", "browser", "vector", "dev", "docs", "all"]
+provides-extras = ["python-llm", "metasploit", "browser", "vector", "dev", "docs", "all"]
 
 [[package]]
 name = "click"
@@ -922,6 +931,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -933,6 +951,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -979,6 +1006,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/e6/7adb4c5fa231e82c35b8f5741a9f2d055f520c29af5546fd70d3e8e1cd2e/fastapi-0.135.3.tar.gz", hash = "sha256:bd6d7caf1a2bdd8d676843cdcd2287729572a1ef524fc4d65c17ae002a1be654", size = 396524, upload-time = "2026-04-01T16:23:58.188Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/a4/5caa2de7f917a04ada20018eccf60d6cc6145b0199d55ca3711b0fc08312/fastapi-0.135.3-py3-none-any.whl", hash = "sha256:9b0f590c813acd13d0ab43dd8494138eb58e484bfac405db1f3187cfc5810d98", size = 117734, upload-time = "2026-04-01T16:23:59.328Z" },
+]
+
+[[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/b2/731a6696e37cd20eed353f69a09f37a984a43c9713764ee3f7ad5f57f7f9/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6e6243d40f6c793c3e2ee14c13769e341b90be5ef0c23c82fa6515a96145181a", size = 516760, upload-time = "2025-10-19T22:25:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/79/c73c47be2a3b8734d16e628982653517f80bbe0570e27185d91af6096507/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:13ec4f2c3b04271f62be2e1ce7e95ad2dd1cf97e94503a3760db739afbd48f00", size = 264748, upload-time = "2025-10-19T22:41:52.873Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c5/84c1eea05977c8ba5173555b0133e3558dc628bcf868d6bf1689ff14aedc/fastuuid-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b2fdd48b5e4236df145a149d7125badb28e0a383372add3fbaac9a6b7a394470", size = 254537, upload-time = "2025-10-19T22:33:55.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/23/4e362367b7fa17dbed646922f216b9921efb486e7abe02147e4b917359f8/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f74631b8322d2780ebcf2d2d75d58045c3e9378625ec51865fe0b5620800c39d", size = 278994, upload-time = "2025-10-19T22:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/72/3985be633b5a428e9eaec4287ed4b873b7c4c53a9639a8b416637223c4cd/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83cffc144dc93eb604b87b179837f2ce2af44871a7b323f2bfed40e8acb40ba8", size = 280003, upload-time = "2025-10-19T22:23:45.415Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/6d/6ef192a6df34e2266d5c9deb39cd3eea986df650cbcfeaf171aa52a059c3/fastuuid-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a771f135ab4523eb786e95493803942a5d1fc1610915f131b363f55af53b219", size = 303583, upload-time = "2025-10-19T22:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/11/8a2ea753c68d4fece29d5d7c6f3f903948cc6e82d1823bc9f7f7c0355db3/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4edc56b877d960b4eda2c4232f953a61490c3134da94f3c28af129fb9c62a4f6", size = 460955, upload-time = "2025-10-19T22:36:25.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/42/7a32c93b6ce12642d9a152ee4753a078f372c9ebb893bc489d838dd4afd5/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bcc96ee819c282e7c09b2eed2b9bd13084e3b749fdb2faf58c318d498df2efbe", size = 480763, upload-time = "2025-10-19T22:24:28.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e9/a5f6f686b46e3ed4ed3b93770111c233baac87dd6586a411b4988018ef1d/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7a3c0bca61eacc1843ea97b288d6789fbad7400d16db24e36a66c28c268cfe3d", size = 452613, upload-time = "2025-10-19T22:25:06.827Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c9/18abc73c9c5b7fc0e476c1733b678783b2e8a35b0be9babd423571d44e98/fastuuid-0.14.0-cp310-cp310-win32.whl", hash = "sha256:7f2f3efade4937fae4e77efae1af571902263de7b78a0aee1a1653795a093b2a", size = 155045, upload-time = "2025-10-19T22:28:32.732Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8a/d9e33f4eb4d4f6d9f2c5c7d7e96b5cdbb535c93f3b1ad6acce97ee9d4bf8/fastuuid-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:ae64ba730d179f439b0736208b4c279b8bc9c089b102aec23f86512ea458c8a4", size = 156122, upload-time = "2025-10-19T22:23:15.59Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
+    { url = "https://files.pythonhosted.org/packages/59/19/2fc58a1446e4d72b655648eb0879b04e88ed6fa70d474efcf550f640f6ec/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7", size = 264569, upload-time = "2025-10-19T22:25:50.977Z" },
+    { url = "https://files.pythonhosted.org/packages/78/29/3c74756e5b02c40cfcc8b1d8b5bac4edbd532b55917a6bcc9113550e99d1/fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1", size = 254366, upload-time = "2025-10-19T22:29:49.166Z" },
+    { url = "https://files.pythonhosted.org/packages/52/96/d761da3fccfa84f0f353ce6e3eb8b7f76b3aa21fd25e1b00a19f9c80a063/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc", size = 278978, upload-time = "2025-10-19T22:35:41.306Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/f84c90167cc7765cb82b3ff7808057608b21c14a38531845d933a4637307/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8", size = 279692, upload-time = "2025-10-19T22:25:36.997Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7b/4bacd03897b88c12348e7bd77943bac32ccf80ff98100598fcff74f75f2e/fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7", size = 303384, upload-time = "2025-10-19T22:29:46.578Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a2/584f2c29641df8bd810d00c1f21d408c12e9ad0c0dafdb8b7b29e5ddf787/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73", size = 460921, upload-time = "2025-10-19T22:36:42.006Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/c6b77443bb7764c760e211002c8638c0c7cce11cb584927e723215ba1398/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36", size = 480575, upload-time = "2025-10-19T22:28:18.975Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/87/93f553111b33f9bb83145be12868c3c475bf8ea87c107063d01377cc0e8e/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94", size = 452317, upload-time = "2025-10-19T22:25:32.75Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8c/a04d486ca55b5abb7eaa65b39df8d891b7b1635b22db2163734dc273579a/fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24", size = 154804, upload-time = "2025-10-19T22:24:15.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b2/2d40bf00820de94b9280366a122cbaa60090c8cf59e89ac3938cf5d75895/fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa", size = 156099, upload-time = "2025-10-19T22:24:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
 ]
 
 [[package]]
@@ -1531,6 +1621,28 @@ wheels = [
 ]
 
 [[package]]
+name = "instructor"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "docstring-parser" },
+    { name = "jinja2" },
+    { name = "jiter" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "tenacity" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/24/f6b28e83b3194c6223ed7c6eed5724687f6ecd378ec2ff24044f0cbf1f09/instructor-1.15.4.tar.gz", hash = "sha256:ea2280c3678d0f6891c4d826104f95624b680e69877113a6345b1d7c9027ba0f", size = 70049678, upload-time = "2026-06-28T07:36:43.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/8d/f668a30fff4d25b36533355e23aeb0b5724df4628eb974124ed64b7bcf8d/instructor-1.15.4-py3-none-any.whl", hash = "sha256:00e0ecda80fd9746fb6d082d3f9641e193adb1d8849f0775f91519a82aeff968", size = 252522, upload-time = "2026-06-28T07:36:36.863Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1585,6 +1697,109 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/2e/a9959997739c403378d0a4a3a1c4ed80b60aeace216c4d37b303a9fc60a4/jiter-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:02f36a5c700f105ac04a6556fe664a59037a2c200db3b7e88784fac2ddf02531", size = 316927, upload-time = "2026-04-10T14:25:40.753Z" },
+    { url = "https://files.pythonhosted.org/packages/27/72/b6de8a531e0adbadd839bec301165feb1fccf00e9ff55073ba2dd20f0043/jiter-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41eab6c09ceffb6f0fe25e214b3068146edb1eda3649ca2aee2a061029c7ba2e", size = 321181, upload-time = "2026-04-10T14:25:42.621Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d8/2040b9efa13c917f855c40890ae4119fe02c25b7c7677d5b4fa820a851fc/jiter-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5cf4d4c109641f9cfaf4a7b6aebd51654e405cd00fa9ebbf87163b8b97b325aa", size = 347387, upload-time = "2026-04-10T14:25:44.212Z" },
+    { url = "https://files.pythonhosted.org/packages/49/62/655c0ad5ce6a8e90f9068c175b8a236877d753e460762b3183c136db1c5b/jiter-0.14.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b80c7b41a628e6be2213ad0ece763c5f88aa5ee003fa394d58acaaee1f4b8342", size = 373083, upload-time = "2026-04-10T14:25:45.55Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/66/549c40fa068f08710b7570869c306a051eb67a29758bd64f4114f730554c/jiter-0.14.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fb3dbf7cc0d4dbe73cce307ebe7eefa7f73a7d3d854dd119ea0c243f03e40927", size = 463639, upload-time = "2026-04-10T14:25:47.452Z" },
+    { url = "https://files.pythonhosted.org/packages/25/2f/97a32a05fed14ed58a18e181fdfb619e05163f3726b54ee6080ec0539c09/jiter-0.14.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7054adcdeb06b46efd17b5734f75817a44a2d06d3748e36c3a023a1bb52af9ec", size = 380735, upload-time = "2026-04-10T14:25:49.305Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/3b/4347e1d6c2a973d653bbb7a2d671a2d2426e54b52ba735b8ff0d0a29b75c/jiter-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d597cd1bf6790376f3fffc7c708766e57301d99a19314824ea0ccc9c3c70e1e2", size = 358632, upload-time = "2026-04-10T14:25:50.931Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/24/ca452fbf2ea33548ed30ce68a39a50442d3f7c9bf0704a7af958a930c057/jiter-0.14.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:df63a14878da754427926281626fd3ee249424a186e25a274e78176d42945264", size = 359969, upload-time = "2026-04-10T14:25:52.381Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a3/94470a0d199287caabeb4da2bb2ae5f6d17f3cf05dfc975d7cb064d58e0f/jiter-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4ea73187627bcc5810e085df715e8a99da8bdfd96a7eb36b4b4df700ba6d4c9c", size = 397529, upload-time = "2026-04-10T14:25:53.801Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/71/6768edc09d7c45c39f093feb3de105fa718a3e982b5208b8a2ed6382b44b/jiter-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9f541eaf7bb8382367a1a23d6fc3d6aad57f8dd8c18c3c17f838bee20f217220", size = 522342, upload-time = "2026-04-10T14:25:55.396Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6b/5c2e17559a0f4e96e934479f7137df46c939e983fa05244e674815befb73/jiter-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:107465250de4fce00fdb47166bcd51df8e634e049541174fe3c71848e44f52ce", size = 556784, upload-time = "2026-04-10T14:25:56.927Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/83/c25f3556a60fc74d11199100f1b6cc0c006b815c8494dea8ca16fe398732/jiter-0.14.0-cp310-cp310-win32.whl", hash = "sha256:ffb2a08a406465bb076b7cc1df41d833106d3cf7905076cc73f0cb90078c7d10", size = 208439, upload-time = "2026-04-10T14:25:58.796Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/99/781a1b413f0989b7f2ea203b094b331685f1a35e52e0a45e5d000ecaab27/jiter-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:cb8b682d10cb0cce7ff4c1af7244af7022c9b01ae16d46c357bdd0df13afb25d", size = 204558, upload-time = "2026-04-10T14:26:00.208Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1f/198ae537fccb7080a0ed655eb56abf64a92f79489dfbf79f40fa34225bcd/jiter-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7e791e247b8044512e070bd1f3633dc08350d32776d2d6e7473309d0edf256a2", size = 316896, upload-time = "2026-04-10T14:26:01.986Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/34/da67cff3fce964a36d03c3e365fb0f8726ade2a6cfd4d3c70107e216ead6/jiter-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:71527ce13fd5a0c4e40ad37331f8c547177dbb2dd0a93e5278b6a5eecf748804", size = 321085, upload-time = "2026-04-10T14:26:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/36/4c72e67180d4e71a4f5dcf7886d0840e83c49ab11788172177a77570326e/jiter-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02c4a7ab56f746014874f2c525584c0daca1dec37f66fd707ecef3b7e5c2228c", size = 347393, upload-time = "2026-04-10T14:26:05.314Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/db/9b39e09ceafa9878235c0fc29e3e3f9b12a4c6a98ea3085b998cadf3accc/jiter-0.14.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:376e9dafff914253bb9d46cdc5f7965607fbe7feb0a491c34e35f92b2770702e", size = 372937, upload-time = "2026-04-10T14:26:06.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/96/0dcba1d7a82c1b720774b48ef239376addbaf30df24c34742ac4a57b67b2/jiter-0.14.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:23ad2a7a9da1935575c820428dd8d2490ce4d23189691ce33da1fc0a58e14e1c", size = 463646, upload-time = "2026-04-10T14:26:08.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e3/f61b71543e746e6b8b805e7755814fc242715c16f1dba58e1cbccb8032c2/jiter-0.14.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:54b3ddf5786bc7732d293bba3411ac637ecfa200a39983166d1df86a59a43c9f", size = 380225, upload-time = "2026-04-10T14:26:10.161Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/5e/0ddeb7096aca099114abe36c4921016e8d251e6f35f5890240b31f1f60ae/jiter-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c001d5a646c2a50dc055dd526dad5d5245969e8234d2b1131d0451e81f3a373", size = 358682, upload-time = "2026-04-10T14:26:11.574Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/fe0c46cd7fda9cad8f1ff9ad217dc61f1e4280b21052ec6dfe88c1446ef2/jiter-0.14.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:834bb5bdabca2e91592a03d373838a8d0a1b8bbde7077ae6913fd2fc51812d00", size = 359973, upload-time = "2026-04-10T14:26:13.316Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/21/f5317f91729b501019184771c80d60abd89907009e7bfa6c7e348c5bdd44/jiter-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4e9178be60e229b1b2b0710f61b9e24d1f4f8556985a83ff4c4f95920eea7314", size = 397568, upload-time = "2026-04-10T14:26:15.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/79d8f33fb2bf168db0df5c9cd16fe440a8ada57e929d3677b22712c2568f/jiter-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a7e4ccff04ec03614e62c613e976a3a5860dc9714ce8266f44328bdc8b1cab2c", size = 522535, upload-time = "2026-04-10T14:26:16.956Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/00/d1e3ff3d2a465e67f08507d74bafb2dcd29eba91dc939820e39e8dea38b8/jiter-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:69539d936fb5d55caf6ecd33e2e884de083ff0ea28579780d56c4403094bb8d9", size = 556709, upload-time = "2026-04-10T14:26:18.5Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/bbb2189f62ace8d95e869aa4c84c9946616f301e2d02895a6f20dcc3bba3/jiter-0.14.0-cp311-cp311-win32.whl", hash = "sha256:4927d09b3e572787cc5e0a5318601448e1ab9391bcef95677f5840c2d00eaa6d", size = 208660, upload-time = "2026-04-10T14:26:20.511Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/86/c500b53dcbf08575f5963e536ebd757a1f7c568272ba5d180b212c9a87fb/jiter-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:42d6ed359ac49eb922fdd565f209c57340aa06d589c84c8413e42a0f9ae1b842", size = 204659, upload-time = "2026-04-10T14:26:22.152Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4a/a676249049d42cb29bef82233e4fe0524d414cbe3606c7a4b311193c2f77/jiter-0.14.0-cp311-cp311-win_arm64.whl", hash = "sha256:6dd689f5f4a5a33747b28686e051095beb214fe28cfda5e9fe58a295a788f593", size = 194772, upload-time = "2026-04-10T14:26:23.458Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/7390a418f10897da93b158f2d5a8bd0bcd73a0f9ec3bb36917085bb759ef/jiter-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:2fb2ce3a7bc331256dfb14cefc34832366bb28a9aca81deaf43bbf2a5659e607", size = 316295, upload-time = "2026-04-10T14:26:24.887Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a0/5854ac00ff63551c52c6c89534ec6aba4b93474e7924d64e860b1c94165b/jiter-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5252a7ca23785cef5d02d4ece6077a1b556a410c591b379f82091c3001e14844", size = 315898, upload-time = "2026-04-10T14:26:26.601Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a1/4f44832650a16b18e8391f1bf1d6ca4909bc738351826bcc198bba4357f4/jiter-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c409578cbd77c338975670ada777add4efd53379667edf0aceea730cabede6fb", size = 343730, upload-time = "2026-04-10T14:26:28.326Z" },
+    { url = "https://files.pythonhosted.org/packages/48/64/a329e9d469f86307203594b1707e11ae51c3348d03bfd514a5f997870012/jiter-0.14.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7ede4331a1899d604463369c730dbb961ffdc5312bc7f16c41c2896415b1304a", size = 370102, upload-time = "2026-04-10T14:26:30.089Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c1/5e3dfc59635aa4d4c7bd20a820ac1d09b8ed851568356802cf1c08edb3cf/jiter-0.14.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:92cd8b6025981a041f5310430310b55b25ca593972c16407af8837d3d7d2ca01", size = 461335, upload-time = "2026-04-10T14:26:31.911Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/dd157009dbc058f7b00108f545ccb72a2d56461395c4fc7b9cfdccb00af4/jiter-0.14.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:351bf6eda4e3a7ceb876377840c702e9a3e4ecc4624dbfb2d6463c67ae52637d", size = 378536, upload-time = "2026-04-10T14:26:33.595Z" },
+    { url = "https://files.pythonhosted.org/packages/91/78/256013667b7c10b8834f8e6e54cd3e562d4c6e34227a1596addccc05e38c/jiter-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1dcfbeb93d9ecd9ca128bbf8910120367777973fa193fb9a39c31237d8df165", size = 353859, upload-time = "2026-04-10T14:26:35.098Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d9/137d65ade9093a409fe80955ce60b12bb753722c986467aeda47faf450ad/jiter-0.14.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:ae039aaef8de3f8157ecc1fdd4d85043ac4f57538c245a0afaecb8321ec951c3", size = 357626, upload-time = "2026-04-10T14:26:36.685Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/48/76750835b87029342727c1a268bea8878ab988caf81ee4e7b880900eeb5a/jiter-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7d9d51eb96c82a9652933bd769fe6de66877d6eb2b2440e281f2938c51b5643e", size = 393172, upload-time = "2026-04-10T14:26:38.097Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/60/456c4e81d5c8045279aefe60e9e483be08793828800a4e64add8fdde7f2a/jiter-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d824ca4148b705970bf4e120924a212fdfca9859a73e42bd7889a63a4ea6bb98", size = 520300, upload-time = "2026-04-10T14:26:39.532Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/9f/2020e0984c235f678dced38fe4eec3058cf528e6af36ebf969b410305941/jiter-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ff3a6465b3a0f54b1a430f45c3c0ba7d61ceb45cbc3e33f9e1a7f638d690baf3", size = 553059, upload-time = "2026-04-10T14:26:40.991Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/32/e2d298e1a22a4bbe6062136d1c7192db7dba003a6975e51d9a9eecabc4c2/jiter-0.14.0-cp312-cp312-win32.whl", hash = "sha256:5dec7c0a3e98d2a3f8a2e67382d0d7c3ac60c69103a4b271da889b4e8bb1e129", size = 206030, upload-time = "2026-04-10T14:26:42.517Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/96369141b3d8a4a8e4590e983085efe1c436f35c0cda940dd76d942e3e40/jiter-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:fc7e37b4b8bc7e80a63ad6cfa5fc11fab27dbfea4cc4ae644b1ab3f273dc348f", size = 201603, upload-time = "2026-04-10T14:26:44.328Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c3/75d847f264647017d7e3052bbcc8b1e24b95fa139c320c5f5066fa7a0bdd/jiter-0.14.0-cp312-cp312-win_arm64.whl", hash = "sha256:ee4a72f12847ef29b072aee9ad5474041ab2924106bdca9fcf5d7d965853e057", size = 191525, upload-time = "2026-04-10T14:26:46Z" },
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a1/ef34ca2cab2962598591636a1804b93645821201cc0095d4a93a9a329c9d/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:a25ffa2dbbdf8721855612f6dca15c108224b12d0c4024d0ac3d7902132b4211", size = 311366, upload-time = "2026-04-10T14:28:27.943Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bb/520576a532a6b8a6f42747afed289c8448c879a34d7802fe2c832d4fd38f/jiter-0.14.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ac9cbaa86c10996b92bd12c91659b60f939f8e28fcfa6bc11a0e90a774ce95b", size = 309873, upload-time = "2026-04-10T14:28:29.688Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7c/c16db114ea1f2f532f198aa8dc39585026af45af362c69a0492f31bc4821/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:844e73b6c56b505e9e169234ea3bdea2ea43f769f847f47ac559ba1d2361ebea", size = 344816, upload-time = "2026-04-10T14:28:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8f/15e7741ff19e9bcd4d753f7ff22f988fd54592f134ca13701c13ea8c20e0/jiter-0.14.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e52c076f187405fc21523c746c04399c9af8ece566077ed147b2126f2bcba577", size = 351445, upload-time = "2026-04-10T14:28:33.093Z" },
+    { url = "https://files.pythonhosted.org/packages/21/42/9042c3f3019de4adcb8c16591c325ec7255beea9fcd33a42a43f3b0b1000/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:fbd9e482663ca9d005d051330e4d2d8150bb208a209409c10f7e7dfdf7c49da9", size = 308810, upload-time = "2026-04-10T14:28:34.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cf/a7e19b308bd86bb04776803b1f01a5f9a287a4c55205f4708827ee487fbf/jiter-0.14.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:33a20d838b91ef376b3a56896d5b04e725c7df5bc4864cc6569cf046a8d73b6d", size = 308443, upload-time = "2026-04-10T14:28:36.658Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/44/e26ede3f0caeff93f222559cb0cc4ca68579f07d009d7b6010c5b586f9b1/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:432c4db5255d86a259efde91e55cb4c8d18c0521d844c9e2e7efcce3899fb016", size = 343039, upload-time = "2026-04-10T14:28:38.356Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e9/1f9ada30cef7b05e74bb06f52127e7a724976c225f46adb65c37b1dadfb6/jiter-0.14.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67f00d94b281174144d6532a04b66a12cb866cbdc47c3af3bfe2973677f9861a", size = 349613, upload-time = "2026-04-10T14:28:40.066Z" },
 ]
 
 [[package]]
@@ -1767,6 +1982,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "litellm"
+version = "1.90.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/00/4187e33818d0de19fd602214ce15a6e1cfa5bf04fb50a6e59606214a92df/litellm-1.90.2.tar.gz", hash = "sha256:b536603894ba2a0ccd14a6f1ebeb5f46cc35b19d4537e8fda7bfdfc7757f19d3", size = 14819154, upload-time = "2026-07-01T02:29:58.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/30/3afa7b212ce1f9bb8b6fa5f58c631f437c1d7b3a025e4e4ed6b01b3d28ad/litellm-1.90.2-py3-none-any.whl", hash = "sha256:6fb46f485150cc861be62a62d670f94d33adbd26991091befeb51bcdfdad34f6", size = 16612720, upload-time = "2026-07-01T02:29:55.215Z" },
 ]
 
 [[package]]
@@ -2898,6 +3136,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/6f/60e2c0acea1e1ac09b3e794b5a19c166eebf91c0b860b3e6db8e74983fda/onnxruntime-1.24.4-cp314-cp314-win_arm64.whl", hash = "sha256:3f0b910e86b759a4732663ec61fd57ac42ee1b0066f68299de164220b660546d", size = 12594365, upload-time = "2026-03-17T22:05:35.795Z" },
     { url = "https://files.pythonhosted.org/packages/cf/68/0c05d10f8f6c40fe0912ebec0d5a33884aaa2af2053507e864dab0883208/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa12ddc54c9c4594073abcaa265cd9681e95fb89dae982a6f508a794ca42e661", size = 15176889, upload-time = "2026-03-17T22:03:48.021Z" },
     { url = "https://files.pythonhosted.org/packages/6c/1d/1666dc64e78d8587d168fec4e3b7922b92eb286a2ddeebcf6acb55c7dc82/onnxruntime-1.24.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1cc6a518255f012134bc791975a6294806be9a3b20c4a54cca25194c90cf731", size = 17247021, upload-time = "2026-03-17T22:04:52.377Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/f5/7c7cb955305cb41f7f3c5fd7e0e38bf6bbf2658468863d4b7b868a5cb8df/openai-2.44.0.tar.gz", hash = "sha256:68a5a5ffad82b8ff7d451c437529fb64f7c3b8123aaf0c021966a882d9e3947d", size = 988753, upload-time = "2026-06-24T20:56:02.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/f4/561ed79fd94876160018a5e75254cfcb9b0e62d4dded9dcb20072e86d623/openai-2.44.0-py3-none-any.whl", hash = "sha256:0a2a3ab2e29aeda368700f662ff9ba0f9df17ba4c54577a64e08b8115a3cc0ad", size = 1366216, upload-time = "2026-06-24T20:55:58.882Z" },
 ]
 
 [[package]]
@@ -4230,15 +4487,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "15.0.0"
+version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]
@@ -4728,6 +4985,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -5250,6 +5516,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uv"
+version = "0.11.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/cb/5efc713948ddb10b00abfb51bfd429221c720175557f9c7965fea2448fe4/uv-0.11.26.tar.gz", hash = "sha256:2a433ece2ace088dd572d8abb0e6bd9a4ecb0e10bc9856447bbb37545f384f29", size = 4331220, upload-time = "2026-06-30T14:52:03.77Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/71/86dbffac9e26df28a16639c426cf4ba572aaf43d9231463e0dca337895b2/uv-0.11.26-py3-none-linux_armv6l.whl", hash = "sha256:fb97bf04512dfe16d86084e75d8129701fc8da9fb40de8746b73c3aa617c5897", size = 25197324, upload-time = "2026-06-30T14:50:51.75Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/80/525b73c8188e7052343e7109466a08fcd5195055aff4b0346ce3622e48cb/uv-0.11.26-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a58a06e5a4b0035538d3ab4160ad74c716076ea7148eb3317171c6276ac020b4", size = 24179172, upload-time = "2026-06-30T14:50:56.52Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5e/cf7b94ed3b1932c2a62573dcd388ad6c1da5c52111cd71ab7f20faa4a0aa/uv-0.11.26-py3-none-macosx_11_0_arm64.whl", hash = "sha256:7b6d078d2ce83897884c2330c0676f27be4bf3d223fb2a409460f579fb5f0a98", size = 22949576, upload-time = "2026-06-30T14:51:00.538Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/fd/71fa021f6909c4139d8354bea623b5e0ef0ce4a08da250da1a1645528da2/uv-0.11.26-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:1cd9ba4951681ce17f1703106266fcbe27aaa7d37f07d53cce8b5686d68a8755", size = 24936673, upload-time = "2026-06-30T14:51:04.496Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/273425e58a8812423e3d1f6c5da1015e636fbf13a83d104317ca37e16304/uv-0.11.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:e4f4c3268e69ac96f01972274a62f5f930c03cbc680adba6f21e63237ba3a639", size = 24719617, upload-time = "2026-06-30T14:51:08.419Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f8/1601e2acc7c54963814b4831eab996d8599e690712722c5acec5114860be/uv-0.11.26-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:efcbe0e187846f5ddba23bcaed17e4f9cd2463da5c45bdb5869616f686d713ff", size = 24734176, upload-time = "2026-06-30T14:51:12.685Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d2/a8a422e54c08cf4b8d51bedb9dbdd3cc233aa290ad8b3ee0438c0c02a3a5/uv-0.11.26-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:120ab2de93164d08cf5950f7fe18cbebe3ff670865ae41a292452bab2346477f", size = 26158780, upload-time = "2026-06-30T14:51:16.514Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e6/647fe5fdc888a3d27f79977877ce4e88052fe9be5398371e51bb134fc262/uv-0.11.26-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9052bf27c7ee426901f35a48715fa9288ce631c1878b91c9a6c950288f4b8633", size = 27009550, upload-time = "2026-06-30T14:51:20.659Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c2/85d8e762ad83b0f14fae2255b0578c4fd7dc915746f81b64ed786342627a/uv-0.11.26-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:efdddfcc9b1b790c5f7985c5c183c851682ced165b44ffa914f4947f5cad1fbf", size = 26183777, upload-time = "2026-06-30T14:51:24.715Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/00/478c3a870dcac690b8c337ee950a60a952e817f574945e85155c3cc0ab34/uv-0.11.26-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dcf4e0b5b5cbdc242dcb002f1f8d99e7cf8c043609869228a9ce15e095c0b18", size = 26260589, upload-time = "2026-06-30T14:51:28.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/51/e4e43e106fb8cdc026b97491ea4600f4194a9c4da0b4e4e30c2a7dceb268/uv-0.11.26-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:866ae8d28f7381c15de0906a284c1e97916424c635bf40f7960b3fc889cd725e", size = 25073850, upload-time = "2026-06-30T14:51:32.717Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c2/e772b7e6c8a835e8bf6739a391cdfc8e8e244c5c496d9b40625068b59ff4/uv-0.11.26-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:22f6d62e794b252ff3a1e2dfe5010cc76208f90b2c906e54971a0223ad6f16bc", size = 25682609, upload-time = "2026-06-30T14:51:36.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/69/ea77209a224a23a399cb7f6414f77ef032bd9e083e01199a0ebebf0d3ff2/uv-0.11.26-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:edd0c12b75141a6d830d138a91e366ad66e630f1c1dcaf83b8325b80cbacfcbb", size = 25800556, upload-time = "2026-06-30T14:51:40.937Z" },
+    { url = "https://files.pythonhosted.org/packages/77/60/b6c0c03d2538a016b6624fa251960012e564ea02f841e958c7d60e974685/uv-0.11.26-py3-none-musllinux_1_1_i686.whl", hash = "sha256:af6a45b11a569cc4d2437e89a25a53dcf753f2a02a8f2de96be09b9b942cb3ec", size = 25385658, upload-time = "2026-06-30T14:51:45.103Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e7/46881ff9164aa2e7c649901837d58eee3c57beb3b0fcc0fea6a4e40cf8f3/uv-0.11.26-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:c28822517d03aebbe9549aaaecc88ad580e4b2b6a927abffe5774a74d6ba09f6", size = 26551013, upload-time = "2026-06-30T14:51:49.062Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/380dad6c2bbe12417025aacd12cfc08322ed4c9dd8f760bff7035b86f22d/uv-0.11.26-py3-none-win32.whl", hash = "sha256:79e5c1b3410047e1962290c3b7b8f512d2c1bb95200c60b016f7729287cf34c0", size = 23947180, upload-time = "2026-06-30T14:51:53.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/13/9c588226d5b478328d739e654944430719f3ffe8999d6a24d425ec9664ab/uv-0.11.26-py3-none-win_amd64.whl", hash = "sha256:d95567e9470dc48ff03265f420c3c6973f6437f18a79d5e00b6eb4b2d9379907", size = 26909320, upload-time = "2026-06-30T14:51:57.235Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1d/ea66b12813878797126e2b3aca124b1c9c5ef53120702d1c00172f90a21d/uv-0.11.26-py3-none-win_arm64.whl", hash = "sha256:7e69d1569afbb936e7bf4e4ab2f72d606405f4a68f380f088a0b2233e84e056a", size = 25176820, upload-time = "2026-06-30T14:52:01.05Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Shifts sourcehunt from "trust the hunter's prose" to "verify the hunter's trace":

- **Structured vulnerability traces** — new `TraceStep` / `VulnerabilityTrace` types and a `record_trace_step` tool so hunters build an ordered, cite-from-source dataflow chain (entry → propagation → sink) that the validator can independently check.
- **LLM layer refactor** — new `clearwing/llm/messages.py` native message helpers; `ChatModel` facade gutted in favor of direct native client calls; multi-provider routing cleaned up.
- **Validator structured output** — enforces JSON verdict via pydantic wire schema + constrained decoding (drops regex fallback); axis-based scoring with optional axes for quick-pass.
- **Ranker robustness** — prompt tuning for weaker/slower models; retry on empty structured output.
- **`--live` mode removed** — simplifies the runner; one execution path instead of two.
- **OpenAI OAuth expansion** — broader provider auth support for Claude subscription flow.
- **Observability** — new `llm_activity` UI module; expanded telemetry in agent runtime.

## Test plan

- [ ] `python -m pytest tests/test_sourcehunt_validator.py -v`
- [ ] `python -m pytest tests/test_sourcehunt_ranker.py -v`
- [ ] `python -m pytest tests/test_agent.py -v`
- [ ] `python -m pytest tests/test_openai_oauth.py -v`
- [ ] `ruff check clearwing/`
- [ ] End-to-end sourcehunt run against a known-vuln repo confirms trace steps appear in findings