### PR TITLE
Stop hunter sessions from grinding to max_steps in degenerate repeated-call loops

### DIFF
--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -1364,7 +1364,7 @@ class HunterRunResult:
     findings: list[Finding]
     cost_usd: float
     tokens_used: int
-    stop_reason: str  # "completed" | "budget_exhausted" | "max_steps"
+    stop_reason: str  # "completed" | "budget_exhausted" | "max_steps" | "degenerate_loop"
     transcript_summary: str = ""
 
 
@@ -1378,6 +1378,7 @@ class NativeHunter:
     agent_mode: str = "constrained"  # "constrained" | "deep"
     budget_usd: float = 0.0  # 0 = unlimited (bounded by max_steps)
     initial_user_message: str = ""  # spec 006: override default first message
+    max_repeated_skips: int = 15  # hard cap on total skipped degenerate-loop calls before giving up
 
     def _should_stop(self, step: int, cost_usd: float) -> str | None:
         """Return a stop reason string, or None to continue."""
@@ -1403,6 +1404,7 @@ class NativeHunter:
         total_output_tokens = 0
         total_cost_usd = 0.0
         repeated_tool_calls: dict[tuple[str, str], int] = {}
+        total_repeated_skips = 0
         tools_by_name = {tool.name: tool for tool in self.tools}
         last_assistant_text = ""
 
@@ -1534,10 +1536,14 @@ class NativeHunter:
                     skipped = repeated_tool_calls[key] > 3
 
                     if skipped:
+                        total_repeated_skips += 1
                         tool_output = {
                             "error": (
-                                "tool call skipped because the assistant repeated the same "
-                                "call too many times"
+                                "tool call skipped: you already made this exact call and it "
+                                "produced no new information. Do not repeat it. Either "
+                                "investigate a different function or code path in this file, "
+                                "or if you have nothing further to add, respond with your "
+                                "final summary and no tool calls to finish this hunt."
                             )
                         }
                         tool_summary = _tool_output_text(
@@ -1593,6 +1599,34 @@ class NativeHunter:
                             "message": _serialize_message(messages[-1]),
                         },
                     )
+                    if skipped and total_repeated_skips > self.max_repeated_skips:
+                        logger.warning(
+                            "Hunter stopped for %s: degenerate_loop (step=%d, cost=$%.4f, "
+                            "findings=%d, skipped=%d)",
+                            self.ctx.file_path,
+                            step,
+                            total_cost_usd,
+                            len(self.ctx.findings),
+                            total_repeated_skips,
+                        )
+                        trajectory.log(
+                            "finish",
+                            {
+                                "step": step,
+                                "status": "degenerate_loop",
+                                "findings": [self._serialize_finding(f) for f in self.ctx.findings],
+                                "total_input_tokens": total_input_tokens,
+                                "total_output_tokens": total_output_tokens,
+                                "total_cost_usd": total_cost_usd,
+                            },
+                        )
+                        return HunterRunResult(
+                            findings=list(self.ctx.findings),
+                            cost_usd=total_cost_usd,
+                            tokens_used=total_input_tokens + total_output_tokens,
+                            stop_reason="degenerate_loop",
+                            transcript_summary=last_assistant_text[-500:],
+                        )
                 continue
 
             if last_assistant_text:

--- a/tests/test_deep_agent_loop.py
+++ b/tests/test_deep_agent_loop.py
@@ -124,6 +124,27 @@ async def test_deep_mode_safety_cap():
 
 
 @pytest.mark.asyncio
+async def test_deep_mode_stops_on_degenerate_loop():
+    # Real failure mode observed against crAPI with a local devstral model
+    # (both 4-bit and 6-bit quantizations): it keeps reissuing the exact
+    # same already-throttled tool call forever and never recovers. This
+    # must not be allowed to grind through the full max_steps budget.
+    hunter, llm = _make_hunter(agent_mode="deep", max_steps=500, budget_usd=0.0)
+
+    llm.achat.return_value = FakeResponse(
+        tool_calls_list=[_make_tool_call("think", {"notes": "same notes"})],
+    )
+
+    with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
+        mock_traj.for_hunter.return_value = MagicMock()
+        result = await hunter.arun()
+
+    assert result.stop_reason == "degenerate_loop"
+    # Should bail out well short of the 500-step budget.
+    assert llm.achat.call_count < 25
+
+
+@pytest.mark.asyncio
 async def test_deep_mode_throttles_repeated_calls():
     hunter, llm = _make_hunter(agent_mode="deep", max_steps=10, budget_usd=0.0)
 


### PR DESCRIPTION
## Summary
- `NativeHunter`'s per-key throttle skips a repeated tool call once it's been seen more than 3 times, but never stopped the session itself — a stuck model could keep reissuing an already-skipped call until `max_steps` (up to 500 in deep mode) was exhausted, since local-model cost is ~0 and never trips the `budget_usd` escape hatch either.
- Add a hard cap (`max_repeated_skips`, default 15) on total skipped calls across a hunt session. Once exceeded, stop immediately with a new `stop_reason="degenerate_loop"` instead of grinding through the rest of the step budget.
- Also make the skip error message more directive (tells the model to investigate a different function/path or wrap up) so a weak model has a real chance to recover before hitting the cap.

Observed running `clearwing sourcehunt` against crAPI with a local model (`mistralai/devstral-small-2-2512` via LM Studio): a hunter stuck on one file burned over an hour and hundreds of steps reissuing the same throttled call before finally hitting `max_steps`. With this fix, equivalent stuck sessions now stop in 15-70 steps (well under 15% of the 500-step ceiling), confirmed across a full live run.

## Test plan
- [x] Added `test_deep_mode_stops_on_degenerate_loop` in `tests/test_deep_agent_loop.py`, asserting `stop_reason == "degenerate_loop"` and that the session stops well short of the 500-step budget.
- [x] `ruff check` / `ruff format --check` clean on the changed files (repo-wide lint/format has pre-existing unrelated drift on `main`).
- [x] Scoped `mypy` clean on the changed file (`clearwing/sourcehunt`); the one hit in `hunter.py` (line 55) is pre-existing on `main`, unrelated to this change.
- [x] Full `pytest -q --strict-markers --strict-config`: all tests in the changed test file pass; the only failure repo-wide (`test_webcrypto_hooks.py`, needs a Playwright browser binary not installed in this sandbox) is pre-existing/environmental, unrelated to this change.
- [x] `python -m build` + `twine check dist/*` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)