### PR TITLE
Deduplicate record_finding calls at the same file and line within one hunt

### DIFF
--- a/clearwing/agent/tools/hunt/reporting.py
+++ b/clearwing/agent/tools/hunt/reporting.py
@@ -222,6 +222,19 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         # Reset only after the authoritative steps are stored on the finding.
         ctx.trace_steps.clear()
 
+        duplicate = next(
+            (f for f in ctx.findings if f.file == file and f.line_number == line_number),
+            None,
+        )
+        if duplicate is not None:
+            return (
+                f"Finding at {file}:{line_number} was already recorded earlier "
+                f"in this session (finding_type={duplicate.finding_type!r}, "
+                f"severity={duplicate.severity!r}). Skipping this duplicate "
+                "call — if you have new information about a different issue, "
+                "record it at a different line instead of re-reporting this one."
+            )
+
         stable_finding_id = stable_run_id(
             "hunter",
             {

--- a/tests/test_hunt_reporting_tools.py
+++ b/tests/test_hunt_reporting_tools.py
@@ -1,0 +1,69 @@
+"""Tests for record_finding / record_trace_step (clearwing/agent/tools/hunt/reporting.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from clearwing.agent.tools.hunt.reporting import build_reporting_tools
+from clearwing.agent.tools.hunt.sandbox import HunterContext
+
+
+@pytest.fixture
+def ctx():
+    return HunterContext(repo_path="/tmp/repo", sandbox=MagicMock(), agent_mode="deep")
+
+
+@pytest.fixture
+def tools(ctx):
+    return {t.name: t.handler for t in build_reporting_tools(ctx)}
+
+
+def _record_finding(tools, **overrides):
+    args = dict(
+        file="app.py",
+        line_number=42,
+        finding_type="sql_injection",
+        severity="high",
+        cwe="CWE-89",
+        description="SQL built via string concatenation.",
+        code_snippet="query = f'SELECT * FROM users WHERE id={user_id}'",
+    )
+    args.update(overrides)
+    return tools["record_finding"](**args)
+
+
+def test_record_finding_requires_trace_step(tools):
+    result = _record_finding(tools)
+    assert "requires at least one trace step" in result
+
+
+def test_record_finding_records_after_trace_step(tools, ctx):
+    tools["record_trace_step"](file="app.py", line=42, note="entry")
+    result = _record_finding(tools)
+    assert "Finding recorded" in result
+    assert len(ctx.findings) == 1
+
+
+def test_record_finding_rejects_exact_line_duplicate(tools, ctx):
+    tools["record_trace_step"](file="app.py", line=42, note="entry")
+    first = _record_finding(tools)
+    assert "Finding recorded" in first
+
+    tools["record_trace_step"](file="app.py", line=42, note="entry again")
+    second = _record_finding(tools, description="Differently worded but same bug.")
+
+    assert "already recorded" in second
+    assert len(ctx.findings) == 1  # the duplicate must NOT be appended
+
+
+def test_record_finding_allows_different_lines(tools, ctx):
+    tools["record_trace_step"](file="app.py", line=42, note="entry")
+    _record_finding(tools, line_number=42)
+
+    tools["record_trace_step"](file="app.py", line=99, note="entry")
+    result = _record_finding(tools, line_number=99, description="A different bug entirely.")
+
+    assert "Finding recorded" in result
+    assert len(ctx.findings) == 2


### PR DESCRIPTION
## Summary
- `record_finding` had zero deduplication: every call was unconditionally appended to the hunter's findings list, even when the model reported the exact same file+line twice in one hunt session with slightly different wording — producing duplicate "distinct" findings in the report for what was really one bug.
- Add a duplicate check keyed on `(file, line_number)` only — deliberately not `finding_type`/`description`, since the real-world duplicates observed had different wording/type for the same line. When a duplicate is detected, the tool returns a message surfacing the earlier finding's type/severity and nudging the model to record genuinely new information at a different line instead of re-reporting the same one.

Observed running `clearwing sourcehunt` against crAPI with a local model (`mistralai/devstral-small-2-2512` via LM Studio): the same line was reported twice, worded differently, as two "distinct" findings in a single hunt session.

## Test plan
- [x] Added `tests/test_hunt_reporting_tools.py` — dedicated coverage for `record_finding`/`record_trace_step` that previously only existed as a "tool name is present" check.
- [x] `ruff check` / `ruff format --check` clean on the changed files (repo-wide lint/format has pre-existing unrelated drift on `main`).
- [x] Scoped `mypy` clean on the changed file (`clearwing/agent/tools`); no new errors introduced.
- [x] Full `pytest -q --strict-markers --strict-config`: 2767 passed; the only pre-existing failure (`test_webcrypto_hooks.py`, needs a Playwright browser binary not installed in this sandbox) is unrelated to this change.
- [x] `python -m build` + `twine check dist/*` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)