### PR TITLE
Stop seed transcripts from silently dropping prior findings

### DIFF
--- a/clearwing/sourcehunt/pool.py
+++ b/clearwing/sourcehunt/pool.py
@@ -244,9 +244,16 @@ def _extract_transcript(result: TargetResult) -> str:
 
     parts: list[str] = []
     for f in findings[:MAX_TRANSCRIPT_FINDINGS]:
-        file = f.get("file", "?") if isinstance(f, dict) else "?"
-        line = f.get("line_number", "?") if isinstance(f, dict) else "?"
-        desc = f.get("description", "") if isinstance(f, dict) else str(f)
+        # result.findings is annotated list[dict] but the real runtime objects
+        # flowing through here are Finding dataclass instances (the cast() at
+        # the call site is a no-op) — Finding implements dict-mimicking
+        # __getitem__/.get() specifically so callers don't need to branch on
+        # dict vs. Finding, matching the existing pattern a few dozen lines
+        # above this function. An isinstance(f, dict) guard here would always
+        # be False in production, silently degrading every entry to "?:?".
+        file = f.get("file", "?")
+        line = f.get("line_number", "?")
+        desc = f.get("description", "") or ""
         parts.append(f"- {file}:{line} — {desc[:200]}")
     if len(findings) > MAX_TRANSCRIPT_FINDINGS:
         parts.append(

--- a/clearwing/sourcehunt/pool.py
+++ b/clearwing/sourcehunt/pool.py
@@ -226,15 +226,34 @@ def _format_seed_context(entries: list) -> str | None:
         return None
 
 
+MAX_TRANSCRIPT_FINDINGS = 25
+
+
 def _extract_transcript(result: TargetResult) -> str:
-    """Build a brief transcript summary from a TargetResult for seeding promoted runs."""
+    """Build a transcript summary from a TargetResult for seeding promoted runs.
+
+    Must surface every finding from the previous pass, not just the first
+    couple: the promoted hunter's prompt explicitly says "a previous
+    investigation found the following ... do not repeat analysis already
+    done," so any finding silently dropped here just gets rediscovered and
+    re-reported as if it were new.
+    """
+    findings = result.findings
+    if not findings:
+        return f"Run completed with status={result.status}, stop_reason={result.stop_reason}"
+
     parts: list[str] = []
-    for f in result.findings:
+    for f in findings[:MAX_TRANSCRIPT_FINDINGS]:
+        file = f.get("file", "?") if isinstance(f, dict) else "?"
+        line = f.get("line_number", "?") if isinstance(f, dict) else "?"
         desc = f.get("description", "") if isinstance(f, dict) else str(f)
-        parts.append(f"Finding: {desc[:200]}")
-    if not parts:
-        parts.append(f"Run completed with status={result.status}, stop_reason={result.stop_reason}")
-    return "\n".join(parts)[:500]
+        parts.append(f"- {file}:{line} — {desc[:200]}")
+    if len(findings) > MAX_TRANSCRIPT_FINDINGS:
+        parts.append(
+            f"... and {len(findings) - MAX_TRANSCRIPT_FINDINGS} more findings "
+            "from the previous pass."
+        )
+    return "Previously found in this file (do not re-report these):\n" + "\n".join(parts)
 
 
 # --- HunterPool -------------------------------------------------------------

--- a/tests/test_band_promotion.py
+++ b/tests/test_band_promotion.py
@@ -21,7 +21,7 @@ from clearwing.sourcehunt.pool import (
     _redundancy_for_rank,
     promotion_decision,
 )
-from clearwing.sourcehunt.state import FileTarget
+from clearwing.sourcehunt.state import FileTarget, Finding
 
 
 def _make_file_target(
@@ -412,6 +412,33 @@ class TestExtractTranscript:
         transcript = _extract_transcript(result)
         assert "status=completed" in transcript
         assert "max_steps" in transcript
+
+    def test_handles_real_finding_dataclass_instances(self):
+        # result.findings is annotated list[dict], but in production the
+        # objects that actually flow through here are Finding dataclass
+        # instances (TargetResult is built with cast(list[dict], findings),
+        # which is a no-op at runtime). A dict-only implementation would
+        # silently degrade every entry to "?:?" with no description text.
+        findings = [
+            Finding(
+                file="jwt.py",
+                line_number=61,
+                description="JWT signature verification is disabled.",
+            ),
+            Finding(
+                file="jwt.py",
+                line_number=54,
+                description="SSL certificate verification is disabled.",
+            ),
+        ]
+        result = TargetResult(target="jwt.py", status="completed", findings=findings)
+        transcript = _extract_transcript(result)
+
+        assert "jwt.py:61" in transcript
+        assert "JWT signature verification is disabled." in transcript
+        assert "jwt.py:54" in transcript
+        assert "SSL certificate verification is disabled." in transcript
+        assert "?:?" not in transcript
 
 
 # --- Pool band wiring tests --------------------------------------------------

--- a/tests/test_band_promotion.py
+++ b/tests/test_band_promotion.py
@@ -8,12 +8,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from clearwing.runners.parallel.executor import TargetResult
 from clearwing.sourcehunt.pool import (
     BAND_ORDER,
+    MAX_TRANSCRIPT_FINDINGS,
     BandBudget,
     HunterPool,
     HuntPoolConfig,
     WorkItem,
+    _extract_transcript,
     _file_rank,
     _redundancy_for_rank,
     promotion_decision,
@@ -371,6 +374,44 @@ class TestSeedTranscript:
             session_id="s1",
         )
         assert "previous investigation" not in hunter.prompt
+
+
+class TestExtractTranscript:
+    def test_includes_every_finding_not_just_the_first_few(self):
+        findings = [
+            {
+                "file": "jwt.py",
+                "line_number": 10 + i,
+                "description": f"Issue number {i} with enough padding text to matter",
+            }
+            for i in range(5)
+        ]
+        result = TargetResult(target="jwt.py", status="completed", findings=findings)
+        transcript = _extract_transcript(result)
+
+        for i in range(5):
+            assert f"jwt.py:{10 + i}" in transcript
+            assert f"Issue number {i}" in transcript
+
+    def test_caps_with_explicit_overflow_note_instead_of_silent_drop(self):
+        findings = [
+            {"file": "big.py", "line_number": i, "description": f"finding {i}"}
+            for i in range(MAX_TRANSCRIPT_FINDINGS + 5)
+        ]
+        result = TargetResult(target="big.py", status="completed", findings=findings)
+        transcript = _extract_transcript(result)
+
+        assert "and 5 more findings" in transcript
+        assert "big.py:0" in transcript
+        assert f"big.py:{MAX_TRANSCRIPT_FINDINGS - 1}" in transcript
+
+    def test_no_findings_falls_back_to_status_summary(self):
+        result = TargetResult(
+            target="x.py", status="completed", stop_reason="max_steps", findings=[]
+        )
+        transcript = _extract_transcript(result)
+        assert "status=completed" in transcript
+        assert "max_steps" in transcript
 
 
 # --- Pool band wiring tests --------------------------------------------------


### PR DESCRIPTION
## Summary
- When a file gets promoted to a deeper hunt band, the new hunter session is seeded with a summary of what the previous pass already found, explicitly telling it "do not repeat analysis already done." The function building that summary (`_extract_transcript`) truncated the whole joined summary to a flat 500 characters, silently dropping all but roughly the first 2 findings before the promoted hunter ever saw them — so later passes routinely re-discovered and re-reported findings the previous pass had already recorded.
- Additionally, fields were extracted via `isinstance(f, dict)`, but the real runtime objects flowing through this function are `Finding` dataclass instances (the `cast(list[dict], findings)` at the call site is a no-op), so `isinstance` was always `False` in production — every seeded entry degraded to `"?:?"` with the description truncated away entirely. `Finding` already implements dict-mimicking `__getitem__`/`.get()` for exactly this reason (matching the pattern used a few lines above this function), so the fix just calls `.get()` unconditionally.
- List every finding (up to a cap of 25, each on its own `file:line` line) instead of silently truncating the joined string, with an explicit "...and N more" note if there are genuinely more than that.

Both issues were caught live running `clearwing sourcehunt` against crAPI.

## Test plan
- [x] Added `TestExtractTranscript` in `tests/test_band_promotion.py`: multi-finding listing, overflow cap, no-findings fallback, and (the regression that caught the `isinstance` bug) real `Finding`-dataclass instances rather than dict literals.
- [x] `ruff check` / `ruff format --check` clean on the changed file (`clearwing/sourcehunt/pool.py`); repo-wide lint/format has pre-existing unrelated drift on `main`.
- [x] Scoped `mypy` clean on the changed file; no new errors introduced.
- [x] Full `pytest -q --strict-markers --strict-config`: `tests/test_band_promotion.py` 39/39 passed; the only pre-existing failure repo-wide (`test_webcrypto_hooks.py`) is unrelated to this change.
- [x] `python -m build` + `twine check dist/*` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)