### PR TITLE
Fix false-positive throttle of read_file/read_source_file

### DIFF
--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -1528,8 +1528,26 @@ class NativeHunter:
                     # argument string would also dodge a raw-prefix key since it
                     # shifts every character after it. Normalizing digit runs
                     # before truncating catches both shapes.
-                    normalized_args = re.sub(r"\d+", "#", tool_call.fn_arguments_json)
-                    key = (tool_call.fn_name, normalized_args[:300])
+                    # read_file/read_source_file take an (offset,limit) or
+                    # (start_line,end_line) pair as literally the ONLY fields
+                    # that legitimately vary between successive, non-redundant
+                    # paginated reads of the same file. Digit-stripping those
+                    # numbers collapses every call on a given path into one
+                    # identical key after just 3 uses, falsely throttling later
+                    # reads that target genuinely unseen line ranges (observed
+                    # live against crAPI: a 433-line file's read_file calls were
+                    # rejected from the 4th call on even though offset/limit
+                    # differed every time and no range was actually
+                    # re-requested, preventing the hunter from ever reading far
+                    # enough to find a real bug later in the file). Keep those
+                    # two tools' arguments literal — only tools without an
+                    # inherent legitimate-pagination shape benefit from
+                    # normalizing away incrementing digits.
+                    if tool_call.fn_name in ("read_file", "read_source_file"):
+                        key = (tool_call.fn_name, tool_call.fn_arguments_json[:300])
+                    else:
+                        normalized_args = re.sub(r"\d+", "#", tool_call.fn_arguments_json)
+                        key = (tool_call.fn_name, normalized_args[:300])
                     repeated_tool_calls[key] = repeated_tool_calls.get(key, 0) + 1
                     skipped = repeated_tool_calls[key] > 3
 

--- a/tests/test_deep_agent_loop.py
+++ b/tests/test_deep_agent_loop.py
@@ -267,6 +267,83 @@ async def test_throttles_calls_with_growing_numeric_prefix():
 
 
 @pytest.mark.asyncio
+async def test_read_file_pagination_is_not_falsely_throttled():
+    # Real failure mode observed against crAPI: read_file's offset/limit
+    # digits used to get stripped before the dedup check, so any four
+    # legitimately-different paginated reads of the same file collapsed
+    # to one key and the 4th+ was falsely rejected as "already made this
+    # call" even though it targeted genuinely unread lines.
+    hunter, llm = _make_hunter(agent_mode="deep", max_steps=20, budget_usd=0.0)
+
+    offsets = [0, 100, 200, 300, 400, 500, 600]
+    call_count = [0]
+
+    async def achat_side_effect(**kwargs):
+        i = call_count[0]
+        call_count[0] += 1
+        if i >= len(offsets):
+            return FakeResponse(text="done")
+        return FakeResponse(
+            tool_calls_list=[
+                _make_tool_call(
+                    "read_file",
+                    {"path": "views.py", "offset": offsets[i], "limit": 100},
+                )
+            ],
+        )
+
+    llm.achat.side_effect = achat_side_effect
+
+    with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
+        mock_logger = MagicMock()
+        mock_traj.for_hunter.return_value = mock_logger
+        await hunter.arun()
+
+    logged = mock_logger.log.call_args_list
+    skipped = [
+        c
+        for c in logged
+        if len(c[0]) > 1 and isinstance(c[0][1], dict) and c[0][1].get("repeated_skip")
+    ]
+    assert len(skipped) == 0
+
+
+@pytest.mark.asyncio
+async def test_read_file_exact_repeat_still_throttled():
+    # The fix must not disable throttling entirely for read_file — a truly
+    # identical (path, offset, limit) repeated verbatim is still a
+    # degenerate loop and must still be caught.
+    hunter, llm = _make_hunter(agent_mode="deep", max_steps=10, budget_usd=0.0)
+
+    call_count = [0]
+
+    async def achat_side_effect(**kwargs):
+        call_count[0] += 1
+        if call_count[0] >= 8:
+            return FakeResponse(text="done")
+        return FakeResponse(
+            tool_calls_list=[
+                _make_tool_call("read_file", {"path": "views.py", "offset": 0, "limit": 2000})
+            ],
+        )
+
+    llm.achat.side_effect = achat_side_effect
+
+    with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
+        mock_logger = MagicMock()
+        mock_traj.for_hunter.return_value = mock_logger
+        await hunter.arun()
+
+    logged = mock_logger.log.call_args_list
+    skipped = [
+        c
+        for c in logged
+        if len(c[0]) > 1 and isinstance(c[0][1], dict) and c[0][1].get("repeated_skip")
+    ]
+    assert len(skipped) > 0
+
+
+@pytest.mark.asyncio
 async def test_hunter_completes_when_no_tool_calls():
     hunter, llm = _make_hunter(agent_mode="deep", max_steps=500, budget_usd=100.0)
 


### PR DESCRIPTION
## Summary
- The repeated-tool-call dedup guard strips all digits from a tool call's JSON arguments before hashing, to catch a model reissuing the same call with a slowly-widening numeric literal (e.g. `grep -B10` creeping to `-B1750`). But `read_file(path, offset, limit)` and `read_source_file(path, start_line, end_line)` use offset/limit as the ONLY fields that legitimately differ between successive, non-redundant paginated reads of the same file. Digit-stripping collapsed every read on a given path to one key after 3 calls, so the 4th+ legitimately-different read was falsely rejected as "you already made this exact call."
- Keep `read_file`/`read_source_file`'s arguments literal (not digit-normalized) for the dedup key, so distinct offset/limit pairs get distinct keys, while an exact repeat of the same call is still throttled. All other tools keep the existing digit-normalization behavior.

Confirmed live against crAPI: hunting `shop/views.py` (433 lines) and `mechanic/views.py` (459 lines), every pass had reads falsely throttled after the 3rd call regardless of the offset requested, preventing the hunter from ever reading far enough to find a real SQL injection later in `shop/views.py`'s `ApplyCouponView`.

## Test plan
- [x] Added `test_read_file_pagination_is_not_falsely_throttled` (7 distinct offset/limit reads produce zero false throttles) and `test_read_file_exact_repeat_still_throttled` (a truly identical call is still caught) in `tests/test_deep_agent_loop.py`.
- [x] `ruff check` / `ruff format --check` clean on the changed files (repo-wide lint/format has pre-existing unrelated drift on `main`).
- [x] Scoped `mypy` clean on the changed file (`clearwing/sourcehunt`); the one hit in `hunter.py` (line 55) is pre-existing on `main`, unrelated to this change.
- [x] Full `pytest -q --strict-markers --strict-config`: all tests in the changed test file pass; the only failure repo-wide (`test_webcrypto_hooks.py`, needs a Playwright browser binary not installed in this sandbox) is pre-existing/environmental, unrelated to this change.
- [x] `python -m build` + `twine check dist/*` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)