### PR TITLE
Fix record_trace_step crash on explicit null optional args

### DIFF
--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -1661,6 +1661,15 @@ class NativeHunter:
             # Reject calls missing required params (model emitted empty/partial args).
             # Return an error string so the model can self-correct on next turn.
             required = set(tool.schema.get("required", [])) if tool.schema else set()
+            # Some local models emit explicit `null` for optional params instead
+            # of omitting them. Arguments are passed straight through to the
+            # handler as **kwargs without going through the schema's Pydantic
+            # model, so an explicit None overrides the handler's own default
+            # (e.g. `function: str = ""`) and can reach strict downstream
+            # validation (TraceStep.function is a plain `str`, not Optional).
+            # Drop None for optional params so the handler default applies,
+            # matching the omitted-argument case.
+            arguments = {k: v for k, v in arguments.items() if v is not None or k in required}
             missing = required - set(arguments.keys())
             if missing:
                 logger.info(

--- a/tests/test_deep_agent_loop.py
+++ b/tests/test_deep_agent_loop.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from genai_pyo3 import ToolCall
 
+from clearwing.agent.tools.hunt import build_reporting_tools
 from clearwing.agent.tools.hunt.sandbox import HunterContext
 from clearwing.llm.native import NativeToolSpec
 from clearwing.sourcehunt.hunter import NativeHunter
@@ -341,6 +342,57 @@ async def test_read_file_exact_repeat_still_throttled():
         if len(c[0]) > 1 and isinstance(c[0][1], dict) and c[0][1].get("repeated_skip")
     ]
     assert len(skipped) > 0
+
+
+@pytest.mark.asyncio
+async def test_record_trace_step_tolerates_explicit_null_optional_args():
+    # Real failure mode observed against crAPI: devstral-small sends explicit
+    # `"function": null` for the unused optional `function` param instead of
+    # omitting it. Tool-call arguments are passed straight through to the
+    # handler as **kwargs without going through the declared Pydantic input
+    # schema, so `function=None` reached TraceStep's plain `str` field (not
+    # Optional) and raised a pydantic ValidationError. _run_tool's generic
+    # except caught it and returned an error string, but the trace step was
+    # silently dropped instead of recorded — 38 times in one batch run.
+    ctx = HunterContext(repo_path="/tmp/repo", sandbox=MagicMock())
+    ctx.files_read.add("views.py")
+    tools = build_reporting_tools(ctx)
+
+    llm = AsyncMock()
+    llm.achat.side_effect = [
+        FakeResponse(
+            tool_calls_list=[
+                _make_tool_call(
+                    "record_trace_step",
+                    {
+                        "file": "views.py",
+                        "line": 10,
+                        "function": None,
+                        "code_snippet": "verify=False,",
+                        "note": "SINK: disables TLS verification",
+                    },
+                )
+            ],
+        ),
+        FakeResponse(text="done"),
+    ]
+
+    hunter = NativeHunter(
+        llm=llm,
+        prompt="test prompt",
+        tools=tools,
+        ctx=ctx,
+        max_steps=2,
+    )
+
+    with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
+        mock_traj.for_hunter.return_value = MagicMock()
+        await hunter.arun()
+
+    assert len(ctx.trace_steps) == 1
+    assert ctx.trace_steps[0].function == ""
+    assert ctx.trace_steps[0].line == 10
+    assert ctx.trace_steps[0].note == "SINK: disables TLS verification"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Tool-call arguments from the model are passed straight to the handler via `**kwargs` (`_run_tool` in `clearwing/sourcehunt/hunter.py`) without going through the declared Pydantic input schema. A value only gets its Python default (e.g. `function: str = ""`) when the key is fully absent from the call — if the model sends the key with an explicit `null`, that `None` reaches the handler directly.
- `mistralai/devstral-small` reliably sends explicit `"function": null` for `record_trace_step`'s unused optional `function` param instead of omitting it. That `None` flows into `TraceStep(function=None, ...)` construction, and since `TraceStep.function` is a plain `str` (not `Optional`), Pydantic raises a validation error. `_run_tool`'s generic `except` catches it and logs a warning instead of crashing the hunter, but the trace step itself is silently dropped — never recorded.
- Fix: after computing the tool schema's `required` set, drop any argument whose value is explicit `None` when that key is not required, so the handler's own default applies — matching the omitted-argument case. This is scoped to the shared dispatch path in `_run_tool`, so it protects every tool with this optional-string-default pattern, not just `record_trace_step`.

Confirmed live against crAPI: 38 occurrences across 12 files in a single batch run, 100% the identical `function: null` pattern (no other field variant observed). Each occurrence silently dropped an ENTRY/PROPAGATION/SINK step from a finding's `vulnerability_trace`, degrading the dataflow evidence attached to the final report.

## Test plan
- [x] Added `test_record_trace_step_tolerates_explicit_null_optional_args` in `tests/test_deep_agent_loop.py`: drives a full `NativeHunter.arun()` loop with a stubbed LLM response that sends `function: null`, asserting the trace step is recorded with the handler's default (`function == ""`) instead of being dropped. Verified this test fails with the exact production warning message on the pre-fix code and passes after the fix.
- [x] `ruff check` / `ruff format --check` clean on the changed files (repo-wide lint/format has pre-existing unrelated drift on `main`, confirmed identical count before/after this change: 109 errors).
- [x] Scoped `mypy` clean on the changed file; confirmed identical error count before/after this change (99 errors, none in the changed lines).
- [x] Full `pytest -q --strict-markers --strict-config`: 2766 passed, 1 failed — the only failure (`test_webcrypto_hooks.py`, missing Playwright browser binary) is pre-existing/environmental, unrelated to this change.
- [x] `python -m build` + `twine check dist/*` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)