### PR TITLE
fix: make cwe optional in record_finding for local model compat

### DIFF
--- a/clearwing/agent/tools/hunt/reporting.py
+++ b/clearwing/agent/tools/hunt/reporting.py
@@ -63,7 +63,13 @@ class RecordFindingInput(ToolInputModel):
     line_number: int
     finding_type: str
     severity: str
-    cwe: str
+    cwe: str = Field(
+        default="",
+        description=(
+            "CWE identifier (for example CWE-89 or CWE-787). "
+            "Leave blank when the finding is not yet classified."
+        ),
+    )
     description: str
     code_snippet: str = ""
     crash_evidence: str = ""
@@ -150,8 +156,8 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         line_number: int,
         finding_type: str,
         severity: str,
-        cwe: str,
         description: str,
+        cwe: str = "",
         code_snippet: str = "",
         crash_evidence: str = "",
         poc: str = "",
@@ -178,8 +184,9 @@ def build_reporting_tools(ctx: HunterContext) -> list:
             line_number: 1-indexed line number.
             finding_type: e.g. sql_injection, memory_safety, timing_side_channel.
             severity: critical / high / medium / low / info.
-            cwe: CWE identifier (e.g. CWE-89, CWE-787, CWE-208).
             description: One- or two-sentence description of the bug.
+            cwe: CWE identifier (e.g. CWE-89, CWE-787, CWE-208). Leave blank
+                if unclassified — don't block on picking one.
             code_snippet: Relevant code snippet (helpful for triage).
             crash_evidence: Sanitizer/PoC output if available.
             poc: Proof-of-concept input.

--- a/tests/test_sourcehunt_hunter.py
+++ b/tests/test_sourcehunt_hunter.py
@@ -724,6 +724,37 @@ class TestRecordFinding:
         assert ctx.findings[0]["seeded_from_crash"] is True
         assert ctx.findings[0]["discovered_by"] == "hunter:memory_safety"
 
+    def test_missing_cwe_does_not_crash(self):
+        """Local models don't always populate every schema field; a hunter
+        that reports a finding without a CWE classification yet should still
+        get it recorded instead of losing the finding to a TypeError."""
+        ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
+        tools = build_hunter_tools(ctx)
+        record = next(t for t in tools if t.name == "record_finding")
+        assert "cwe" not in record.schema.get("required", [])
+        assert record.schema["properties"]["cwe"]["default"] == ""
+        msg = record.invoke(
+            {
+                "file": "src/codec_a.c",
+                "line_number": 9,
+                "finding_type": "memory_safety",
+                "severity": "critical",
+                "description": "memcpy with unchecked length",
+                "trace": {
+                    "steps": [
+                        {
+                            "file": "src/codec_a.c",
+                            "line": 9,
+                            "note": "SINK: unchecked memcpy",
+                        }
+                    ]
+                },
+            }
+        )
+        assert "Finding recorded" in msg
+        assert len(ctx.findings) == 1
+        assert ctx.findings[0]["cwe"] == ""
+
     def test_streamed_trace_is_required_and_authoritative(self):
         """record_finding persists streamed steps without model reassembly."""
         ctx = HunterContext(


### PR DESCRIPTION
## Summary
- Makes `cwe` field optional (default `""`) in `RecordFindingInput` schema and `record_finding` handler signature
- Local models (devstral, quantized Qwen variants) frequently omit CWE classification — this prevented findings from being recorded at all
- Adds test verifying findings record successfully without a CWE

## Test plan
- [x] `test_missing_cwe_does_not_crash` passes
- [ ] Existing `TestRecordFinding` suite still green
- [ ] Run a hunter session with a local model and confirm findings land without CWE