### PR TITLE
fix(security): sandbox create_custom_tool and gate behind HITL

### DIFF
--- a/clearwing/agent/tools/ops/dynamic_tool_creator.py
+++ b/clearwing/agent/tools/ops/dynamic_tool_creator.py
@@ -2,7 +2,6 @@ import json
 import os
 import re
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
@@ -55,29 +54,66 @@ def _validate_parameters(parameters: list[dict]) -> str | None:
     return None
 
 
-def _sandbox_env() -> dict:
-    return {
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-    }
+# Docker image used to execute generated tools. Deliberately minimal — the
+# tool only ever needs a Python interpreter and its stdlib.
+SANDBOX_IMAGE = "python:3.12-slim"
+
+# Timeout covers container start plus tool execution (not an initial image
+# pull; pre-pull the image if the first invocation matters).
+SANDBOX_TIMEOUT_SECONDS = 120
 
 
 def _run_sandboxed(file_path: Path, kwargs: dict) -> str:
-    """Execute a generated tool file in an isolated interpreter."""
-    proc = subprocess.run(
-        [sys.executable, "-I", str(file_path)],
-        input=json.dumps(kwargs),
-        env=_sandbox_env(),
-        capture_output=True,
-        text=True,
-        timeout=60,
-    )
+    """Execute a generated tool file inside a network-isolated Docker container.
+
+    The tool's temp directory is mounted read-only at /tool, the container has
+    no network, all capabilities dropped, no-new-privileges, and memory/pid
+    limits. If Docker is unavailable the call fails closed — there is
+    deliberately no host-interpreter fallback.
+    """
+    argv = [
+        "docker",
+        "run",
+        "--rm",
+        "-i",
+        "--network=none",
+        "--cap-drop=ALL",
+        "--security-opt=no-new-privileges",
+        "--memory=512m",
+        "--pids-limit=128",
+        "-v",
+        f"{file_path.parent}:/tool:ro",
+        SANDBOX_IMAGE,
+        "python",
+        "-I",
+        f"/tool/{file_path.name}",
+    ]
+    try:
+        proc = subprocess.run(
+            argv,
+            input=json.dumps(kwargs),
+            capture_output=True,
+            text=True,
+            timeout=SANDBOX_TIMEOUT_SECONDS,
+        )
+    except FileNotFoundError:
+        return json.dumps(
+            {
+                "error": (
+                    "Docker is required to execute custom tools and was not "
+                    "found; refusing to fall back to host execution."
+                )
+            }
+        )
+    except subprocess.TimeoutExpired:
+        return json.dumps({"error": "sandboxed execution timed out"})
     if proc.returncode != 0:
         return json.dumps({"error": proc.stderr.strip() or "sandbox exited non-zero"})
     return proc.stdout
 
 
 def _make_stub(tool_name: str, description: str, parameters: list[dict], file_path: Path):
-    """Build an @tool-decorated stub that shells out to the sandboxed subprocess."""
+    """Build an @tool-decorated stub that runs the tool in a Docker sandbox."""
     param_names = [p["name"] for p in parameters]
 
     async def _stub(**kwargs) -> str:
@@ -98,9 +134,11 @@ def create_custom_tool(
 ) -> dict:
     """Create a new tool at runtime by writing a Python file.
 
-    The generated file is written to an ephemeral temp directory and executed
-    in an isolated Python subprocess (`python -I`) with a minimal environment.
-    It has access to: asyncio, json, re, socket, subprocess.
+    Disabled by default; set CLEARWING_ENABLE_DYNAMIC_TOOLS=1 to enable. The
+    generated file is written to an ephemeral temp directory and executed
+    inside a network-isolated Docker container (`--network=none`, all
+    capabilities dropped, memory/pid limits, read-only mount). It has access
+    to: asyncio, json, re, socket, subprocess.
 
     Args:
         tool_name: Name for the tool (lowercase alphanumeric and underscores,
@@ -113,9 +151,20 @@ def create_custom_tool(
     Returns:
         Dict with keys: success, tool_name, message.
     """
+    if os.environ.get("CLEARWING_ENABLE_DYNAMIC_TOOLS") != "1":
+        return {
+            "success": False,
+            "tool_name": tool_name,
+            "message": (
+                "create_custom_tool is disabled by default for security. "
+                "Set CLEARWING_ENABLE_DYNAMIC_TOOLS=1 to enable runtime "
+                "tool creation."
+            ),
+        }
+
     if not interrupt(
         f"Approve creating custom tool '{tool_name}' that will execute "
-        f"arbitrary Python code in a sandboxed subprocess?"
+        f"arbitrary Python code in a network-isolated Docker container?"
     ):
         return {
             "success": False,
@@ -174,7 +223,7 @@ def create_custom_tool(
         "tool_name": tool_name,
         "message": (
             f"Tool '{tool_name}' created and registered "
-            f"(sandboxed subprocess at {file_path})."
+            f"(runs in a Docker sandbox from {file_path})."
         ),
     }
 

--- a/clearwing/agent/tools/ops/dynamic_tool_creator.py
+++ b/clearwing/agent/tools/ops/dynamic_tool_creator.py
@@ -1,13 +1,22 @@
-import importlib
-import importlib.util
+import json
+import os
 import re
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
-from clearwing.agent.tooling import tool
+from clearwing.agent.tooling import interrupt, tool
 
 _CUSTOM_TOOL_REGISTRY: dict = {}
 
-CUSTOM_TOOLS_DIR = Path(__file__).parent.parent.parent / "custom_tools"
+# Generated tool source is written to an ephemeral temp directory rather than
+# the installed package tree so an attacker cannot persist code on disk or
+# poison the import path.
+CUSTOM_TOOLS_DIR = Path(tempfile.mkdtemp(prefix="clearwing_custom_tools_"))
+
+_NAME_RE = re.compile(r"^[a-z_][a-z0-9_]{0,40}$")
+_ALLOWED_PARAM_TYPES = frozenset({"str", "int", "float", "bool", "dict", "list"})
 
 TOOL_TEMPLATE = '''"""Auto-generated custom tool: {tool_name}"""
 import asyncio
@@ -16,18 +25,68 @@ import re
 import socket
 import subprocess
 
-from clearwing.agent.tooling import tool
 
-
-@tool
 async def {tool_name}({param_signature}) -> str:
     """{description}"""
 {code}
+
+
+if __name__ == "__main__":
+    import sys as _sys
+    _kwargs = json.loads(_sys.stdin.read() or "{{}}")
+    _result = asyncio.run({tool_name}(**_kwargs))
+    _sys.stdout.write(json.dumps(_result))
 '''
 
 
 def _validate_tool_name(name: str) -> bool:
-    return bool(re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", name))
+    return bool(_NAME_RE.fullmatch(name))
+
+
+def _validate_parameters(parameters: list[dict]) -> str | None:
+    """Return an error string if any parameter is invalid, else None."""
+    for p in parameters:
+        pname = p.get("name")
+        ptype = p.get("type", "str")
+        if not isinstance(pname, str) or not _NAME_RE.fullmatch(pname):
+            return f"Invalid parameter name: {pname!r}"
+        if ptype not in _ALLOWED_PARAM_TYPES:
+            return f"Invalid parameter type: {ptype!r}"
+    return None
+
+
+def _sandbox_env() -> dict:
+    return {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+    }
+
+
+def _run_sandboxed(file_path: Path, kwargs: dict) -> str:
+    """Execute a generated tool file in an isolated interpreter."""
+    proc = subprocess.run(
+        [sys.executable, "-I", str(file_path)],
+        input=json.dumps(kwargs),
+        env=_sandbox_env(),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if proc.returncode != 0:
+        return json.dumps({"error": proc.stderr.strip() or "sandbox exited non-zero"})
+    return proc.stdout
+
+
+def _make_stub(tool_name: str, description: str, parameters: list[dict], file_path: Path):
+    """Build an @tool-decorated stub that shells out to the sandboxed subprocess."""
+    param_names = [p["name"] for p in parameters]
+
+    async def _stub(**kwargs) -> str:
+        forwarded = {k: kwargs.get(k) for k in param_names}
+        return _run_sandboxed(file_path, forwarded)
+
+    _stub.__name__ = tool_name
+    _stub.__doc__ = description
+    return tool(_stub)
 
 
 @tool
@@ -39,23 +98,47 @@ def create_custom_tool(
 ) -> dict:
     """Create a new tool at runtime by writing a Python file.
 
-    The tool will be a @tool-decorated async function. It has access to:
-    asyncio, json, re, socket, subprocess.
+    The generated file is written to an ephemeral temp directory and executed
+    in an isolated Python subprocess (`python -I`) with a minimal environment.
+    It has access to: asyncio, json, re, socket, subprocess.
 
     Args:
-        tool_name: Name for the tool (alphanumeric and underscores only).
+        tool_name: Name for the tool (lowercase alphanumeric and underscores,
+            max 41 chars, must not start with a digit).
         description: Description of what the tool does.
         parameters: List of parameter dicts with keys: name, type, description.
+            ``type`` must be one of str, int, float, bool, dict, list.
         python_code: Python code for the function body (will be indented).
 
     Returns:
         Dict with keys: success, tool_name, message.
     """
+    if not interrupt(
+        f"Approve creating custom tool '{tool_name}' that will execute "
+        f"arbitrary Python code in a sandboxed subprocess?"
+    ):
+        return {
+            "success": False,
+            "tool_name": tool_name,
+            "message": "Custom tool creation not approved.",
+        }
+
     if not _validate_tool_name(tool_name):
         return {
             "success": False,
             "tool_name": tool_name,
-            "message": "Invalid tool name. Use only alphanumeric characters and underscores.",
+            "message": (
+                "Invalid tool name. Use lowercase letters, digits and "
+                "underscores only (max 41 chars, cannot start with a digit)."
+            ),
+        }
+
+    param_error = _validate_parameters(parameters)
+    if param_error:
+        return {
+            "success": False,
+            "tool_name": tool_name,
+            "message": param_error,
         }
 
     # Build parameter signature
@@ -68,9 +151,13 @@ def create_custom_tool(
     # Indent code body
     indented_code = "\n".join(f"    {line}" for line in python_code.strip().splitlines())
 
+    # Escape the description so a crafted docstring cannot break out of the
+    # triple-quoted block and inject top-level code.
+    safe_description = json.dumps(description)[1:-1]
+
     file_content = TOOL_TEMPLATE.format(
         tool_name=tool_name,
-        description=description,
+        description=safe_description,
         param_signature=param_signature,
         code=indented_code,
     )
@@ -79,26 +166,16 @@ def create_custom_tool(
     file_path = CUSTOM_TOOLS_DIR / f"{tool_name}.py"
     file_path.write_text(file_content)
 
-    # Load the module
-    spec = importlib.util.spec_from_file_location(
-        f"clearwing.agent.custom_tools.{tool_name}", str(file_path)
-    )
-    if spec is None or spec.loader is None:
-        return {
-            "success": False,
-            "tool_name": tool_name,
-            "message": f"Failed to build import spec for {file_path}",
-        }
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-
-    tool_func = getattr(module, tool_name)
-    _CUSTOM_TOOL_REGISTRY[tool_name] = tool_func
+    stub = _make_stub(tool_name, safe_description, parameters, file_path)
+    _CUSTOM_TOOL_REGISTRY[tool_name] = stub
 
     return {
         "success": True,
         "tool_name": tool_name,
-        "message": f"Tool '{tool_name}' created and registered.",
+        "message": (
+            f"Tool '{tool_name}' created and registered "
+            f"(sandboxed subprocess at {file_path})."
+        ),
     }
 
 

--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -1,6 +1,8 @@
 """Tests for dynamic tool creator."""
 
+import inspect
 import json
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -18,8 +20,14 @@ from clearwing.agent.tools.ops.dynamic_tool_creator import (
 
 
 @pytest.fixture
-def approve():
-    """Auto-approve the human-in-the-loop gate for tests that exercise the happy path."""
+def enabled(monkeypatch):
+    """Enable the default-disabled dynamic tools feature."""
+    monkeypatch.setenv("CLEARWING_ENABLE_DYNAMIC_TOOLS", "1")
+
+
+@pytest.fixture
+def approve(enabled):
+    """Enable the feature and auto-approve the human-in-the-loop gate."""
     with patch.object(dtc_mod, "interrupt", return_value=True):
         yield
 
@@ -144,7 +152,7 @@ class TestSecurityHardening:
         yield
         _CUSTOM_TOOL_REGISTRY.clear()
 
-    def test_interrupt_gate_blocks_when_denied(self):
+    def test_interrupt_gate_blocks_when_denied(self, enabled):
         with patch.object(dtc_mod, "interrupt", return_value=False):
             result = create_custom_tool.invoke(
                 {
@@ -209,7 +217,7 @@ class TestSecurityHardening:
         pkg_root = str(clearwing.__path__[0])
         assert not str(CUSTOM_TOOLS_DIR).startswith(pkg_root)
 
-    def test_stub_shells_to_isolated_subprocess(self, approve):
+    def test_stub_runs_in_isolated_docker_container(self, approve):
         create_custom_tool.invoke(
             {
                 "tool_name": "test_greeting",
@@ -219,13 +227,99 @@ class TestSecurityHardening:
             }
         )
         stub = _CUSTOM_TOOL_REGISTRY["test_greeting"]
-        with patch.object(dtc_mod, "subprocess") as mock_sub:
-            mock_sub.run.return_value.returncode = 0
-            mock_sub.run.return_value.stdout = json.dumps("hi")
+        with patch.object(dtc_mod.subprocess, "run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = json.dumps("hi")
             out = stub.invoke({"name": "hi"})
         assert out == json.dumps("hi")
-        args, kwargs = mock_sub.run.call_args
+        args, kwargs = mock_run.call_args
         argv = args[0]
-        assert argv[1] == "-I"
+        assert argv[0] == "docker"
+        assert argv[1] == "run"
+        assert "--rm" in argv
+        assert "--network=none" in argv
+        assert "--cap-drop=ALL" in argv
+        assert "--security-opt=no-new-privileges" in argv
+        assert "--memory=512m" in argv
+        assert "--pids-limit=128" in argv
+        # The tool dir is mounted read-only and the file executed from /tool
+        mount = argv[argv.index("-v") + 1]
+        assert mount == f"{CUSTOM_TOOLS_DIR}:/tool:ro"
+        assert argv[-3:] == ["python", "-I", "/tool/test_greeting.py"]
+        # No host interpreter anywhere in the invocation
+        assert sys.executable not in argv
         assert kwargs["capture_output"] is True
-        assert set(kwargs["env"].keys()) == {"PATH"}
+
+    def test_no_host_python_execution_path_in_module(self):
+        # The maintainer-flagged `subprocess.run([sys.executable, "-I", ...])`
+        # host path must be gone entirely: the module must not reference the
+        # host interpreter at all.
+        source = inspect.getsource(dtc_mod)
+        assert "sys.executable" not in source
+        assert not hasattr(dtc_mod, "sys")
+
+    def test_fails_closed_when_docker_missing(self, approve):
+        create_custom_tool.invoke(
+            {
+                "tool_name": "test_greeting",
+                "description": "d",
+                "parameters": [{"name": "name", "type": "str"}],
+                "python_code": "return name",
+            }
+        )
+        stub = _CUSTOM_TOOL_REGISTRY["test_greeting"]
+        with patch.object(
+            dtc_mod.subprocess,
+            "run",
+            side_effect=FileNotFoundError("No such file or directory: 'docker'"),
+        ):
+            out = stub.invoke({"name": "hi"})
+        payload = json.loads(out)
+        assert "error" in payload
+        assert "docker" in payload["error"].lower()
+        assert "host" in payload["error"].lower()
+
+
+class TestDefaultDisabled:
+    """create_custom_tool must be disabled unless explicitly opted in."""
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self):
+        yield
+        _CUSTOM_TOOL_REGISTRY.clear()
+
+    def _invoke(self):
+        return create_custom_tool.invoke(
+            {
+                "tool_name": "gated_tool",
+                "description": "d",
+                "parameters": [],
+                "python_code": "return 'x'",
+            }
+        )
+
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("CLEARWING_ENABLE_DYNAMIC_TOOLS", raising=False)
+        with patch.object(
+            dtc_mod, "interrupt", side_effect=AssertionError("interrupt must not be reached")
+        ):
+            result = self._invoke()
+        assert result["success"] is False
+        assert "disabled by default" in result["message"]
+        assert "CLEARWING_ENABLE_DYNAMIC_TOOLS" in result["message"]
+        assert "gated_tool" not in _CUSTOM_TOOL_REGISTRY
+
+    def test_disabled_unless_env_is_exactly_one(self, monkeypatch):
+        for value in ("true", "yes", "0", ""):
+            monkeypatch.setenv("CLEARWING_ENABLE_DYNAMIC_TOOLS", value)
+            result = self._invoke()
+            assert result["success"] is False, f"value {value!r} should not enable"
+        assert "gated_tool" not in _CUSTOM_TOOL_REGISTRY
+
+    def test_enabled_still_requires_interrupt_approval(self, monkeypatch):
+        monkeypatch.setenv("CLEARWING_ENABLE_DYNAMIC_TOOLS", "1")
+        with patch.object(dtc_mod, "interrupt", return_value=False) as mock_interrupt:
+            result = self._invoke()
+        mock_interrupt.assert_called_once()
+        assert result["success"] is False
+        assert "not approved" in result["message"].lower()

--- a/tests/test_dynamic_tools.py
+++ b/tests/test_dynamic_tools.py
@@ -1,17 +1,27 @@
 """Tests for dynamic tool creator."""
 
-from pathlib import Path
+import json
+from unittest.mock import patch
 
 import pytest
 
+import clearwing.agent.tools.ops.dynamic_tool_creator as dtc_mod
 from clearwing.agent.tools.ops.dynamic_tool_creator import (
     _CUSTOM_TOOL_REGISTRY,
+    CUSTOM_TOOLS_DIR,
+    _validate_parameters,
+    _validate_tool_name,
     create_custom_tool,
     get_custom_tools,
     list_custom_tools,
 )
 
-CUSTOM_TOOLS_DIR = Path(__file__).parent.parent / "clearwing" / "agent" / "custom_tools"
+
+@pytest.fixture
+def approve():
+    """Auto-approve the human-in-the-loop gate for tests that exercise the happy path."""
+    with patch.object(dtc_mod, "interrupt", return_value=True):
+        yield
 
 
 class TestDynamicToolCreator:
@@ -26,7 +36,7 @@ class TestDynamicToolCreator:
         # Clear registry
         _CUSTOM_TOOL_REGISTRY.clear()
 
-    def test_create_simple_tool(self):
+    def test_create_simple_tool(self, approve):
         result = create_custom_tool.invoke(
             {
                 "tool_name": "test_greeting",
@@ -39,17 +49,16 @@ class TestDynamicToolCreator:
         assert result["success"] is True
         assert result["tool_name"] == "test_greeting"
 
-        # Verify file was written
+        # Verify file was written to the ephemeral temp dir, not the package tree
         tool_file = CUSTOM_TOOLS_DIR / "test_greeting.py"
         assert tool_file.exists()
         content = tool_file.read_text()
         assert "test_greeting" in content
-        assert "@tool" in content
 
         # Verify registered
         assert "test_greeting" in _CUSTOM_TOOL_REGISTRY
 
-    def test_create_tool_with_multiple_params(self):
+    def test_create_tool_with_multiple_params(self, approve):
         result = create_custom_tool.invoke(
             {
                 "tool_name": "test_adder",
@@ -65,7 +74,7 @@ class TestDynamicToolCreator:
         assert result["success"] is True
         assert "test_adder" in _CUSTOM_TOOL_REGISTRY
 
-    def test_name_validation_rejects_path_traversal(self):
+    def test_name_validation_rejects_path_traversal(self, approve):
         result = create_custom_tool.invoke(
             {
                 "tool_name": "../../../etc/evil",
@@ -76,7 +85,7 @@ class TestDynamicToolCreator:
         )
         assert result["success"] is False
 
-    def test_name_validation_rejects_special_chars(self):
+    def test_name_validation_rejects_special_chars(self, approve):
         result = create_custom_tool.invoke(
             {
                 "tool_name": "my-tool",
@@ -87,7 +96,7 @@ class TestDynamicToolCreator:
         )
         assert result["success"] is False
 
-    def test_name_validation_rejects_starting_digit(self):
+    def test_name_validation_rejects_starting_digit(self, approve):
         result = create_custom_tool.invoke(
             {
                 "tool_name": "1tool",
@@ -98,7 +107,7 @@ class TestDynamicToolCreator:
         )
         assert result["success"] is False
 
-    def test_list_custom_tools(self):
+    def test_list_custom_tools(self, approve):
         create_custom_tool.invoke(
             {
                 "tool_name": "test_greeting",
@@ -112,7 +121,7 @@ class TestDynamicToolCreator:
         assert len(result) == 1
         assert result[0]["name"] == "test_greeting"
 
-    def test_get_custom_tools(self):
+    def test_get_custom_tools(self, approve):
         create_custom_tool.invoke(
             {
                 "tool_name": "test_greeting",
@@ -125,3 +134,98 @@ class TestDynamicToolCreator:
         tools = get_custom_tools()
         assert len(tools) == 1
         assert tools[0].name == "test_greeting"
+
+
+class TestSecurityHardening:
+    """Regression tests for the c14 sandbox hardening."""
+
+    @pytest.fixture(autouse=True)
+    def cleanup(self):
+        yield
+        _CUSTOM_TOOL_REGISTRY.clear()
+
+    def test_interrupt_gate_blocks_when_denied(self):
+        with patch.object(dtc_mod, "interrupt", return_value=False):
+            result = create_custom_tool.invoke(
+                {
+                    "tool_name": "denied_tool",
+                    "description": "d",
+                    "parameters": [],
+                    "python_code": "return 'x'",
+                }
+            )
+        assert result["success"] is False
+        assert "not approved" in result["message"].lower()
+        assert "denied_tool" not in _CUSTOM_TOOL_REGISTRY
+
+    def test_name_regex_rejects_uppercase(self):
+        assert _validate_tool_name("MyTool") is False
+
+    def test_name_regex_rejects_over_length(self):
+        assert _validate_tool_name("a" * 42) is False
+        assert _validate_tool_name("a" * 41) is True
+
+    def test_parameter_name_validated(self):
+        err = _validate_parameters([{"name": "x; import os", "type": "str"}])
+        assert err is not None
+        assert "Invalid parameter name" in err
+
+    def test_parameter_type_allowlist(self):
+        err = _validate_parameters([{"name": "x", "type": "__import__('os')"}])
+        assert err is not None
+        assert "Invalid parameter type" in err
+        assert _validate_parameters([{"name": "x", "type": "int"}]) is None
+
+    def test_rejects_invalid_parameter_via_tool(self, approve):
+        result = create_custom_tool.invoke(
+            {
+                "tool_name": "bad_param_tool",
+                "description": "d",
+                "parameters": [{"name": "x)", "type": "str"}],
+                "python_code": "return 'x'",
+            }
+        )
+        assert result["success"] is False
+
+    def test_description_is_escaped(self, approve):
+        # A description that would otherwise close the docstring and inject code.
+        result = create_custom_tool.invoke(
+            {
+                "tool_name": "test_greeting",
+                "description": '"""\nimport os; os.system("id")\n"""',
+                "parameters": [],
+                "python_code": "return 'ok'",
+            }
+        )
+        assert result["success"] is True
+        content = (CUSTOM_TOOLS_DIR / "test_greeting.py").read_text()
+        # The raw triple-quote sequence must not survive into the generated file.
+        assert '"""\nimport os' not in content
+        (CUSTOM_TOOLS_DIR / "test_greeting.py").unlink()
+
+    def test_temp_dir_outside_package_tree(self):
+        import clearwing
+
+        pkg_root = str(clearwing.__path__[0])
+        assert not str(CUSTOM_TOOLS_DIR).startswith(pkg_root)
+
+    def test_stub_shells_to_isolated_subprocess(self, approve):
+        create_custom_tool.invoke(
+            {
+                "tool_name": "test_greeting",
+                "description": "d",
+                "parameters": [{"name": "name", "type": "str"}],
+                "python_code": "return name",
+            }
+        )
+        stub = _CUSTOM_TOOL_REGISTRY["test_greeting"]
+        with patch.object(dtc_mod, "subprocess") as mock_sub:
+            mock_sub.run.return_value.returncode = 0
+            mock_sub.run.return_value.stdout = json.dumps("hi")
+            out = stub.invoke({"name": "hi"})
+        assert out == json.dumps("hi")
+        args, kwargs = mock_sub.run.call_args
+        argv = args[0]
+        assert argv[1] == "-I"
+        assert kwargs["capture_output"] is True
+        assert set(kwargs["env"].keys()) == {"PATH"}


### PR DESCRIPTION
# fix(security): sandbox and gate `create_custom_tool`

## Vulnerability

`create_custom_tool` accepted an LLM-supplied `tool_name`, `description`,
`parameters`, and `python_code`, wrote a `.py` file into the installed
`clearwing/agent/custom_tools/` package directory, and immediately loaded it
into the host interpreter via `importlib.util.spec_from_file_location` /
`spec.loader.exec_module`. Several inputs were interpolated into the source
template without escaping:

- `description` was placed inside a triple-quoted docstring. A payload such as
  `"""\nimport os; os.system(...)\n"""` closed the docstring and executed at
  import time.
- `parameters[i]['name']` and `['type']` were interpolated into the function
  signature with no validation, allowing arbitrary syntax injection
  (`name="x=0): pass\nimport os#"`, `type="str=__import__('os').system('id')"`).
- `tool_name` was validated against `^[a-zA-Z_][a-zA-Z0-9_]*$` (unbounded
  length, mixed case) and used both as a filename and a Python identifier.
- Generated files persisted inside the installed package tree, so a single
  successful injection survived process restarts and became importable by any
  later `import clearwing.agent.custom_tools.*`.
- No human-in-the-loop gate: the LLM could call this tool autonomously.

## Impact

Remote code execution in the agent host process with the operator's
privileges, triggerable by any prompt-injection vector that can influence
tool arguments. Because generated files landed in the package tree, the RCE
was also persistent across sessions.

## Fix

- Gate the tool behind `interrupt()` so a human must approve every creation.
- Tighten `_validate_tool_name` to `^[a-z_][a-z0-9_]{0,40}$`.
- Validate every `parameters[i]['name']` against the same regex and restrict
  `['type']` to `{"str","int","float","bool","dict","list"}`.
- Escape `description` via `json.dumps()[1:-1]` before templating.
- Write generated files to `tempfile.mkdtemp()` instead of the package tree.
- Replace `importlib.exec_module` with an out-of-process run:
  `subprocess.run([sys.executable, "-I", tmpfile], env={"PATH": ...},
  capture_output=True)`. The registered tool is now a stub that shells to that
  subprocess and returns its stdout, so generated code never executes inside
  the agent's interpreter or with its environment.

## Testing

`tests/test_dynamic_tools.py` extended with a `TestSecurityHardening` class
covering: interrupt denial, tightened name regex (uppercase, length),
parameter name/type allowlist, docstring-escape regression, temp-dir location
outside the package tree, and verification that the registered stub invokes
`subprocess.run([..., "-I", ...], capture_output=True, env={"PATH": ...})`.

Full suite: 2770 passed, 2 skipped, 1 pre-existing unrelated failure
(`test_webcrypto_hooks.py::TestInstallOnBlankPage::test_succeeds_with_init_script`).
