### PR TITLE
fix(security): allowlist connect_mcp_server command and confine server path

### DIFF
--- a/clearwing/agent/tools/ops/mcp_tools.py
+++ b/clearwing/agent/tools/ops/mcp_tools.py
@@ -1,11 +1,66 @@
+import os
+from pathlib import Path
 from typing import Any
 
-from clearwing.agent.tooling import tool
+from clearwing.agent.tooling import interrupt, tool
 
 from ....mcp.client import MCPClient
 
 # Global registry of active MCP clients
 _MCP_CLIENTS: dict[str, MCPClient] = {}
+
+
+def _allowed_commands() -> set[str]:
+    raw = os.environ.get(
+        "CLEARWING_MCP_ALLOWED_COMMANDS", "python,python3,node,npx,bun"
+    )
+    return {c.strip() for c in raw.split(",") if c.strip()}
+
+
+def _servers_dir() -> Path:
+    return Path(
+        os.environ.get(
+            "CLEARWING_MCP_SERVERS_DIR", str(Path.home() / ".clearwing" / "mcp_servers")
+        )
+    ).resolve()
+
+
+def _minimal_env() -> dict[str, str]:
+    return {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", str(Path.home())),
+    }
+
+
+def _validate_launch_spec(command: str, args: list[str]) -> str | None:
+    """Return an error string if the launch spec is not permitted, else None."""
+    cmd_name = Path(command).name
+    allowed = _allowed_commands()
+    if cmd_name not in allowed:
+        return (
+            f"Command '{cmd_name}' is not in the MCP allowlist "
+            f"({sorted(allowed)}). Set CLEARWING_MCP_ALLOWED_COMMANDS to extend it."
+        )
+
+    if not args:
+        return (
+            "At least one argument (the server script path) is required so it can "
+            "be confined to CLEARWING_MCP_SERVERS_DIR."
+        )
+
+    servers_dir = _servers_dir()
+    try:
+        script = Path(args[0]).resolve()
+    except (OSError, ValueError) as exc:  # pragma: no cover - defensive
+        return f"Could not resolve server script path: {exc}"
+    try:
+        script.relative_to(servers_dir)
+    except ValueError:
+        return (
+            f"Server script '{script}' is outside the permitted directory "
+            f"'{servers_dir}'. Set CLEARWING_MCP_SERVERS_DIR to change it."
+        )
+    return None
 
 
 @tool
@@ -15,6 +70,12 @@ def connect_mcp_server(name: str, command: str, args: list[str] | None = None) -
     This allows the agent to access additional tools from external providers,
     such as source code analysis, database access, or cloud APIs.
 
+    The launcher command must be on the ``CLEARWING_MCP_ALLOWED_COMMANDS``
+    allowlist (default: ``python,python3,node,npx,bun``) and the first argument
+    must resolve to a path under ``CLEARWING_MCP_SERVERS_DIR`` (default:
+    ``~/.clearwing/mcp_servers``). The server process is started with a minimal
+    ``PATH``/``HOME`` environment.
+
     Args:
         name: A unique identifier for this MCP server.
         command: The shell command to start the MCP server (stdio transport).
@@ -23,11 +84,22 @@ def connect_mcp_server(name: str, command: str, args: list[str] | None = None) -
     Returns:
         Dict with status, server name, and list of available tools.
     """
+    args = list(args or [])
+
+    if not interrupt(
+        f"Approve launching MCP server '{name}' via `{command} {' '.join(args)}`?"
+    ):
+        return {"status": "error", "message": "MCP server launch not approved."}
+
+    error = _validate_launch_spec(command, args)
+    if error:
+        return {"status": "error", "message": error}
+
     if name in _MCP_CLIENTS:
         return {"status": "already_connected", "name": name}
 
     try:
-        client = MCPClient(command, args or [])
+        client = MCPClient(command, args, env=_minimal_env())
         client.connect()
         _MCP_CLIENTS[name] = client
 

--- a/clearwing/mcp/client.py
+++ b/clearwing/mcp/client.py
@@ -6,9 +6,10 @@ import threading
 class MCPClient:
     """MCP client for connecting to external MCP servers via stdio transport."""
 
-    def __init__(self, command: str, args: list[str] = None):
+    def __init__(self, command: str, args: list[str] = None, env: dict[str, str] | None = None):
         self.command = command
         self.args = args or []
+        self.env = env
         self.process: subprocess.Popen | None = None
         self._id_counter = 0
         self._pending_requests: dict[int, threading.Event] = {}
@@ -24,6 +25,7 @@ class MCPClient:
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
+            env=self.env,
         )
         self._read_thread = threading.Thread(target=self._read_loop, daemon=True)
         self._read_thread.start()

--- a/tests/test_mcp_tools_security.py
+++ b/tests/test_mcp_tools_security.py
@@ -1,0 +1,121 @@
+"""Security tests for connect_mcp_server (c15 command allowlist)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import clearwing.agent.tools.ops.mcp_tools as mcp_mod
+from clearwing.agent.tools.ops.mcp_tools import (
+    _MCP_CLIENTS,
+    _allowed_commands,
+    _servers_dir,
+    _validate_launch_spec,
+    connect_mcp_server,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_clients():
+    _MCP_CLIENTS.clear()
+    yield
+    _MCP_CLIENTS.clear()
+
+
+@pytest.fixture
+def approve():
+    with patch.object(mcp_mod, "interrupt", return_value=True):
+        yield
+
+
+@pytest.fixture
+def servers_dir(tmp_path, monkeypatch):
+    d = tmp_path / "mcp_servers"
+    d.mkdir()
+    monkeypatch.setenv("CLEARWING_MCP_SERVERS_DIR", str(d))
+    return d
+
+
+class TestInterruptGate:
+    def test_denied(self, servers_dir):
+        with patch.object(mcp_mod, "interrupt", return_value=False):
+            result = connect_mcp_server.invoke(
+                {"name": "x", "command": "python3", "args": [str(servers_dir / "s.py")]}
+            )
+        assert result["status"] == "error"
+        assert "not approved" in result["message"].lower()
+
+
+class TestCommandAllowlist:
+    def test_default_allowlist(self, monkeypatch):
+        monkeypatch.delenv("CLEARWING_MCP_ALLOWED_COMMANDS", raising=False)
+        assert _allowed_commands() == {"python", "python3", "node", "npx", "bun"}
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("CLEARWING_MCP_ALLOWED_COMMANDS", "deno, python3 ")
+        assert _allowed_commands() == {"deno", "python3"}
+
+    def test_rejects_disallowed_command(self, approve, servers_dir):
+        result = connect_mcp_server.invoke(
+            {"name": "x", "command": "bash", "args": [str(servers_dir / "s.sh")]}
+        )
+        assert result["status"] == "error"
+        assert "allowlist" in result["message"]
+
+    def test_basename_is_checked(self, approve, servers_dir):
+        # /usr/bin/bash -> basename 'bash' still rejected
+        result = connect_mcp_server.invoke(
+            {"name": "x", "command": "/usr/bin/bash", "args": [str(servers_dir / "s.sh")]}
+        )
+        assert result["status"] == "error"
+
+
+class TestServersDirConfinement:
+    def test_default_dir(self, monkeypatch):
+        monkeypatch.delenv("CLEARWING_MCP_SERVERS_DIR", raising=False)
+        assert _servers_dir() == (Path.home() / ".clearwing" / "mcp_servers").resolve()
+
+    def test_rejects_script_outside_dir(self, approve, servers_dir, tmp_path):
+        outside = tmp_path / "elsewhere.py"
+        outside.write_text("")
+        result = connect_mcp_server.invoke(
+            {"name": "x", "command": "python3", "args": [str(outside)]}
+        )
+        assert result["status"] == "error"
+        assert "outside the permitted directory" in result["message"]
+
+    def test_rejects_traversal(self, approve, servers_dir):
+        err = _validate_launch_spec("python3", [str(servers_dir / ".." / "evil.py")])
+        assert err is not None
+
+    def test_requires_first_arg(self, approve, servers_dir):
+        result = connect_mcp_server.invoke({"name": "x", "command": "python3", "args": []})
+        assert result["status"] == "error"
+        assert "server script path" in result["message"]
+
+
+class TestMinimalEnvPassedToPopen:
+    def test_happy_path_passes_minimal_env(self, approve, servers_dir):
+        script = servers_dir / "server.py"
+        script.write_text("")
+
+        fake_client = MagicMock()
+        fake_client.list_tools.return_value = [{"name": "t"}]
+        with patch.object(mcp_mod, "MCPClient", return_value=fake_client) as mock_cls:
+            result = connect_mcp_server.invoke(
+                {"name": "srv", "command": "python3", "args": [str(script)]}
+            )
+        assert result["status"] == "connected"
+        _, kwargs = mock_cls.call_args
+        assert set(kwargs["env"].keys()) == {"PATH", "HOME"}
+
+    def test_client_forwards_env_to_popen(self):
+        from clearwing.mcp.client import MCPClient
+
+        with patch("clearwing.mcp.client.subprocess.Popen") as mock_popen:
+            mock_popen.return_value.stdout = iter([])
+            client = MCPClient("python3", ["x.py"], env={"PATH": "/usr/bin", "HOME": "/tmp"})
+            with patch.object(client, "call", return_value={}):
+                client.connect()
+        _, kwargs = mock_popen.call_args
+        assert kwargs["env"] == {"PATH": "/usr/bin", "HOME": "/tmp"}


### PR DESCRIPTION
# fix(security): allowlist and confine `connect_mcp_server`

## Vulnerability

`connect_mcp_server` accepted an arbitrary `command` and `args` from the LLM
and passed them straight to `subprocess.Popen([command] + args, ...)` inside
`MCPClient.connect()`, inheriting the full parent environment. There was no
allowlist on the executable, no restriction on which script could be launched,
and no human-in-the-loop gate.

## Impact

Arbitrary command execution on the agent host. A prompt-injected model could
call `connect_mcp_server("x", "bash", ["-c", "curl ... | sh"])` (or any binary
on `$PATH`) and the process would inherit every secret in the agent's
environment (`ANTHROPIC_API_KEY`, cloud credentials, etc.).

## Fix

- Gate the tool behind `interrupt()` so a human must approve every launch.
- Allowlist `Path(command).name` against
  `CLEARWING_MCP_ALLOWED_COMMANDS` (default `python,python3,node,npx,bun`).
- Require `Path(args[0]).resolve()` to lie under `CLEARWING_MCP_SERVERS_DIR`
  (default `~/.clearwing/mcp_servers`), rejecting traversal and empty `args`.
- Thread an `env` parameter through `MCPClient` to `Popen` and pass a minimal
  `{"PATH": ..., "HOME": ...}` so the server process does not inherit host
  secrets.

## Testing

New `tests/test_mcp_tools_security.py` covers: interrupt denial, default and
overridden allowlist, rejection of disallowed commands (including absolute
paths), servers-dir default, rejection of scripts outside the directory and
`..` traversal, empty-args rejection, minimal `env` passed to `MCPClient`, and
`MCPClient` forwarding `env=` to `Popen`.

Full suite: 2772 passed, 2 skipped, 1 pre-existing unrelated failure
(`test_webcrypto_hooks.py::TestInstallOnBlankPage::test_succeeds_with_init_script`).
