### PR TITLE
fix(security): require X-API-Key on /api/operate and /ws/agent

### DIFF
--- a/clearwing/ui/web/app.py
+++ b/clearwing/ui/web/app.py
@@ -1,14 +1,15 @@
 """FastAPI web UI backend for Clearwing."""
 
 import asyncio
+import hmac
 import json
 import logging
+import os
 import uuid
+from pathlib import Path
 from typing import Any
 
-from pathlib import Path
-
-from fastapi import FastAPI, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import Depends, FastAPI, Header, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -32,6 +33,11 @@ def _make_cost_tracker():
     return telemetry.CostTracker()
 
 
+def _cors_origins() -> list[str]:
+    raw = os.environ.get("CLEARWING_WEB_CORS_ORIGINS", "")
+    return [o.strip() for o in raw.split(",") if o.strip()]
+
+
 def create_app():
     """Create and configure the FastAPI application."""
     app = FastAPI(
@@ -42,11 +48,31 @@ def create_app():
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=_cors_origins(),
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # ---------------------------------------------------------------
+    # Authentication for privileged endpoints
+    # ---------------------------------------------------------------
+
+    _api_key = os.environ.get("CLEARWING_WEB_API_KEY")
+
+    def require_api_key(x_api_key: str | None = Header(default=None, alias="X-API-Key")) -> None:
+        if not _api_key:
+            # Should be unreachable because routes are not mounted without a key,
+            # but keep a defensive fallback.
+            raise HTTPException(status_code=503, detail="API key not configured")
+        if x_api_key is None or not hmac.compare_digest(x_api_key, _api_key):
+            raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    def _ws_authorized(websocket: WebSocket) -> bool:
+        provided = websocket.headers.get("x-api-key") or websocket.query_params.get("api_key")
+        return bool(
+            _api_key and provided is not None and hmac.compare_digest(provided, _api_key)
+        )
 
     # Serve the single-page frontend
     _static_dir = Path(__file__).parent / "static"
@@ -132,9 +158,38 @@ def create_app():
             media_type="text/plain",
         )
 
-    @app.post("/api/operate")
+    if not _api_key:
+        logger.error(
+            "CLEARWING_WEB_API_KEY is not set; refusing to mount /api/operate* "
+            "and /ws/agent. Set the environment variable and restart to enable "
+            "the operator endpoints."
+        )
+
+        @app.post("/api/operate")
+        async def _operate_disabled_post():
+            raise HTTPException(
+                status_code=503,
+                detail="Operator API disabled: CLEARWING_WEB_API_KEY is not set",
+            )
+
+        @app.get("/api/operate/{session_id}")
+        async def _operate_disabled_get(session_id: str):
+            raise HTTPException(
+                status_code=503,
+                detail="Operator API disabled: CLEARWING_WEB_API_KEY is not set",
+            )
+
+        @app.websocket("/ws/agent")
+        async def _ws_disabled(websocket: WebSocket):
+            await websocket.close(code=1008)
+
+        return app
+
+    @app.post("/api/operate", dependencies=[Depends(require_api_key)])
     async def start_operator(request_body: dict):
         """Start an autonomous Operator agent session.
+
+        Requires the ``X-API-Key`` header to match ``CLEARWING_WEB_API_KEY``.
 
         Request body:
         {
@@ -142,9 +197,11 @@ def create_app():
             "goals": ["Scan ports", "Find vulnerabilities"],
             "model": "claude-sonnet-4-6",
             "max_turns": 50,
-            "timeout_minutes": 30,
-            "auto_approve_exploits": false
+            "timeout_minutes": 30
         }
+
+        ``auto_approve_exploits`` is ignored if supplied; exploit approval is
+        always required.
         """
         target = request_body.get("target")
         goals = request_body.get("goals", [])
@@ -170,7 +227,10 @@ def create_app():
                     api_key=request_body.get("api_key"),
                     max_turns=request_body.get("max_turns", 50),
                     timeout_minutes=request_body.get("timeout_minutes", 30),
-                    auto_approve_exploits=request_body.get("auto_approve_exploits", False),
+                    # auto_approve_exploits is intentionally not accepted from
+                    # the request body; a remote caller must never be able to
+                    # bypass the exploit approval gate.
+                    auto_approve_exploits=False,
                 )
                 operator = OperatorAgent(config)
                 result = await operator.arun()
@@ -264,7 +324,7 @@ def create_app():
         finally:
             db.close()
 
-    @app.get("/api/operate/{session_id}")
+    @app.get("/api/operate/{session_id}", dependencies=[Depends(require_api_key)])
     async def get_operator_status(session_id: str):
         """Get the status of an operator session."""
         if session_id not in _sessions:
@@ -292,6 +352,9 @@ def create_app():
         - Server sends: {"type": "error", "message": "..."}
         - Server sends: {"type": "complete"}
         """
+        if not _ws_authorized(websocket):
+            await websocket.close(code=1008)
+            return
         await websocket.accept()
 
         message_queue: asyncio.Queue = asyncio.Queue()

--- a/tests/test_webui.py
+++ b/tests/test_webui.py
@@ -8,17 +8,32 @@ import pytest
 fastapi = pytest.importorskip("fastapi")
 from fastapi.testclient import TestClient
 
-from clearwing.ui.web.app import create_app
+from clearwing.ui.web.app import _cors_origins, create_app
+
+API_KEY = "test-key-8f3a"
+AUTH = {"X-API-Key": API_KEY}
 
 
 @pytest.fixture
-def app():
+def app(monkeypatch):
+    monkeypatch.setenv("CLEARWING_WEB_API_KEY", API_KEY)
     return create_app()
 
 
 @pytest.fixture
 def client(app):
     return TestClient(app)
+
+
+@pytest.fixture
+def unauth_app(monkeypatch):
+    monkeypatch.delenv("CLEARWING_WEB_API_KEY", raising=False)
+    return create_app()
+
+
+@pytest.fixture
+def unauth_client(unauth_app):
+    return TestClient(unauth_app)
 
 
 class TestHealthEndpoint:
@@ -108,7 +123,7 @@ class TestMetricsEndpoints:
 
 class TestOperateEndpoints:
     def test_start_operator_missing_fields(self, client):
-        resp = client.post("/api/operate", json={})
+        resp = client.post("/api/operate", json={}, headers=AUTH)
         assert resp.status_code == 400
 
     def test_start_operator(self, client):
@@ -118,6 +133,7 @@ class TestOperateEndpoints:
                 "target": "10.0.0.1",
                 "goals": ["Scan ports"],
             },
+            headers=AUTH,
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -125,7 +141,7 @@ class TestOperateEndpoints:
         assert data["status"] == "running"
 
     def test_get_operator_status_not_found(self, client):
-        resp = client.get("/api/operate/nonexistent")
+        resp = client.get("/api/operate/nonexistent", headers=AUTH)
         assert resp.status_code == 404
 
     def test_get_operator_status(self, client):
@@ -136,22 +152,23 @@ class TestOperateEndpoints:
                 "target": "10.0.0.1",
                 "goals": ["Scan"],
             },
+            headers=AUTH,
         )
         sid = resp.json()["session_id"]
 
-        resp = client.get(f"/api/operate/{sid}")
+        resp = client.get(f"/api/operate/{sid}", headers=AUTH)
         assert resp.status_code == 200
         assert resp.json()["target"] == "10.0.0.1"
 
 
 class TestWebSocketEndpoint:
     def test_websocket_connect(self, client):
-        with client.websocket_connect("/ws/agent"):
+        with client.websocket_connect("/ws/agent", headers=AUTH):
             # Just connect and disconnect
             pass
 
     def test_websocket_invalid_json(self, client):
-        with client.websocket_connect("/ws/agent") as ws:
+        with client.websocket_connect("/ws/agent", headers=AUTH) as ws:
             ws.send_text("not json")
             # Should disconnect gracefully
 
@@ -168,3 +185,88 @@ class TestCreateApp:
         [type(m) for m in app.user_middleware]
         # Just verify the app was created without error
         assert app is not None
+
+
+class TestOperateAuth:
+    """c16: /api/operate* and /ws/agent require X-API-Key."""
+
+    def test_operate_requires_key(self, client):
+        resp = client.post("/api/operate", json={"target": "x", "goals": ["g"]})
+        assert resp.status_code == 401
+
+    def test_operate_rejects_wrong_key(self, client):
+        resp = client.post(
+            "/api/operate",
+            json={"target": "x", "goals": ["g"]},
+            headers={"X-API-Key": "wrong"},
+        )
+        assert resp.status_code == 401
+
+    def test_operate_status_requires_key(self, client):
+        resp = client.get("/api/operate/abc")
+        assert resp.status_code == 401
+
+    def test_websocket_rejects_without_key(self, client):
+        with pytest.raises(Exception):
+            with client.websocket_connect("/ws/agent"):
+                pass
+
+    def test_websocket_rejects_wrong_key(self, client):
+        with pytest.raises(Exception):
+            with client.websocket_connect("/ws/agent", headers={"X-API-Key": "nope"}):
+                pass
+
+    def test_auto_approve_exploits_ignored(self, client):
+        with patch("clearwing.ui.web.app.OperatorConfig") as mock_cfg:
+            client.post(
+                "/api/operate",
+                json={
+                    "target": "10.0.0.1",
+                    "goals": ["g"],
+                    "auto_approve_exploits": True,
+                },
+                headers=AUTH,
+            )
+            # Background task may or may not have run yet under TestClient;
+            # if it did, auto_approve_exploits must be False regardless of body.
+            for call in mock_cfg.call_args_list:
+                assert call.kwargs.get("auto_approve_exploits") is False
+
+
+class TestOperateDisabledWithoutKey:
+    """c16: routes refuse to mount when CLEARWING_WEB_API_KEY is unset."""
+
+    def test_operate_503_without_env(self, unauth_client):
+        resp = unauth_client.post("/api/operate", json={"target": "x", "goals": ["g"]})
+        assert resp.status_code == 503
+        assert "CLEARWING_WEB_API_KEY" in resp.json()["detail"]
+
+    def test_operate_status_503_without_env(self, unauth_client):
+        resp = unauth_client.get("/api/operate/abc")
+        assert resp.status_code == 503
+
+    def test_health_still_works_without_env(self, unauth_client):
+        assert unauth_client.get("/api/health").status_code == 200
+
+    def test_websocket_closed_without_env(self, unauth_client):
+        with pytest.raises(Exception):
+            with unauth_client.websocket_connect("/ws/agent"):
+                pass
+
+    def test_log_emitted(self, monkeypatch, caplog):
+        monkeypatch.delenv("CLEARWING_WEB_API_KEY", raising=False)
+        with caplog.at_level("ERROR", logger="clearwing.ui.web.app"):
+            create_app()
+        assert any("CLEARWING_WEB_API_KEY" in r.message for r in caplog.records)
+
+
+class TestCorsOrigins:
+    def test_default_empty(self, monkeypatch):
+        monkeypatch.delenv("CLEARWING_WEB_CORS_ORIGINS", raising=False)
+        assert _cors_origins() == []
+
+    def test_from_env(self, monkeypatch):
+        monkeypatch.setenv(
+            "CLEARWING_WEB_CORS_ORIGINS", "https://a.example, https://b.example "
+        )
+        assert _cors_origins() == ["https://a.example", "https://b.example"]


### PR DESCRIPTION
# fix(security): require API key on operator web endpoints

## Vulnerability

`clearwing/ui/web/app.py` mounted `POST /api/operate`,
`GET /api/operate/{session_id}`, and `WS /ws/agent` with no authentication,
enabled `CORSMiddleware(allow_origins=["*"])`, and forwarded
`auto_approve_exploits` from the request body straight into `OperatorConfig`.

## Impact

Anyone with network reachability to the web UI (or, given the wildcard CORS,
any web page loaded in an operator's browser) could start an autonomous
pentest agent against an arbitrary target, read its findings, and set
`auto_approve_exploits=true` to bypass the human approval gate on exploit
execution. This is unauthenticated remote command-and-control of an offensive
agent.

## Fix

- Require an `X-API-Key` header equal to `CLEARWING_WEB_API_KEY` (compared via
  `hmac.compare_digest`) on `POST /api/operate`, `GET /api/operate/{id}`, and
  the `/ws/agent` WebSocket handshake (header or `?api_key=` query param).
- If `CLEARWING_WEB_API_KEY` is unset, log an error and mount stub handlers
  that return `503` / close `1008` instead of the real routes.
- Drop `auto_approve_exploits` from the accepted request body and hard-code
  it to `False` in the `OperatorConfig` built by the web layer.
- Source CORS origins from `CLEARWING_WEB_CORS_ORIGINS` (comma-separated,
  default empty list) instead of `["*"]`.

## Testing

`tests/test_webui.py` extended with `TestOperateAuth` (401 without / with
wrong key, WebSocket rejection, `auto_approve_exploits` ignored),
`TestOperateDisabledWithoutKey` (503 stubs, WebSocket close, error log
emitted, health still works), and `TestCorsOrigins` (default `[]`, env
parsing). Existing operate/WebSocket tests updated to send the header.

Full suite: 2774 passed, 2 skipped, 1 pre-existing unrelated failure
(`test_webcrypto_hooks.py::TestInstallOnBlankPage::test_succeeds_with_init_script`).
