### PR TITLE
fix(security): default-deny host-RCE tools in MCP server registration

### DIFF
--- a/clearwing/mcp/server.py
+++ b/clearwing/mcp/server.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from typing import Any
+
+_DEFAULT_DENIED_TOOLS = "create_custom_tool,connect_mcp_server,kali_cleanup"
+
+
+def _denied_tools() -> set[str]:
+    raw = os.environ.get("CLEARWING_MCP_DENIED_TOOLS", _DEFAULT_DENIED_TOOLS)
+    return {t.strip() for t in raw.split(",") if t.strip()}
 
 
 class MCPServer:
@@ -40,11 +48,20 @@ class MCPServer:
         return name, description, schema
 
     def _register_tools(self) -> None:
-        """Register all Clearwing tools as MCP-compatible tool definitions."""
+        """Register all Clearwing tools as MCP-compatible tool definitions.
+
+        Tools whose names appear in ``CLEARWING_MCP_DENIED_TOOLS`` (default:
+        ``create_custom_tool,connect_mcp_server,kali_cleanup``) are skipped so
+        the MCP surface cannot be used to spawn processes, register runtime
+        code, or tear down the isolation container.
+        """
         from clearwing.agent.tools import get_all_tools
 
+        denied = _denied_tools()
         for tool in get_all_tools():
             name, description, schema = self._tool_to_mcp(tool)
+            if name in denied:
+                continue
             self._tools[name] = {
                 "description": description,
                 "input_schema": schema,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
-from clearwing.mcp.server import MCPServer
+from clearwing.mcp.server import MCPServer, _denied_tools
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -288,3 +288,62 @@ class TestNotificationsInitialized:
         request = {"jsonrpc": "2.0", "method": "notifications/initialized"}
         response = server.handle_request(request)
         assert response is None
+
+
+class TestDenylist:
+    """c17: _register_tools filters against CLEARWING_MCP_DENIED_TOOLS."""
+
+    def _build_real(self, tool_names):
+        tools = [_make_fake_tool(n, f"desc {n}") for n in tool_names]
+        with patch("clearwing.agent.tools.get_all_tools", return_value=tools):
+            return MCPServer()
+
+    def test_default_denylist(self, monkeypatch):
+        monkeypatch.delenv("CLEARWING_MCP_DENIED_TOOLS", raising=False)
+        assert _denied_tools() == {
+            "create_custom_tool",
+            "connect_mcp_server",
+            "kali_cleanup",
+        }
+
+    def test_default_denied_tools_not_registered(self, monkeypatch):
+        monkeypatch.delenv("CLEARWING_MCP_DENIED_TOOLS", raising=False)
+        server = self._build_real(
+            [
+                "validate_target",
+                "create_custom_tool",
+                "connect_mcp_server",
+                "kali_cleanup",
+            ]
+        )
+        assert "validate_target" in server._tools
+        assert "create_custom_tool" not in server._tools
+        assert "connect_mcp_server" not in server._tools
+        assert "kali_cleanup" not in server._tools
+
+    def test_denied_tool_not_in_tools_list(self, monkeypatch):
+        monkeypatch.delenv("CLEARWING_MCP_DENIED_TOOLS", raising=False)
+        server = self._build_real(["validate_target", "create_custom_tool"])
+        response = server.handle_request({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+        names = {t["name"] for t in response["result"]["tools"]}
+        assert "create_custom_tool" not in names
+
+    def test_denied_tool_call_rejected(self, monkeypatch):
+        monkeypatch.delenv("CLEARWING_MCP_DENIED_TOOLS", raising=False)
+        server = self._build_real(["create_custom_tool"])
+        response = server.handle_request(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "create_custom_tool", "arguments": {}},
+            }
+        )
+        assert "error" in response
+        assert response["error"]["code"] == -32602
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("CLEARWING_MCP_DENIED_TOOLS", "validate_target, other")
+        server = self._build_real(["validate_target", "create_custom_tool"])
+        assert "validate_target" not in server._tools
+        assert "create_custom_tool" in server._tools


### PR DESCRIPTION
# fix(security): denylist dangerous tools on the MCP server

## Vulnerability

`MCPServer._register_tools()` exposed every tool returned by
`clearwing.agent.tools.get_all_tools()` over the stdio MCP transport,
including `create_custom_tool` (runtime code registration),
`connect_mcp_server` (arbitrary process spawn), and `kali_cleanup`
(tears down the isolation container). Any downstream MCP client could invoke
these via `tools/call` without the interactive approval gates that protect
them in the CLI/agent path.

## Impact

An MCP client (or a model driving one) could reach the process-spawn and
code-generation primitives directly, bypassing the human-in-the-loop
`interrupt()` gates and expanding the blast radius of a compromised or
prompt-injected client to full host RCE.

## Fix

Filter `_register_tools()` against a denylist read from
`CLEARWING_MCP_DENIED_TOOLS` (default
`create_custom_tool,connect_mcp_server,kali_cleanup`). Denied tools are
neither listed by `tools/list` nor callable via `tools/call` (which now
returns `-32602 Unknown tool`).

## Testing

`tests/test_mcp.py` gains a `TestDenylist` class covering: default denylist
contents, denied tools absent from the registry and from `tools/list`,
`tools/call` on a denied tool returning `-32602`, and env-var override.

Full suite: 2766 passed, 2 skipped, 1 pre-existing unrelated failure
(`test_webcrypto_hooks.py::TestInstallOnBlankPage::test_succeeds_with_init_script`).
