### PR TITLE
Fix sandbox image build on Apple Silicon (arm64)

### DIFF
--- a/clearwing/sandbox/builders.py
+++ b/clearwing/sandbox/builders.py
@@ -42,13 +42,14 @@ class BuildRecipe:
         return compute_sanitizer_env(self, sanitizers)
 
 
-# Per-language base images. gcc:13 ships libasan/libubsan; rust uses the
-# nightly image for sanitizer support; python doesn't need a build but does
-# benefit from gcc for native extensions. unknown uses debian:11-slim (bullseye)
-# which has ltrace; debian:12 (bookworm) dropped it.
+# Per-language base images. gcc:12-bullseye ships libasan/libubsan on Debian 11
+# (bullseye). gcc:13 is bookworm-based and has no ltrace on amd64 either (the
+# package exists but was removed from the slim image). rust uses the slim image;
+# python doesn't need a build but benefits from gcc for native extensions.
+# unknown uses debian:11-slim.
 DEFAULT_BASE_IMAGES = {
-    "c": "gcc:13",
-    "cpp": "gcc:13",
+    "c": "gcc:12-bullseye",
+    "cpp": "gcc:12-bullseye",
     "rust": "rust:1-slim",
     "go": "golang:1.22",
     "python": "python:3.12-slim",

--- a/clearwing/sandbox/hunter_sandbox.py
+++ b/clearwing/sandbox/hunter_sandbox.py
@@ -17,6 +17,7 @@ import logging
 import math
 import os
 import shutil
+import subprocess
 import tempfile
 
 from .builders import (
@@ -48,7 +49,12 @@ class HunterSandbox:
     # image, and spawn containers from either one by name.
     DEFAULT_EXTRA_VARIANTS: tuple[tuple[str, ...], ...] = ()
 
-    DEEP_AGENT_PACKAGES = ["python3", "valgrind", "ccache", "git", "ltrace"]
+    DEEP_AGENT_PACKAGES = ["python3", "valgrind", "ccache", "git"]
+    # Packages that are useful but not available on all architectures.
+    # ltrace is x86_64-only (not packaged for arm64 on any Debian release).
+    # Installed in a separate best-effort layer so their absence doesn't
+    # fail the entire image build.
+    DEEP_AGENT_OPTIONAL_PACKAGES = ["ltrace"]
     EXPLOIT_AGENT_PACKAGES = ["gdb", "python3-pip", "ruby", "binutils"]
     EXPLOIT_POST_INSTALL = [
         "pip3 install --break-system-packages pwntools ROPgadget seccomp-tools 2>/dev/null || true",
@@ -80,12 +86,14 @@ class HunterSandbox:
         for v in self.extra_variants:
             validate_sanitizer_combo(v)
         self.extra_packages = list(extra_packages or [])
+        self._optional_packages: list[str] = []
         self.post_install_commands = list(post_install_commands or [])
         self.deep_agent_mode = deep_agent_mode
         if deep_agent_mode:
             for pkg in self.DEEP_AGENT_PACKAGES:
                 if pkg not in self.extra_packages:
                     self.extra_packages.append(pkg)
+            self._optional_packages.extend(self.DEEP_AGENT_OPTIONAL_PACKAGES)
         self.build_recipe = build_recipe or BuildSystemDetector.detect(self.repo_path)
         self._client = None
         self._image_tag: str | None = None  # primary variant tag
@@ -203,31 +211,71 @@ class HunterSandbox:
         self.build_image()
         return dict(self._variant_images)
 
+    def _target_platform(self) -> str:
+        """Docker platform string for builds.
+
+        C/C++ toolchains (gcc, valgrind, sanitizers) run painfully slow under
+        qemu on Apple Silicon and occasionally miscompile. Use native arm64 for
+        those languages; pin amd64 for everything else for reproducibility.
+        """
+        import platform as _plat
+
+        lang = (self.build_recipe.primary_language or "").lower()
+        if lang in ("c", "cpp", "c++") and _plat.machine() in ("arm64", "aarch64"):
+            return "linux/arm64"
+        return "linux/amd64"
+
     def _build_variant_image(self, sanitizers: list[str]) -> str:
-        """Build one sandbox image for the given sanitizer combo."""
-        client = self._get_client()
+        """Build one sandbox image for the given sanitizer combo.
+
+        Uses the `docker build` CLI instead of the Python SDK's images.build()
+        because the SDK eagerly resolves ALL credential helpers configured in
+        ~/.docker/config.json. If any helper errors (e.g. docker-credential-gcloud
+        with an expired token), the entire build fails — even though the base
+        image doesn't need that registry. The CLI only authenticates against
+        registries it actually needs to pull from.
+        """
         dockerfile = self._render_dockerfile(sanitizers=sanitizers)
         tag = self._compute_tag(dockerfile, sanitizers=sanitizers)
 
-        try:
-            client.images.get(tag)
+        # Check cache via CLI — avoids credential helper issues on cache check too
+        check = subprocess.run(
+            ["docker", "image", "inspect", tag],
+            capture_output=True, timeout=10,
+        )
+        if check.returncode == 0:
             logger.debug("Reusing sourcehunt sandbox image %s", tag)
             return tag
-        except Exception:
-            pass
 
         with tempfile.TemporaryDirectory(prefix="clearwing-sandbox-build-") as build_dir:
             dockerfile_path = os.path.join(build_dir, "Dockerfile")
             with open(dockerfile_path, "w", encoding="utf-8") as f:
                 f.write(dockerfile)
 
+            platform_flag = self._target_platform()
             logger.info(
-                "Building sourcehunt sandbox image %s (sanitizers=%s)",
+                "Building sourcehunt sandbox image %s (sanitizers=%s, platform=%s)",
                 tag,
                 ",".join(sanitizers),
+                platform_flag,
             )
             try:
-                client.images.build(path=build_dir, tag=tag, rm=True, forcerm=True, platform="linux/amd64", network_mode="host")
+                proc = subprocess.run(
+                    [
+                        "docker", "build",
+                        "--progress=plain",
+                        "--platform", platform_flag,
+                        "-t", tag,
+                        build_dir,
+                    ],
+                    capture_output=True, text=True, timeout=300,
+                )
+                if proc.returncode != 0:
+                    raise RuntimeError(proc.stderr[-2000:] or proc.stdout[-2000:])
+            except subprocess.TimeoutExpired as e:
+                raise RuntimeError(f"Sandbox image build timed out after 300s") from e
+            except RuntimeError:
+                raise
             except Exception as e:
                 logger.warning("Sandbox image build failed: %s", e)
                 logger.debug("Sandbox image build failed", exc_info=True)
@@ -417,6 +465,18 @@ class HunterSandbox:
         else:
             apt_block = "# (no apt packages)"
 
+        # Optional packages: installed best-effort (e.g. ltrace is missing on
+        # arm64/bookworm). Separate layer so a missing package doesn't fail the
+        # entire build.
+        optional_apt_block = ""
+        if self._optional_packages:
+            opt_list = " ".join(self._optional_packages)
+            optional_apt_block = (
+                f"RUN apt-get update -qq && "
+                f"DEBIAN_FRONTEND=noninteractive apt-get install -y -qq {opt_list} 2>/dev/null || true ; "
+                f"rm -rf /var/lib/apt/lists/*"
+            )
+
         post_install_block = ""
         if self.post_install_commands:
             post_install_block = "\n".join(f"RUN {cmd}" for cmd in self.post_install_commands)
@@ -429,6 +489,8 @@ class HunterSandbox:
 {variant_header}
 
 {apt_block}
+
+{optional_apt_block}
 
 {post_install_block}
 

--- a/tests/test_hunter_sandbox.py
+++ b/tests/test_hunter_sandbox.py
@@ -119,32 +119,40 @@ def mock_docker():
 
 
 class TestHunterSandboxBuildImage:
-    def test_build_image_calls_images_build(self, temp_repo: Path, mock_docker):
+    @patch("clearwing.sandbox.hunter_sandbox.subprocess.run")
+    def test_build_image_calls_images_build(self, mock_run, temp_repo: Path):
         (temp_repo / "Makefile").write_text("all:\n")
-        # Make images.get raise so we go down the build path
-        mock_docker.images.get.side_effect = Exception("not found")
+        # inspect miss → build
+        mock_run.side_effect = [
+            MagicMock(returncode=1),  # docker image inspect
+            MagicMock(returncode=0, stdout="", stderr=""),  # docker build
+        ]
 
         sb = HunterSandbox(repo_path=str(temp_repo))
         tag = sb.build_image()
         assert tag.startswith("clearwing-sourcehunt:")
-        mock_docker.images.build.assert_called_once()
-        kwargs = mock_docker.images.build.call_args.kwargs
-        assert kwargs["tag"] == tag
+        assert mock_run.call_count == 2
+        build_argv = mock_run.call_args_list[1][0][0]
+        assert "build" in build_argv
+        assert tag in build_argv
 
-    def test_build_image_reuses_cached(self, temp_repo: Path, mock_docker):
+    @patch("clearwing.sandbox.hunter_sandbox.subprocess.run")
+    def test_build_image_reuses_cached(self, mock_run, temp_repo: Path):
         (temp_repo / "Makefile").write_text("all:\n")
-        # images.get succeeds → reuse
-        mock_docker.images.get.return_value = MagicMock()
+        # docker image inspect succeeds → cached
+        mock_run.return_value = MagicMock(returncode=0)
 
         sb = HunterSandbox(repo_path=str(temp_repo))
         sb.build_image()
-        mock_docker.images.build.assert_not_called()
+        mock_run.assert_called_once()
+        argv = mock_run.call_args[0][0]
+        assert "inspect" in argv
 
     def test_dockerfile_includes_recipe_apt_packages(self, temp_repo: Path):
         (temp_repo / "Makefile").write_text("all:\n")
         sb = HunterSandbox(repo_path=str(temp_repo))
         df = sb._render_dockerfile()
-        assert "FROM gcc:13" in df
+        assert "FROM gcc:12-bullseye" in df
         assert "ripgrep" in df
         assert "gdb" in df
         assert "ltrace" not in df

--- a/tests/test_sandbox_creation.py
+++ b/tests/test_sandbox_creation.py
@@ -1,0 +1,644 @@
+"""Tests for sandbox creation correctness.
+
+Validates that HunterSandbox produces correctly-configured containers:
+- Dockerfile renders with correct base images and sanitizer flags
+- Workspace mounts are correct (ro vs writable copy)
+- Image tags are deterministic and content-addressed
+- Build failures are surfaced cleanly
+- Writable workspace flow: copy_tree_into + git init
+- Platform/arch considerations
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from clearwing.sandbox.builders import (
+    DEFAULT_BASE_IMAGES,
+    BuildRecipe,
+    BuildSystemDetector,
+    compute_sanitizer_env,
+    validate_sanitizer_combo,
+)
+from clearwing.sandbox.container import SandboxConfig, SandboxContainer
+from clearwing.sandbox.hunter_sandbox import HunterSandbox
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def c_repo(tmp_path: Path) -> Path:
+    (tmp_path / "Makefile").write_text("all:\n\tgcc -o main main.c\n")
+    (tmp_path / "main.c").write_text("int main() { return 0; }\n")
+    return tmp_path
+
+
+@pytest.fixture
+def cpp_repo(tmp_path: Path) -> Path:
+    (tmp_path / "CMakeLists.txt").write_text("project(test)\n")
+    (tmp_path / "main.cpp").write_text("int main() {}\n")
+    return tmp_path
+
+
+@pytest.fixture
+def python_repo(tmp_path: Path) -> Path:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='testpkg'\n")
+    (tmp_path / "app.py").write_text("print('hi')\n")
+    return tmp_path
+
+
+@pytest.fixture
+def mock_docker():
+    with patch("docker.from_env") as mock_from_env:
+        client = MagicMock()
+        mock_from_env.return_value = client
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Dockerfile rendering correctness
+# ---------------------------------------------------------------------------
+
+
+class TestDockerfileRendering:
+    def test_c_dockerfile_uses_gcc_base(self, c_repo: Path):
+        sb = HunterSandbox(repo_path=str(c_repo))
+        df = sb._render_dockerfile()
+        assert df.startswith("FROM gcc:12-bullseye")
+
+    def test_cpp_dockerfile_uses_gcc_base(self, cpp_repo: Path):
+        sb = HunterSandbox(repo_path=str(cpp_repo))
+        df = sb._render_dockerfile()
+        assert "FROM gcc:12-bullseye" in df
+
+    def test_python_dockerfile_no_sanitizer_flags(self, python_repo: Path):
+        sb = HunterSandbox(repo_path=str(python_repo))
+        df = sb._render_dockerfile()
+        assert "FROM python:3.12-slim" in df
+        # Python doesn't get CFLAGS sanitizer injection
+        assert "fsanitize" not in df
+
+    def test_sanitizer_env_in_dockerfile(self, c_repo: Path):
+        sb = HunterSandbox(repo_path=str(c_repo), sanitizers=["asan", "ubsan"])
+        df = sb._render_dockerfile()
+        assert "fsanitize=address" in df
+        assert "fsanitize=undefined" in df
+        assert "ASAN_OPTIONS" in df
+        assert "UBSAN_OPTIONS" in df
+
+    def test_msan_variant_dockerfile(self, c_repo: Path):
+        sb = HunterSandbox(repo_path=str(c_repo), sanitizers=["msan"])
+        df = sb._render_dockerfile()
+        assert "fsanitize=memory" in df
+        assert "MSAN_OPTIONS" in df
+        # Must NOT contain asan flags
+        assert "fsanitize=address" not in df
+
+    def test_apt_packages_include_ripgrep_and_gdb(self, c_repo: Path):
+        sb = HunterSandbox(repo_path=str(c_repo))
+        df = sb._render_dockerfile()
+        assert "ripgrep" in df
+        assert "gdb" in df
+
+    def test_extra_packages_appear_in_dockerfile(self, c_repo: Path):
+        sb = HunterSandbox(
+            repo_path=str(c_repo), extra_packages=["python3-pip", "curl"]
+        )
+        df = sb._render_dockerfile()
+        assert "python3-pip" in df
+        assert "curl" in df
+
+    def test_post_install_commands_render(self, c_repo: Path):
+        sb = HunterSandbox(
+            repo_path=str(c_repo),
+            post_install_commands=["pip3 install pyjwt || true"],
+        )
+        df = sb._render_dockerfile()
+        assert "RUN pip3 install pyjwt || true" in df
+
+    def test_deep_agent_mode_adds_valgrind_and_ltrace(self, c_repo: Path):
+        sb = HunterSandbox(repo_path=str(c_repo), deep_agent_mode=True)
+        df = sb._render_dockerfile()
+        assert "valgrind" in df
+        assert "ltrace" in df
+        assert "python3" in df
+
+    def test_workspace_dir_created(self, c_repo: Path):
+        sb = HunterSandbox(repo_path=str(c_repo))
+        df = sb._render_dockerfile()
+        assert "WORKDIR /workspace" in df
+        assert "mkdir -p /scratch" in df
+
+
+# ---------------------------------------------------------------------------
+# Image tag content-addressing
+# ---------------------------------------------------------------------------
+
+
+class TestImageTagDeterminism:
+    def test_same_config_same_tag(self, c_repo: Path):
+        sb1 = HunterSandbox(repo_path=str(c_repo), sanitizers=["asan"])
+        sb2 = HunterSandbox(repo_path=str(c_repo), sanitizers=["asan"])
+        df1 = sb1._render_dockerfile()
+        df2 = sb2._render_dockerfile()
+        assert sb1._compute_tag(df1) == sb2._compute_tag(df2)
+
+    def test_different_sanitizers_different_tag(self, c_repo: Path):
+        sb_asan = HunterSandbox(repo_path=str(c_repo), sanitizers=["asan"])
+        sb_msan = HunterSandbox(repo_path=str(c_repo), sanitizers=["msan"])
+        tag_asan = sb_asan._compute_tag(sb_asan._render_dockerfile())
+        tag_msan = sb_msan._compute_tag(sb_msan._render_dockerfile())
+        assert tag_asan != tag_msan
+
+    def test_different_extra_packages_different_tag(self, c_repo: Path):
+        sb1 = HunterSandbox(repo_path=str(c_repo))
+        sb2 = HunterSandbox(repo_path=str(c_repo), extra_packages=["curl"])
+        tag1 = sb1._compute_tag(sb1._render_dockerfile())
+        tag2 = sb2._compute_tag(sb2._render_dockerfile())
+        assert tag1 != tag2
+
+    def test_tag_prefix(self, c_repo: Path):
+        sb = HunterSandbox(repo_path=str(c_repo))
+        tag = sb._compute_tag(sb._render_dockerfile())
+        assert tag.startswith("clearwing-sourcehunt:")
+        # Hash portion is 12 hex chars
+        hash_part = tag.split(":")[1]
+        assert len(hash_part) == 12
+        assert all(c in "0123456789abcdef" for c in hash_part)
+
+
+# ---------------------------------------------------------------------------
+# Build image flow
+# ---------------------------------------------------------------------------
+
+
+class TestBuildImageFlow:
+    @patch("clearwing.sandbox.hunter_sandbox.subprocess.run")
+    def test_build_calls_docker_cli_when_not_cached(self, mock_run, c_repo: Path):
+        # First call: `docker image inspect` → not found (returncode=1)
+        # Second call: `docker build` → success
+        inspect_result = MagicMock(returncode=1)
+        build_result = MagicMock(returncode=0, stdout="", stderr="")
+        mock_run.side_effect = [inspect_result, build_result]
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        tag = sb.build_image()
+
+        assert tag.startswith("clearwing-sourcehunt:")
+        assert mock_run.call_count == 2
+        # Second call is the actual docker build
+        build_call = mock_run.call_args_list[1]
+        build_argv = build_call[0][0]
+        assert "docker" in build_argv[0]
+        assert "build" in build_argv
+        assert tag in build_argv
+
+    @patch("clearwing.sandbox.hunter_sandbox.subprocess.run")
+    def test_build_reuses_cached_image(self, mock_run, c_repo: Path):
+        # docker image inspect succeeds → cached
+        mock_run.return_value = MagicMock(returncode=0)
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        # Only the inspect call, no build
+        mock_run.assert_called_once()
+        argv = mock_run.call_args[0][0]
+        assert "inspect" in argv
+
+    @patch("clearwing.sandbox.hunter_sandbox.subprocess.run")
+    def test_build_failure_raises_runtime_error(self, mock_run, c_repo: Path):
+        inspect_result = MagicMock(returncode=1)
+        build_result = MagicMock(returncode=1, stdout="", stderr="apt-get failed")
+        mock_run.side_effect = [inspect_result, build_result]
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        with pytest.raises(RuntimeError):
+            sb.build_image()
+
+    @patch("clearwing.sandbox.hunter_sandbox.subprocess.run")
+    def test_extra_variants_built(self, mock_run, c_repo: Path):
+        # Each variant: inspect (miss) + build (ok) = 2 calls per variant
+        mock_run.side_effect = [
+            MagicMock(returncode=1),  # inspect primary
+            MagicMock(returncode=0, stdout="", stderr=""),  # build primary
+            MagicMock(returncode=1),  # inspect msan
+            MagicMock(returncode=0, stdout="", stderr=""),  # build msan
+        ]
+        sb = HunterSandbox(
+            repo_path=str(c_repo),
+            sanitizers=["asan", "ubsan"],
+            extra_variants=[["msan"]],
+        )
+        sb.build_image()
+        assert mock_run.call_count == 4  # 2 inspects + 2 builds
+        assert len(sb.available_variants) == 2
+
+
+# ---------------------------------------------------------------------------
+# Spawn container correctness
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnContainer:
+    def test_spawn_readonly_workspace(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "abc123"
+        mock_container.short_id = "abc1"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        container = sb.spawn(session_id="test-ro", scratch_mount=False)
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        volumes = kwargs["volumes"]
+        repo_abs = os.path.abspath(str(c_repo))
+        assert volumes[repo_abs]["bind"] == "/workspace"
+        assert volumes[repo_abs]["mode"] == "ro"
+
+    def test_spawn_writable_workspace_copies_tree(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "writable-cid"
+        mock_container.short_id = "writ"
+        mock_container.exec_run.return_value = MagicMock(exit_code=0, output=(b"", b""))
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo), deep_agent_mode=True)
+        sb.build_image()
+
+        with (
+            patch.object(SandboxContainer, "start", return_value="writable-cid"),
+            patch.object(SandboxContainer, "copy_tree_into") as mock_copy,
+            patch.object(SandboxContainer, "exec") as mock_exec,
+        ):
+            mock_exec.return_value = MagicMock(exit_code=0)
+            container = sb.spawn(writable_workspace=True)
+
+        # Must copy, then git init
+        mock_copy.assert_called_once_with(str(c_repo), "/workspace")
+        git_calls = [
+            c for c in mock_exec.call_args_list
+            if isinstance(c[0][0], str) and "git init" in c[0][0]
+        ]
+        assert len(git_calls) == 1
+
+    def test_spawn_writable_no_ro_mount(self, c_repo: Path, mock_docker):
+        """Writable workspace must NOT have a read-only bind mount."""
+        mock_docker.images.get.return_value = MagicMock()
+
+        sb = HunterSandbox(repo_path=str(c_repo), deep_agent_mode=True)
+
+        with (
+            patch.object(HunterSandbox, "_build_variant_image", return_value="img:test"),
+            patch.object(SandboxContainer, "start", return_value="cid"),
+            patch.object(SandboxContainer, "copy_tree_into"),
+            patch.object(SandboxContainer, "exec", return_value=MagicMock(exit_code=0)),
+        ):
+            container = sb.spawn(writable_workspace=True)
+
+        for mount in container.config.mounts:
+            host, container_path, mode = mount
+            if container_path == "/workspace":
+                pytest.fail(
+                    f"Writable workspace should not have a /workspace mount, "
+                    f"found mode={mode}"
+                )
+
+    def test_spawn_network_disabled(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "net-test"
+        mock_container.short_id = "net"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        sb.spawn(scratch_mount=False)
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        assert kwargs["network_mode"] == "none"
+
+    def test_spawn_seccomp_is_inline_json(self, c_repo: Path, mock_docker):
+        """Security: seccomp profile must be inline JSON, not a file path."""
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "sec-test"
+        mock_container.short_id = "sec"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        sb.spawn(scratch_mount=False)
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        sec_opts = kwargs["security_opt"]
+        seccomp_opts = [o for o in sec_opts if o.startswith("seccomp=")]
+        assert len(seccomp_opts) == 1
+        value = seccomp_opts[0][len("seccomp="):]
+        # Must not be a path
+        assert not value.startswith("/")
+        parsed = json.loads(value)
+        assert parsed.get("defaultAction") == "SCMP_ACT_ALLOW"
+
+    def test_spawn_caps_dropped(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "cap-test"
+        mock_container.short_id = "cap"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        sb.spawn(scratch_mount=False)
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        assert kwargs["cap_drop"] == ["ALL"]
+        assert "SYS_PTRACE" in kwargs["cap_add"]
+
+    def test_spawn_scratch_mount_is_rw(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "scratch-test"
+        mock_container.short_id = "scr"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        sb.spawn(scratch_mount=True)
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        volumes = kwargs["volumes"]
+        rw_mounts = [
+            (host, info) for host, info in volumes.items()
+            if info.get("mode") == "rw"
+        ]
+        assert len(rw_mounts) == 1
+        assert rw_mounts[0][1]["bind"] == "/scratch"
+
+        sb.cleanup()
+
+    def test_spawn_session_id_in_env(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "env-test"
+        mock_container.short_id = "env"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        sb.spawn(session_id="hunt-42", scratch_mount=False)
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        assert kwargs["environment"]["CLEARWING_SESSION_ID"] == "hunt-42"
+
+    def test_spawn_sanitizer_variant_in_env(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "var-test"
+        mock_container.short_id = "var"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo), sanitizers=["asan", "ubsan"])
+        sb.build_image()
+        sb.spawn(scratch_mount=False)
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        env = kwargs["environment"]
+        # Should contain both, order determined by sorted list in variant_key
+        assert "asan" in env["CLEARWING_SANITIZER_VARIANT"]
+        assert "ubsan" in env["CLEARWING_SANITIZER_VARIANT"]
+
+    def test_spawn_memory_limit(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "mem-test"
+        mock_container.short_id = "mem"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        sb.spawn(memory_mb=4096, scratch_mount=False)
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        # mem_limit is passed as "<N>m" string by SandboxContainer
+        assert kwargs["mem_limit"] == "4096m"
+
+
+# ---------------------------------------------------------------------------
+# Sanitizer validation
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizerValidation:
+    def test_asan_plus_msan_rejected(self):
+        with pytest.raises(ValueError, match="cannot coexist"):
+            validate_sanitizer_combo(["asan", "msan"])
+
+    def test_asan_plus_tsan_rejected(self):
+        with pytest.raises(ValueError, match="cannot coexist"):
+            validate_sanitizer_combo(["asan", "tsan"])
+
+    def test_msan_plus_tsan_rejected(self):
+        with pytest.raises(ValueError, match="cannot coexist"):
+            validate_sanitizer_combo(["msan", "tsan"])
+
+    def test_asan_ubsan_allowed(self):
+        validate_sanitizer_combo(["asan", "ubsan"])  # should not raise
+
+    def test_msan_alone_allowed(self):
+        validate_sanitizer_combo(["msan"])  # should not raise
+
+    def test_constructor_rejects_bad_combo(self, c_repo: Path):
+        with pytest.raises(ValueError):
+            HunterSandbox(repo_path=str(c_repo), sanitizers=["asan", "msan"])
+
+
+# ---------------------------------------------------------------------------
+# compute_sanitizer_env correctness
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizerEnv:
+    def test_c_asan_ubsan_env(self, c_repo: Path):
+        recipe = BuildSystemDetector.detect(str(c_repo))
+        env = compute_sanitizer_env(recipe, ["asan", "ubsan"])
+        assert "-fsanitize=address" in env["CFLAGS"]
+        assert "-fsanitize=undefined" in env["CFLAGS"]
+        assert env["CXXFLAGS"] == env["CFLAGS"]
+        assert "ASAN_OPTIONS" in env
+        assert "UBSAN_OPTIONS" in env
+
+    def test_c_msan_env(self, c_repo: Path):
+        recipe = BuildSystemDetector.detect(str(c_repo))
+        env = compute_sanitizer_env(recipe, ["msan"])
+        assert "-fsanitize=memory" in env["CFLAGS"]
+        assert "track-origins" in env["CFLAGS"]
+        assert "MSAN_OPTIONS" in env
+        # No asan pollution
+        assert "ASAN_OPTIONS" not in env
+
+    def test_python_ignores_sanitizers(self, python_repo: Path):
+        recipe = BuildSystemDetector.detect(str(python_repo))
+        env = compute_sanitizer_env(recipe, ["asan", "ubsan"])
+        # Python recipe doesn't inject CFLAGS
+        assert "CFLAGS" not in env
+
+    def test_asan_options_non_fatal(self, c_repo: Path):
+        """Sandbox must not abort on first ASan error — hunter needs all traces."""
+        recipe = BuildSystemDetector.detect(str(c_repo))
+        env = compute_sanitizer_env(recipe, ["asan"])
+        assert "halt_on_error=0" in env["ASAN_OPTIONS"]
+        assert "abort_on_error=0" in env["ASAN_OPTIONS"]
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestCleanup:
+    def test_cleanup_stops_all_containers(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "cleanup-test"
+        mock_container.short_id = "cln"
+        mock_docker.containers.run.return_value = mock_container
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        sb.spawn(scratch_mount=False)
+        sb.spawn(scratch_mount=False)
+        sb.cleanup()
+
+        assert mock_container.stop.call_count == 2
+        assert mock_container.remove.call_count == 2
+
+    def test_cleanup_remove_image(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+
+        sb = HunterSandbox(repo_path=str(c_repo))
+        sb.build_image()
+        sb.cleanup(remove_image=True)
+        mock_docker.images.remove.assert_called_once()
+
+    def test_context_manager_cleans_up(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "ctx-test"
+        mock_container.short_id = "ctx"
+        mock_docker.containers.run.return_value = mock_container
+
+        with HunterSandbox(repo_path=str(c_repo)) as sb:
+            sb.build_image()
+            sb.spawn(scratch_mount=False)
+
+        mock_container.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Writable workspace git init failure is non-fatal
+# ---------------------------------------------------------------------------
+
+
+class TestWritableWorkspaceResilience:
+    def test_git_init_failure_does_not_crash_spawn(self, c_repo: Path, mock_docker):
+        """If git init in writable workspace fails, spawn still succeeds."""
+        mock_docker.images.get.return_value = MagicMock()
+
+        sb = HunterSandbox(repo_path=str(c_repo), deep_agent_mode=True)
+
+        with (
+            patch.object(HunterSandbox, "_build_variant_image", return_value="img:t"),
+            patch.object(SandboxContainer, "start", return_value="cid"),
+            patch.object(SandboxContainer, "copy_tree_into"),
+            patch.object(
+                SandboxContainer, "exec",
+                side_effect=RuntimeError("git not installed"),
+            ),
+        ):
+            # Should not raise despite git init failure
+            container = sb.spawn(writable_workspace=True)
+            assert container is not None
+
+    def test_copy_tree_failure_propagates(self, c_repo: Path, mock_docker):
+        """If copy_tree_into fails, spawn MUST fail — we can't hunt without code."""
+        mock_docker.images.get.return_value = MagicMock()
+
+        sb = HunterSandbox(repo_path=str(c_repo), deep_agent_mode=True)
+
+        with (
+            patch.object(HunterSandbox, "_build_variant_image", return_value="img:t"),
+            patch.object(SandboxContainer, "start", return_value="cid"),
+            patch.object(
+                SandboxContainer, "copy_tree_into",
+                side_effect=RuntimeError("tar failed"),
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="tar failed"):
+                sb.spawn(writable_workspace=True)
+
+
+# ---------------------------------------------------------------------------
+# Variant selection at spawn time
+# ---------------------------------------------------------------------------
+
+
+class TestVariantSpawn:
+    def test_spawn_msan_variant(self, c_repo: Path, mock_docker):
+        mock_docker.images.get.side_effect = Exception("not found")
+
+        sb = HunterSandbox(
+            repo_path=str(c_repo),
+            sanitizers=["asan", "ubsan"],
+            extra_variants=[["msan"]],
+        )
+        sb.build_image()
+
+        mock_docker.images.get.side_effect = None
+        mock_docker.images.get.return_value = MagicMock()
+        mock_container = MagicMock()
+        mock_container.id = "msan-cid"
+        mock_container.short_id = "msa"
+        mock_docker.containers.run.return_value = mock_container
+
+        container = sb.spawn(variant=["msan"], scratch_mount=False)
+        assert container.variant == ["msan"]
+
+        kwargs = mock_docker.containers.run.call_args.kwargs
+        env = kwargs["environment"]
+        assert "msan" in env["CLEARWING_SANITIZER_VARIANT"]
+        assert "MSAN_OPTIONS" in env
+
+    @patch("clearwing.sandbox.hunter_sandbox.subprocess.run")
+    def test_spawn_unbuilt_variant_auto_builds(self, mock_run, c_repo: Path, mock_docker):
+        """Requesting an unbuilt variant auto-builds on demand."""
+        # Primary build: inspect miss + build ok
+        mock_run.side_effect = [
+            MagicMock(returncode=1),  # inspect primary
+            MagicMock(returncode=0, stdout="", stderr=""),  # build primary
+            MagicMock(returncode=1),  # inspect tsan (auto-build)
+            MagicMock(returncode=0, stdout="", stderr=""),  # build tsan
+        ]
+
+        sb = HunterSandbox(repo_path=str(c_repo), sanitizers=["asan", "ubsan"])
+        sb.build_image()
+
+        mock_container = MagicMock()
+        mock_container.id = "tsan-cid"
+        mock_container.short_id = "tsa"
+        mock_docker.containers.run.return_value = mock_container
+
+        container = sb.spawn(variant=["tsan"], scratch_mount=False)
+        assert container.variant == ["tsan"]
+        # 4 subprocess calls: 2 for primary + 2 for tsan auto-build
+        assert mock_run.call_count == 4


### PR DESCRIPTION
## Summary

- Switches from Docker SDK `images.build()` to subprocess `docker build` CLI to avoid credential helper failures (`docker-credential-gcloud`, etc.)
- Uses `gcc:12-bullseye` base image for C/C++ sandbox (ltrace available on x86_64)
- Makes ltrace a best-effort optional install (missing on arm64/all Debian)
- Adds platform-aware builds: native arm64 for C/C++, amd64 emulation for others
- Updates unit tests to mock `subprocess.run` instead of SDK calls


## Failure

<img width="1624" height="264" alt="image" src="https://github.com/user-attachments/assets/d80b7477-c097-4eeb-b2f7-9f83f3e89093" />

## Fix

<img width="1602" height="375" alt="image" src="https://github.com/user-attachments/assets/2c398125-223d-46df-a3d4-b453bde351fc" />


## Test plan

- [ ] `python -m pytest tests/test_hunter_sandbox.py tests/test_sandbox_creation.py -v`
- [ ] Verify `docker build` succeeds on arm64 Mac (no credential helper errors)
- [ ] Verify x86_64 CI still builds sandbox images correctly