### PR TITLE
Add optional per-endpoint pricing to the budget model

### DIFF
--- a/clearwing/llm/budget.py
+++ b/clearwing/llm/budget.py
@@ -20,9 +20,12 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from clearwing.observability.telemetry import CostTracker
+
+if TYPE_CHECKING:
+    from clearwing.providers.env import LLMEndpoint
 
 
 class BudgetExceeded(RuntimeError):
@@ -41,6 +44,31 @@ class ModelPricing:
     output_per_million: float
     cached_input_per_million: float
     source: str
+
+
+def _endpoint_pricing(endpoint: LLMEndpoint | None) -> ModelPricing | None:
+    """Map an endpoint's optional :class:`EndpointPricing` to ``ModelPricing``.
+
+    When the active endpoint carries a ``pricing`` block it is the
+    authoritative price for cost accounting, so this converts it into the
+    ledger's own ``ModelPricing`` shape (``*_per_mtok`` → ``*_per_million``).
+    The cached-read rate falls back to the input rate when the endpoint does
+    not carry a distinct cached price, matching the operator-override and
+    pricing-table behavior. Returns ``None`` when the endpoint is absent or
+    carries no pricing, so runs without endpoint pricing are unaffected.
+    """
+    pricing = getattr(endpoint, "pricing", None)
+    if pricing is None:
+        return None
+    cached = (
+        pricing.cached_per_mtok if pricing.cached_per_mtok is not None else pricing.input_per_mtok
+    )
+    return ModelPricing(
+        input_per_million=float(pricing.input_per_mtok),
+        output_per_million=float(pricing.output_per_mtok),
+        cached_input_per_million=float(cached),
+        source="endpoint_pricing",
+    )
 
 
 @dataclass(slots=True)
@@ -101,6 +129,7 @@ class SpendLedger:
         output_price_per_million: float | None = None,
         default_max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
         manifest_filename: str = "manifest.json",
+        endpoint: LLMEndpoint | None = None,
     ) -> None:
         if not math.isfinite(limit_usd) or limit_usd < 0:
             raise BudgetConfigurationError("LLM budget must be a finite value >= 0")
@@ -136,10 +165,12 @@ class SpendLedger:
                 cached_input_per_million=float(input_price_per_million),
                 source="operator_override",
             )
-            if input_price_per_million is not None
-            and output_price_per_million is not None
+            if input_price_per_million is not None and output_price_per_million is not None
             else None
         )
+        # The active endpoint's own price, when it carries one, outranks both
+        # the operator override and the built-in table (see `_resolve_pricing`).
+        self._endpoint_pricing = _endpoint_pricing(endpoint)
 
         self._lock = threading.RLock()
         self._spent_usd = 0.0
@@ -209,11 +240,7 @@ class SpendLedger:
             provider=provider,
             strict=self.enforcing,
         )
-        if (
-            self.enforcing
-            and pricing.output_per_million > 0
-            and not supports_output_limit
-        ):
+        if self.enforcing and pricing.output_per_million > 0 and not supports_output_limit:
             raise BudgetConfigurationError(
                 f"--budget cannot be enforced for provider {provider!r}: "
                 "it does not accept an output-token ceiling"
@@ -257,9 +284,7 @@ class SpendLedger:
                     0.0,
                     self.limit_usd - self._spent_usd - self._reserved_usd,
                 )
-                input_cost = (
-                    input_token_upper_bound * pricing.input_per_million / 1_000_000
-                )
+                input_cost = input_token_upper_bound * pricing.input_per_million / 1_000_000
                 if input_cost > available + self._EPSILON:
                     self._mark_exhausted_locked(
                         stage=stage,
@@ -273,9 +298,7 @@ class SpendLedger:
 
                 if pricing.output_per_million > 0:
                     affordable_output = math.floor(
-                        max(0.0, available - input_cost)
-                        * 1_000_000
-                        / pricing.output_per_million
+                        max(0.0, available - input_cost) * 1_000_000 / pricing.output_per_million
                     )
                     effective_max_tokens = min(requested, affordable_output)
                     if effective_max_tokens < 1:
@@ -292,9 +315,7 @@ class SpendLedger:
                     effective_max_tokens = requested
 
                 reserved_usd = input_cost + (
-                    (effective_max_tokens or 0)
-                    * pricing.output_per_million
-                    / 1_000_000
+                    (effective_max_tokens or 0) * pricing.output_per_million / 1_000_000
                 )
                 if reserved_usd > available + self._EPSILON:
                     self._mark_exhausted_locked(
@@ -355,9 +376,7 @@ class SpendLedger:
             cached_count = min(input_count, max(0, int(cached_input_tokens or 0)))
             usage_missing = input_tokens is None and output_tokens is None
 
-            provider_cost = (
-                float(provider_cost_usd) if provider_cost_usd is not None else None
-            )
+            provider_cost = float(provider_cost_usd) if provider_cost_usd is not None else None
             if provider_cost is not None and math.isfinite(provider_cost) and provider_cost >= 0:
                 actual_cost = provider_cost
                 cost_source = "provider"
@@ -587,6 +606,14 @@ class SpendLedger:
         provider: str,
         strict: bool,
     ) -> ModelPricing:
+        # Highest precedence: the active endpoint's own price. When an
+        # LLMEndpoint carries a `pricing` block it is the authoritative,
+        # already-resolved per-model price and outranks both the operator
+        # override and the built-in pricing table. Absent it (the default for
+        # every endpoint) this is None and the existing sources apply unchanged.
+        if self._endpoint_pricing is not None:
+            return self._endpoint_pricing
+
         if self._pricing_override is not None:
             return self._pricing_override
 
@@ -643,9 +670,7 @@ class SpendLedger:
         return ModelPricing(
             input_per_million=float(prices["input"]),
             output_per_million=float(prices["output"]),
-            cached_input_per_million=float(
-                prices.get("cached_input", prices["input"])
-            ),
+            cached_input_per_million=float(prices.get("cached_input", prices["input"])),
             source=f"pricing_table:{matched_key}",
         )
 

--- a/clearwing/providers/__init__.py
+++ b/clearwing/providers/__init__.py
@@ -13,6 +13,7 @@ from clearwing.providers.env import (
     ENV_API_KEY,
     ENV_BASE_URL,
     ENV_MODEL,
+    EndpointPricing,
     LLMEndpoint,
     resolve_llm_endpoint,
 )
@@ -27,6 +28,7 @@ from clearwing.providers.manager import (
 __all__ = [
     # Endpoint resolution
     "LLMEndpoint",
+    "EndpointPricing",
     "resolve_llm_endpoint",
     "ENV_BASE_URL",
     "ENV_API_KEY",

--- a/clearwing/providers/env.py
+++ b/clearwing/providers/env.py
@@ -50,6 +50,28 @@ DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6"
 
 
 @dataclass(frozen=True)
+class EndpointPricing:
+    """Per-model price attached to an endpoint, in USD per one million tokens.
+
+    Whoever constructs an :class:`LLMEndpoint` may attach an
+    ``EndpointPricing`` describing the price of that endpoint's model. When
+    present it is the authoritative price the budget ledger uses for cost
+    accounting, ahead of any operator-supplied override or the built-in
+    pricing table. Leaving it ``None`` (the default for every endpoint) keeps
+    the ledger's existing pricing behavior unchanged.
+
+    Only ``input_per_mtok`` and ``output_per_mtok`` are required. The two
+    cache-related rates are optional; a consumer that does not distinguish a
+    cached-read price falls back to the input rate.
+    """
+
+    input_per_mtok: float
+    output_per_mtok: float
+    cached_per_mtok: float | None = None
+    cache_creation_per_mtok: float | None = None
+
+
+@dataclass(frozen=True)
 class LLMEndpoint:
     """The resolved LLM configuration for one command invocation.
 
@@ -82,6 +104,11 @@ class LLMEndpoint:
     #: via `adapter:` in the `provider:` config block (e.g. the
     #: `openai-responses` preset writes `adapter: openai_resp`).
     adapter: str | None = None
+    #: Optional per-model price for this endpoint. When set, budget/cost
+    #: accounting treats it as the authoritative price for this endpoint's
+    #: model, ahead of any operator override or the built-in pricing table.
+    #: ``None`` (the default) leaves existing pricing behavior unchanged.
+    pricing: EndpointPricing | None = None
 
     @property
     def is_openai_compat(self) -> bool:
@@ -446,6 +473,7 @@ __all__ = [
     "ENV_BASE_URL",
     "ENV_MODEL",
     "DEFAULT_ANTHROPIC_MODEL",
+    "EndpointPricing",
     "LLMEndpoint",
     "resolve_llm_endpoint",
 ]

--- a/tests/test_llm_spend_budget.py
+++ b/tests/test_llm_spend_budget.py
@@ -17,6 +17,7 @@ from clearwing.llm.budget import (
     SpendLedger,
 )
 from clearwing.llm.native import AsyncLLMClient
+from clearwing.providers import EndpointPricing, LLMEndpoint
 from clearwing.sourcehunt.pool import HunterPool, HuntPoolConfig
 from clearwing.sourcehunt.runner import SourceHuntRunner
 
@@ -114,10 +115,7 @@ def test_reservations_are_atomic_across_concurrent_native_calls(tmp_path, monkey
 
     async def run_calls():
         return await asyncio.gather(
-            *[
-                client.achat(messages=[ChatMessage("user", f"call {idx}")])
-                for idx in range(8)
-            ],
+            *[client.achat(messages=[ChatMessage("user", f"call {idx}")]) for idx in range(8)],
             return_exceptions=True,
         )
 
@@ -131,7 +129,8 @@ def test_reservations_are_atomic_across_concurrent_native_calls(tmp_path, monkey
 
 
 def test_unlimited_ledger_tracks_usage_without_changing_output_limit(
-    tmp_path, monkeypatch,
+    tmp_path,
+    monkeypatch,
 ):
     ledger = _ledger(tmp_path, budget=0.0)
     client = AsyncLLMClient(
@@ -261,7 +260,9 @@ def test_streaming_calls_settle_against_the_same_ledger(tmp_path, monkeypatch):
         usage=Usage(prompt_tokens=0, completion_tokens=1, total_tokens=1),
     )
     monkeypatch.setattr(
-        AsyncLLMClient, "_build_client", lambda self, cls: StreamingClient(),
+        AsyncLLMClient,
+        "_build_client",
+        lambda self, cls: StreamingClient(),
     )
     monkeypatch.setattr(
         AsyncLLMClient,
@@ -304,8 +305,7 @@ def test_ledger_persists_reservations_settlements_and_final_status(tmp_path):
 
     manifest = json.loads(ledger.manifest_path.read_text(encoding="utf-8"))
     events = [
-        json.loads(line)
-        for line in ledger.ledger_path.read_text(encoding="utf-8").splitlines()
+        json.loads(line) for line in ledger.ledger_path.read_text(encoding="utf-8").splitlines()
     ]
 
     assert summary["status"] == "budget_exhausted"
@@ -363,11 +363,11 @@ def test_cancellation_closes_an_inflight_reservation(tmp_path, monkeypatch):
 
         monkeypatch.setattr(AsyncLLMClient, "_build_client", lambda self, cls: object())
         monkeypatch.setattr(
-            AsyncLLMClient, "_achat_with_provider_policy", wait_forever,
+            AsyncLLMClient,
+            "_achat_with_provider_policy",
+            wait_forever,
         )
-        task = asyncio.create_task(
-            client.achat(messages=[ChatMessage("user", "cancel me")])
-        )
+        task = asyncio.create_task(client.achat(messages=[ChatMessage("user", "cancel me")]))
         await entered.wait()
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
@@ -437,7 +437,8 @@ def test_runner_manifest_uses_ranker_ledger_not_hunter_totals(tmp_path, monkeypa
 
 
 def test_runner_returns_clean_partial_result_when_budget_cannot_fit_call(
-    tmp_path, monkeypatch,
+    tmp_path,
+    monkeypatch,
 ):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -456,7 +457,9 @@ def test_runner_returns_clean_partial_result_when_budget_cannot_fit_call(
 
     monkeypatch.setattr(AsyncLLMClient, "_build_client", lambda self, cls: object())
     monkeypatch.setattr(
-        AsyncLLMClient, "_achat_with_provider_policy", should_not_dispatch,
+        AsyncLLMClient,
+        "_achat_with_provider_policy",
+        should_not_dispatch,
     )
 
     runner = SourceHuntRunner(
@@ -473,9 +476,7 @@ def test_runner_returns_clean_partial_result_when_budget_cannot_fit_call(
     )
     result = runner.run()
     manifest = json.loads(
-        (tmp_path / "out" / result.session_id / "manifest.json").read_text(
-            encoding="utf-8"
-        )
+        (tmp_path / "out" / result.session_id / "manifest.json").read_text(encoding="utf-8")
     )
 
     assert dispatched is False
@@ -525,3 +526,177 @@ def test_no_rank_skips_ranker_pricing_preflight_and_dispatch(tmp_path, monkeypat
     assert dispatched is False
     assert result.status == "completed"
     assert result.cost_usd == 0.0
+
+
+# --- Per-endpoint pricing -------------------------------------------------
+#
+# An LLMEndpoint may carry an optional EndpointPricing. When it does, the
+# ledger treats it as the authoritative price for that run — ahead of the
+# operator override and the built-in pricing table. When it doesn't, pricing
+# resolution is exactly as before.
+
+
+def test_endpoint_pricing_drives_budget(tmp_path):
+    """A priced endpoint is used verbatim, even for an unknown model."""
+
+    endpoint = LLMEndpoint(
+        provider="openai_compat",
+        model="private-model-with-unknown-price",
+        base_url="https://gateway.example/v1",
+        pricing=EndpointPricing(input_per_mtok=2.0, output_per_mtok=8.0),
+    )
+    ledger = SpendLedger(
+        limit_usd=1.0,
+        session_id="endpoint-priced",
+        repo_url="/tmp/repo",
+        output_dir=tmp_path,
+        endpoint=endpoint,
+    )
+
+    # Without endpoint pricing this model has no verified price under a strict
+    # (enforcing) budget and would raise; the endpoint price makes it usable.
+    pricing = ledger.validate_model(
+        model="private-model-with-unknown-price",
+        provider="openai_compat",
+        supports_output_limit=True,
+    )
+
+    assert pricing.source == "endpoint_pricing"
+    assert pricing.input_per_million == pytest.approx(2.0)
+    assert pricing.output_per_million == pytest.approx(8.0)
+    # No distinct cached rate supplied -> falls back to the input rate.
+    assert pricing.cached_input_per_million == pytest.approx(2.0)
+
+
+def test_endpoint_pricing_uses_explicit_cached_rate(tmp_path):
+    endpoint = LLMEndpoint(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        pricing=EndpointPricing(
+            input_per_mtok=3.0,
+            output_per_mtok=15.0,
+            cached_per_mtok=0.3,
+            cache_creation_per_mtok=3.75,
+        ),
+    )
+    ledger = SpendLedger(
+        limit_usd=1.0,
+        session_id="endpoint-cached",
+        repo_url="/tmp/repo",
+        output_dir=tmp_path,
+        endpoint=endpoint,
+    )
+
+    pricing = ledger.validate_model(
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        supports_output_limit=True,
+    )
+
+    assert pricing.cached_input_per_million == pytest.approx(0.3)
+
+
+def test_endpoint_pricing_outranks_operator_override(tmp_path):
+    """Endpoint pricing wins over an explicit input/output price override."""
+
+    endpoint = LLMEndpoint(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        pricing=EndpointPricing(input_per_mtok=1.0, output_per_mtok=1.0),
+    )
+    ledger = SpendLedger(
+        limit_usd=1.0,
+        session_id="endpoint-vs-override",
+        repo_url="/tmp/repo",
+        output_dir=tmp_path,
+        input_price_per_million=99.0,
+        output_price_per_million=99.0,
+        endpoint=endpoint,
+    )
+
+    pricing = ledger.validate_model(
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        supports_output_limit=True,
+    )
+
+    assert pricing.source == "endpoint_pricing"
+    assert pricing.input_per_million == pytest.approx(1.0)
+    assert pricing.output_per_million == pytest.approx(1.0)
+
+
+def test_endpoint_pricing_charges_at_endpoint_rate(tmp_path, monkeypatch):
+    """Settlement uses the endpoint rate: 1 output token costs exactly $1."""
+
+    endpoint = LLMEndpoint(
+        provider="anthropic",
+        model="private-priced-model",
+        pricing=EndpointPricing(
+            input_per_mtok=0.0,
+            output_per_mtok=1_000_000.0,
+        ),
+    )
+    ledger = SpendLedger(
+        limit_usd=1.0,
+        session_id="endpoint-charge",
+        repo_url="/tmp/repo",
+        output_dir=tmp_path,
+        endpoint=endpoint,
+    )
+    client = AsyncLLMClient(
+        model_name="private-priced-model",
+        provider_name="anthropic",
+        api_key="test",
+    ).with_spend_ledger(ledger, stage="rank")
+
+    async def fake_policy(self, client_obj, request, options):
+        return ChatResponse(
+            content=[{"text": "done"}],
+            usage=Usage(prompt_tokens=0, completion_tokens=1, total_tokens=1),
+        )
+
+    monkeypatch.setattr(AsyncLLMClient, "_build_client", lambda self, cls: object())
+    monkeypatch.setattr(AsyncLLMClient, "_achat_with_provider_policy", fake_policy)
+
+    asyncio.run(client.achat(messages=[ChatMessage("user", "hi")]))
+
+    assert ledger.spent_usd == pytest.approx(1.0)
+
+
+def test_endpoint_without_pricing_falls_back_to_table(tmp_path):
+    """An endpoint carrying no pricing leaves resolution unchanged."""
+
+    endpoint = LLMEndpoint(provider="anthropic", model="claude-sonnet-4-6")
+    ledger = SpendLedger(
+        limit_usd=1.0,
+        session_id="endpoint-no-pricing",
+        repo_url="/tmp/repo",
+        output_dir=tmp_path,
+        endpoint=endpoint,
+    )
+
+    pricing = ledger.validate_model(
+        model="claude-sonnet-4-6",
+        provider="anthropic",
+        supports_output_limit=True,
+    )
+
+    assert pricing.source == "pricing_table:claude-sonnet-4-6"
+
+
+def test_no_endpoint_preserves_strict_unknown_model_rejection(tmp_path):
+    """Omitting the endpoint entirely keeps today's strict-budget behavior."""
+
+    ledger = SpendLedger(
+        limit_usd=1.0,
+        session_id="no-endpoint",
+        repo_url="/tmp/repo",
+        output_dir=tmp_path,
+    )
+
+    with pytest.raises(BudgetConfigurationError, match="No verified pricing"):
+        ledger.validate_model(
+            model="private-model-with-unknown-price",
+            provider="openai",
+            supports_output_limit=True,
+        )


### PR DESCRIPTION
## What

Adds a generic, backward-compatible capability: an `LLMEndpoint` can carry
per-model pricing, and the run-scoped budget/cost model honors it.

- **`clearwing/providers/env.py`** — new `EndpointPricing` dataclass
  (`input_per_mtok`, `output_per_mtok`, optional `cached_per_mtok` and
  `cache_creation_per_mtok`, all USD per one million tokens) and a new
  optional `pricing: EndpointPricing | None = None` field on `LLMEndpoint`.
- **`clearwing/providers/__init__.py`** — export `EndpointPricing` alongside
  `LLMEndpoint`.
- **`clearwing/llm/budget.py`** — `SpendLedger` gains an optional
  `endpoint=` parameter. When the endpoint carries `pricing`, it becomes the
  authoritative price in `_resolve_pricing`, ahead of the operator
  input/output override and the built-in pricing table. Field names are
  mapped `*_per_mtok` → `*_per_million`; a missing cached rate falls back to
  the input rate, matching the existing override/table behavior.

## Why it's safe

Purely additive. `EndpointPricing`, `LLMEndpoint.pricing`, and
`SpendLedger(endpoint=...)` all default to `None`, so every existing path —
CLI flags, `CLEARWING_*` env vars, `config.yaml`, and the Anthropic default,
plus the operator `--input-price`/`--output-price` override and the built-in
pricing table — behaves exactly as before when no endpoint pricing is set.

## Where it came from

This generalizes an integration originally built downstream (the cwpro
project), where a managing process resolves a canonical per-model price and
needs the ledger to honor it. The upstream seam here carries **no**
downstream-specific coupling — no process-routing envelope, no header
plumbing. Whoever constructs an endpoint may set `.pricing`; the budget model
simply prefers it when present.

## Tests

Added to `tests/test_llm_spend_budget.py`:

- an endpoint **with** pricing drives the budget (used verbatim, even for an
  otherwise-unpriced model; charged at the endpoint rate on settlement),
- explicit cached rate is honored; absent cached rate falls back to input,
- endpoint pricing outranks an operator override,
- an endpoint **without** pricing falls back to the pricing table unchanged,
- omitting the endpoint entirely preserves today's strict-budget rejection of
  unknown models.

`test_llm_spend_budget.py` + `test_providers_env.py`: 53 passed. `ruff check`
adds zero new findings and `ruff format --check` is clean on the changed
files; the scoped mypy gate error count is unchanged.