### PR TITLE
Recognize assembly/asm-generator sources in sourcehunt discovery

### DIFF
--- a/clearwing/sourcehunt/preprocessor.py
+++ b/clearwing/sourcehunt/preprocessor.py
@@ -97,6 +97,10 @@ _SOURCE_EXTS_TO_LANG: dict[str, str] = {
     ".hh": "cpp",
     ".hxx": "cpp",
     ".rs": "rust",
+    ".s": "asm",
+    ".asm": "asm",
+    ".pl": "perl",
+    ".pm": "perl",
 }
 
 


### PR DESCRIPTION
## Problem

Sourcehunt's preprocessor only treats C/C++/Rust and the original static-analyzer languages as source files. Assembly (`.s`/`.S`, `.asm`) and asm-generator scripts (`.pl`/`.pm`) are dropped at the extension gate (`preprocessor.py`, `_SOURCE_EXTS_TO_LANG`), so they never become `FileTarget`s.

For a subsystem that contains *only* such files (e.g. OpenSSL's `crypto/aes/asm/`, which is 100% `.pl` Perl generators + `.S` assembly), this means **zero** FileTargets are discovered. `subsystem_from_path()` then raises `ValueError` and the runner logs:

```
WARNING  No files match subsystem path: crypto/aes/asm
```

The subsystem is hunted as empty — even though the vulnerable file (e.g. `crypto/aes/asm/aes-cfb-avx512.pl`) is present in the checkout.

## Motivating CVE

This was surfaced while running the CVE eval against **[CVE-2026-28386](https://nvd.nist.gov/vuln/detail/CVE-2026-28386)** — *OpenSSL AES-CFB128 OOB read on AVX-512+VAES partial blocks* (CWE-125 Out-of-bounds Read; High/CVSS 7.5).

- **Repo:** `openssl/openssl`
- **Subsystem:** `crypto/aes/asm`
- **Vulnerable file:** `crypto/aes/asm/aes-cfb-avx512.pl` (a Perl generator that emits the actual AVX-512 assembly)
- **Vulnerable commit:** `481743fb8aa2b72f0a82c4c112880c290339fa60`
- **Root cause:** The AVX-512+VAES AES-CFB128 path uses `vmovdqu8` to load 16-byte XMM registers from the IV/input buffers on partial blocks. A `k1` opmask bounds the valid bytes, but the loads omit the `{%k1}{z}` masked-with-zeroing decorator, so a full 16-byte read happens regardless — reading past the input buffer.

Because the vulnerable code lives entirely in a `.pl`/`.S`-only directory, the pre-fix pipeline discovered **0 FileTargets** there and never hunted the actual vulnerability. This PR is what lets sourcehunt see that subsystem at all.

## Fix

Add `.s`/`.asm` (→ `asm`) and `.pl`/`.pm` (→ `perl`) to `_SOURCE_EXTS_TO_LANG` so these files surface as FileTargets for the LLM hunt.

- `Path(...).suffix.lower()` means `.S` arrives as `.s`, so one entry covers both.
- The callgraph (`callgraph._LANG_EXT_MAP`) and taint (`taint._language_for`) passes have no grammar for `perl`/`asm` and already skip unknown languages gracefully — so these files get a **content-only** hunt rather than static reachability. That's the correct floor for a directory the pipeline otherwise treats as empty; no crashes, no behavior change for existing languages.
- The sandbox image build selects toolchains from `build_recipe.primary_language`, not from FileTarget language labels, so it's unaffected.

## Verification

- On a synthetic tree mirroring `crypto/aes/asm/` (`aes-cfb-avx512.pl`, `aes-ia64.S`, plus a sibling `.c`), the two asm files now resolve to `perl`/`asm` FileTargets and `subsystem_from_path("crypto/aes/asm", ...)` matches them instead of raising.
- `pytest tests/ -k "preprocess or subsystem"` → **99 passed**, no regressions. (Two `async def` subsystem tests error only because `pytest-asyncio` isn't installed in this environment — unrelated to this change.)
