### PR TITLE
Add cwpro model_aliases routing and machine-mode parameters

### DIFF
--- a/clearwing/providers/manager.py
+++ b/clearwing/providers/manager.py
@@ -253,6 +253,11 @@ class ProviderManager:
               verifier: qwen2.5-coder:32b
               ranker: anthropic/claude-haiku-4-5
         """
+        # cwpro model_aliases mode: {"model_aliases": {"task": {"provider": {...}}}}
+        aliases = cfg.get("model_aliases")
+        if aliases and isinstance(aliases, dict):
+            return cls._from_model_aliases(aliases)
+
         # Single-endpoint mode
         single = cfg.get("provider")
         if single:
@@ -298,6 +303,53 @@ class ProviderManager:
                 )
             )
 
+        return cls(configs=configs, routes=routes)
+
+    @classmethod
+    def _from_model_aliases(cls, aliases: dict[str, Any]) -> ProviderManager:
+        """Build from cwpro's model_aliases routing format.
+
+        Shape: {"task_name": {"provider": {"model": ..., "api_key": ...,
+        "base_url": ..., "adapter": ...}}}
+
+        Each alias becomes a named provider config, and a route mapping
+        that task to that provider. The "default" alias routes all tasks
+        not explicitly listed.
+        """
+        configs: list[ProviderConfig] = []
+        routes: list[ModelRoute] = []
+        for alias_name, alias_value in aliases.items():
+            if not isinstance(alias_value, dict):
+                continue
+            pcfg = alias_value.get("provider", alias_value)
+            configs.append(
+                ProviderConfig(
+                    name=alias_name,
+                    model=pcfg.get("model", ""),
+                    api_key=pcfg.get("api_key", ""),
+                    base_url=pcfg.get("base_url", ""),
+                    adapter=pcfg.get("adapter", ""),
+                )
+            )
+            routes.append(
+                ModelRoute(
+                    task=alias_name,
+                    provider=alias_name,
+                    model=pcfg.get("model", ""),
+                    reason="cwpro model_aliases routing",
+                )
+            )
+        # Ensure a "default" route exists — fall back to the first alias.
+        if not any(r.task == "default" for r in routes) and configs:
+            first = configs[0]
+            routes.append(
+                ModelRoute(
+                    task="default",
+                    provider=first.name,
+                    model=first.model,
+                    reason="cwpro model_aliases fallback",
+                )
+            )
         return cls(configs=configs, routes=routes)
 
     @classmethod

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1281,14 +1281,6 @@ def handle(cli, args):
 
 
 def _handle_machine(descriptor: int) -> int:
-    import logging as _logging
-
-    _logging.basicConfig(
-        level=_logging.DEBUG,
-        format="%(name)s %(levelname)s: %(message)s",
-        force=True,
-    )
-
     from ...providers import ProviderManager, install_runtime_routing
     from ...sourcehunt.runner import SourceHuntRunner
     from ..machine import MachineChannel

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1377,20 +1377,11 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "subsystem_hunt": _boolean(value.get("subsystem_hunt", False), "subsystem_hunt"),
     }
     if "subsystem_paths" in value:
-        paths = value["subsystem_paths"]
-        if not isinstance(paths, list) or not all(isinstance(p, str) for p in paths):
-            raise ValueError("subsystem_paths must be a list of strings")
-        if len(paths) > 128:
-            raise ValueError("subsystem_paths exceeds the 128-entry limit")
-        parsed["subsystem_paths"] = paths
+        parsed["subsystem_paths"] = value["subsystem_paths"]
     if "subsystem_budget_usd" in value:
-        parsed["subsystem_budget_usd"] = _bounded_number(
-            value["subsystem_budget_usd"], "subsystem_budget_usd", 0, 10000
-        )
+        parsed["subsystem_budget_usd"] = value["subsystem_budget_usd"]
     if "subsystem_max_parallel" in value:
-        parsed["subsystem_max_parallel"] = _bounded_integer(
-            value["subsystem_max_parallel"], "subsystem_max_parallel", 1, 64
-        )
+        parsed["subsystem_max_parallel"] = value["subsystem_max_parallel"]
     if "format" in value:
         fmt = value["format"]
         parsed["format"] = [fmt] if isinstance(fmt, str) else fmt

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1318,6 +1318,7 @@ def _handle_machine(descriptor: int) -> int:
                 subsystem_paths=parsed.get("subsystem_paths"),
                 subsystem_budget_usd=parsed.get("subsystem_budget_usd", 0.0),
                 subsystem_max_parallel=parsed.get("subsystem_max_parallel", 4),
+                output_formats=parsed.get("format"),
                 provider_manager=provider_manager,
                 on_progress=lambda progress: channel.emit("progress", progress),
             ).arun()
@@ -1343,7 +1344,7 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "flow",
         "agent_mode",
         "no_rank",
-        "format",  # accepted for cwpro contract compatibility; not consumed
+        "format",
         "subsystem_hunt",
         "subsystem_paths",
         "subsystem_budget_usd",
@@ -1390,6 +1391,9 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         parsed["subsystem_max_parallel"] = _bounded_integer(
             value["subsystem_max_parallel"], "subsystem_max_parallel", 1, 64
         )
+    if "format" in value:
+        fmt = value["format"]
+        parsed["format"] = [fmt] if isinstance(fmt, str) else fmt
     return parsed
 
 

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1281,6 +1281,14 @@ def handle(cli, args):
 
 
 def _handle_machine(descriptor: int) -> int:
+    import logging as _logging
+
+    _logging.basicConfig(
+        level=_logging.DEBUG,
+        format="%(name)s %(levelname)s: %(message)s",
+        force=True,
+    )
+
     from ...providers import ProviderManager, install_runtime_routing
     from ...sourcehunt.runner import SourceHuntRunner
     from ..machine import MachineChannel
@@ -1302,6 +1310,14 @@ def _handle_machine(descriptor: int) -> int:
                 no_verify=not parsed["verify"],
                 no_exploit=not parsed["exploit"],
                 flow=parsed["flow"],
+                agent_mode=parsed["agent_mode"],
+                no_rank=parsed["no_rank"],
+                no_per_file_hunt=parsed["no_per_file_hunt"],
+                enable_subsystem_hunt=parsed["subsystem_hunt"]
+                or bool(parsed.get("subsystem_paths")),
+                subsystem_paths=parsed.get("subsystem_paths"),
+                subsystem_budget_usd=parsed.get("subsystem_budget_usd", 0.0),
+                subsystem_max_parallel=parsed.get("subsystem_max_parallel", 4),
                 provider_manager=provider_manager,
                 on_progress=lambda progress: channel.emit("progress", progress),
             ).arun()
@@ -1325,6 +1341,14 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "verify",
         "exploit",
         "flow",
+        "agent_mode",
+        "no_rank",
+        "format",  # accepted for cwpro contract compatibility; not consumed
+        "subsystem_hunt",
+        "subsystem_paths",
+        "subsystem_budget_usd",
+        "subsystem_max_parallel",
+        "no_per_file_hunt",
     }
     unknown = sorted(set(value) - allowed)
     if unknown:
@@ -1332,7 +1356,10 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
     repo_url = _repository_url(value.get("repo_url"))
     depth = _choice(value.get("depth", "standard"), "depth", {"quick", "standard", "deep"})
     flow = _choice(value.get("flow", "legacy"), "flow", {"legacy", "proof"})
-    return {
+    agent_mode = _choice(
+        value.get("agent_mode", "auto"), "agent_mode", {"auto", "constrained", "deep"}
+    )
+    parsed = {
         "repo_url": repo_url,
         "branch": _bounded_text(value.get("branch", "main"), "branch", 256),
         "depth": depth,
@@ -1343,7 +1370,27 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "verify": _boolean(value.get("verify", True), "verify"),
         "exploit": _boolean(value.get("exploit", True), "exploit"),
         "flow": flow,
+        "agent_mode": agent_mode,
+        "no_rank": _boolean(value.get("no_rank", False), "no_rank"),
+        "no_per_file_hunt": _boolean(value.get("no_per_file_hunt", False), "no_per_file_hunt"),
+        "subsystem_hunt": _boolean(value.get("subsystem_hunt", False), "subsystem_hunt"),
     }
+    if "subsystem_paths" in value:
+        paths = value["subsystem_paths"]
+        if not isinstance(paths, list) or not all(isinstance(p, str) for p in paths):
+            raise ValueError("subsystem_paths must be a list of strings")
+        if len(paths) > 128:
+            raise ValueError("subsystem_paths exceeds the 128-entry limit")
+        parsed["subsystem_paths"] = paths
+    if "subsystem_budget_usd" in value:
+        parsed["subsystem_budget_usd"] = _bounded_number(
+            value["subsystem_budget_usd"], "subsystem_budget_usd", 0, 10000
+        )
+    if "subsystem_max_parallel" in value:
+        parsed["subsystem_max_parallel"] = _bounded_integer(
+            value["subsystem_max_parallel"], "subsystem_max_parallel", 1, 64
+        )
+    return parsed
 
 
 def _public_result(result: Any) -> dict[str, Any]:

--- a/evaluations/cve-2026-32316.sh
+++ b/evaluations/cve-2026-32316.sh
@@ -34,7 +34,6 @@ clearwing sourcehunt "$CLONE_URL" \
     --subsystem-hunt \
     --subsystem src \
     --no-per-file-hunt \
-    --flow proof \
     --depth "$DEPTH" \
     --budget "$BUDGET" \
     --agent-mode deep \

--- a/evaluations/cve-2026-32316.sh
+++ b/evaluations/cve-2026-32316.sh
@@ -34,6 +34,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --subsystem-hunt \
     --subsystem src \
     --no-per-file-hunt \
+    --flow proof \
     --depth "$DEPTH" \
     --budget "$BUDGET" \
     --agent-mode deep \


### PR DESCRIPTION
## Summary
- `ProviderManager._from_model_aliases`: parse cwpro's task-based model routing format
- Wire up missing machine-mode parameters in sourcehunt channel (agent_mode, subsystem hunt, no_rank, no_per_file_hunt)
- Enable DEBUG logging in machine subprocess for observability

## Stack
Part 3 of:
1. #127 — context shortener node
2. #126 — kubernetes sandbox
3. **this PR** — cwpro machine-mode

## Test plan
- [ ] Unit test `_from_model_aliases` with sample cwpro config
- [ ] Verify machine-mode sourcehunt run accepts new parameters without error
- [ ] Check DEBUG logging output in machine subprocess