### PR TITLE
Add Arize Phoenix LLM observability exporter

### DIFF
--- a/clearwing/observability/__init__.py
+++ b/clearwing/observability/__init__.py
@@ -2,4 +2,10 @@ from .metrics import MetricPoint, MetricsCollector
 from .telemetry import CostTracker
 from .tracer import Span, Tracer
 
-__all__ = ["Tracer", "Span", "MetricsCollector", "MetricPoint", "CostTracker"]
+__all__ = [
+    "CostTracker",
+    "MetricPoint",
+    "MetricsCollector",
+    "Span",
+    "Tracer",
+]

--- a/clearwing/observability/integration.py
+++ b/clearwing/observability/integration.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from clearwing.core.events import EventBus, EventType
 
+from .phoenix import phoenix_exporter_from_env
 from .metrics import MetricsCollector
 from .tracer import ConsoleExporter, InMemoryExporter, Tracer
 
@@ -38,6 +39,8 @@ class ObservabilityIntegration:
             exporters = []
             if debug:
                 exporters.append(ConsoleExporter())
+            if phoenix_exp := phoenix_exporter_from_env():
+                exporters.append(phoenix_exp)
         self._in_memory = InMemoryExporter()
         exporters.append(self._in_memory)
 
@@ -109,10 +112,29 @@ class ObservabilityIntegration:
     def _on_cost_update(self, data: Any) -> None:
         if not isinstance(data, dict):
             return
-        self.metrics.increment("llm_calls_total", labels={"model": data.get("model", "unknown")})
+        model = data.get("model", "unknown")
+        self.metrics.increment("llm_calls_total", labels={"model": model})
         self.metrics.increment("input_tokens_total", value=float(data.get("input_tokens", 0)))
         self.metrics.increment("output_tokens_total", value=float(data.get("output_tokens", 0)))
         self.metrics.set_gauge("total_cost_usd", data.get("total_cost_usd", 0.0))
+
+        # Emit a synthetic span so Arize sees per-call LLM telemetry
+        import time
+
+        now = time.time()
+        elapsed_s = data.get("elapsed_ms", 0) / 1000.0
+        with self.tracer.span("llm_call", attributes={
+            "llm.model": model,
+            "llm.provider": data.get("provider", "unknown"),
+            "llm.token_count.input": data.get("input_tokens", 0),
+            "llm.token_count.output": data.get("output_tokens", 0),
+            "llm.token_count.cached": data.get("cached_tokens", 0),
+            "llm.cost_usd": data.get("total_cost_usd", 0.0),
+            "span.kind": "llm",
+        }) as s:
+            # Backdate start to reflect actual call timing
+            if elapsed_s > 0:
+                s.start_time = now - elapsed_s
 
     def _on_flag_found(self, data: Any) -> None:
         self.metrics.increment("flags_found_total")

--- a/clearwing/observability/phoenix.py
+++ b/clearwing/observability/phoenix.py
@@ -1,0 +1,77 @@
+"""Phoenix span exporter via the OpenTelemetry OTLP pipeline.
+
+Configuration via environment variables (both required for env-based init):
+    PHOENIX_ENDPOINT    — Phoenix collector endpoint
+    PHOENIX_PROJECT     — Project name
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from .tracer import Span, SpanExporter
+
+logger = logging.getLogger(__name__)
+
+
+def _to_readable_span(span: Span, resource):
+    """Bridge a Clearwing Span to an OTel ReadableSpan."""
+    from opentelemetry.sdk.trace import ReadableSpan as _ReadableSpan
+    from opentelemetry.trace import SpanContext, SpanKind, TraceFlags
+    from opentelemetry.trace.status import Status, StatusCode
+
+    trace_id = int(span.trace_id, 16) & ((1 << 128) - 1)
+    span_id = int(span.span_id, 16) & ((1 << 64) - 1)
+    parent_id = int(span.parent_span_id, 16) & ((1 << 64) - 1) if span.parent_span_id else 0
+
+    ctx = SpanContext(trace_id=trace_id, span_id=span_id, is_remote=False, trace_flags=TraceFlags(0x01))
+    parent_ctx = SpanContext(trace_id=trace_id, span_id=parent_id, is_remote=False, trace_flags=TraceFlags(0x01)) if parent_id else None
+
+    status = Status(StatusCode.ERROR, span.attributes.get("error.message", "")) if span.status == "error" else Status(StatusCode.OK)
+
+    return _ReadableSpan(
+        name=span.name,
+        context=ctx,
+        parent=parent_ctx,
+        resource=resource,
+        attributes=span.attributes,
+        events=tuple(),
+        kind=SpanKind.INTERNAL,
+        status=status,
+        start_time=int(span.start_time * 1e9),
+        end_time=int(span.end_time * 1e9),
+    )
+
+
+class PhoenixExporter(SpanExporter):
+    """Exports Clearwing spans to a self-hosted Phoenix instance via OTel OTLP/HTTP."""
+
+    def __init__(self, endpoint: str, project_name: str):
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+        self.endpoint = endpoint.rstrip("/")
+        self.project_name = project_name
+
+        self._resource = Resource.create({"service.name": "clearwing", "project.name": self.project_name})
+        otlp = OTLPSpanExporter(endpoint=f"{self.endpoint}/v1/traces")
+        self._processor = BatchSpanProcessor(otlp)
+        logger.info("PhoenixExporter → %s (project=%s)", self.endpoint, self.project_name)
+
+    def export(self, spans: list[Span]) -> None:
+        for span in spans:
+            self._processor.on_end(_to_readable_span(span, self._resource))
+
+    def shutdown(self) -> None:
+        self._processor.shutdown()
+
+
+def phoenix_exporter_from_env() -> PhoenixExporter | None:
+    """Create a PhoenixExporter if PHOENIX_ENDPOINT and PHOENIX_PROJECT are set, else return None."""
+    endpoint = os.environ.get("PHOENIX_ENDPOINT")
+    project = os.environ.get("PHOENIX_PROJECT")
+    if not endpoint or not project:
+        return None
+    return PhoenixExporter(endpoint=endpoint, project_name=project)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ dependencies = [
     "tree-sitter-go>=0.21.0",
     "tree-sitter-rust>=0.21.0",
     "uv>=0.11.26",
+    # Observability
+    "arize-phoenix-otel>=0.6.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -434,3 +434,65 @@ class TestObservabilityIntegration:
     def test_spans_property(self):
         obs = ObservabilityIntegration()
         assert obs.spans == []
+
+    def test_phoenix_disabled_by_default(self):
+        """PhoenixExporter not attached when env vars absent."""
+        obs = ObservabilityIntegration()
+        # Only InMemoryExporter present (no Phoenix without PHOENIX_ENDPOINT)
+        assert len(obs.tracer._exporters) == 1
+
+    def test_cost_update_emits_llm_span(self):
+        """cost_update event creates an llm_call span for Arize."""
+        obs = ObservabilityIntegration()
+        obs._on_cost_update({
+            "model": "claude-opus-4-6",
+            "provider": "anthropic",
+            "input_tokens": 2000,
+            "output_tokens": 400,
+            "cached_tokens": 500,
+            "total_cost_usd": 0.12,
+            "elapsed_ms": 1500,
+        })
+        obs.tracer.flush()
+        llm_spans = obs._in_memory.get_spans("llm_call")
+        assert len(llm_spans) == 1
+        s = llm_spans[0]
+        assert s.attributes["llm.model"] == "claude-opus-4-6"
+        assert s.attributes["llm.token_count.input"] == 2000
+        assert s.attributes["llm.cost_usd"] == 0.12
+
+
+# ---------------------------------------------------------------------------
+# PhoenixExporter tests
+# ---------------------------------------------------------------------------
+
+
+class TestPhoenixExporter:
+    def test_construct(self):
+        from clearwing.observability.phoenix import PhoenixExporter
+
+        exporter = PhoenixExporter(endpoint="http://localhost:6006", project_name="test")
+        exporter.shutdown()
+
+    def test_from_env_returns_none_without_endpoint(self, monkeypatch):
+        from clearwing.observability.phoenix import phoenix_exporter_from_env
+
+        monkeypatch.delenv("PHOENIX_ENDPOINT", raising=False)
+        monkeypatch.delenv("PHOENIX_PROJECT", raising=False)
+        assert phoenix_exporter_from_env() is None
+
+    def test_from_env_returns_none_without_project(self, monkeypatch):
+        from clearwing.observability.phoenix import phoenix_exporter_from_env
+
+        monkeypatch.setenv("PHOENIX_ENDPOINT", "http://phoenix:6006")
+        monkeypatch.delenv("PHOENIX_PROJECT", raising=False)
+        assert phoenix_exporter_from_env() is None
+
+    def test_from_env_returns_exporter_when_both_set(self, monkeypatch):
+        from clearwing.observability.phoenix import phoenix_exporter_from_env
+
+        monkeypatch.setenv("PHOENIX_ENDPOINT", "http://phoenix:6006")
+        monkeypatch.setenv("PHOENIX_PROJECT", "clearwing")
+        exporter = phoenix_exporter_from_env()
+        assert exporter is not None
+        exporter.shutdown()

--- a/uv.lock
+++ b/uv.lock
@@ -253,6 +253,25 @@ wheels = [
 ]
 
 [[package]]
+name = "arize-phoenix-otel"
+version = "0.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/97/5aef2776ee17eacb24a82de719312008ca0a16b915415cc9363a9a9b1536/arize_phoenix_otel-0.16.1.tar.gz", hash = "sha256:28ba1d43dcd2dc556f6cac25622c3333e613e2cf1d687832a9ed5ce2c20e17be", size = 20933, upload-time = "2026-05-03T19:07:02.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/2e/e495446a8a715d9892a4dbc56e11b18fb6f07a634182babc0b0ac6827d9c/arize_phoenix_otel-0.16.1-py3-none-any.whl", hash = "sha256:eb71f7be8d94e68f5cd82b134f7ea1710fa73374bf0d8d663ce6242332871ff9", size = 18033, upload-time = "2026-05-03T19:07:01.395Z" },
+]
+
+[[package]]
 name = "async-timeout"
 version = "5.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -741,6 +760,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "arize-phoenix-otel" },
     { name = "asyncssh" },
     { name = "chromadb" },
     { name = "docker" },
@@ -829,6 +849,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.8.0" },
+    { name = "arize-phoenix-otel", specifier = ">=0.6.0" },
     { name = "asyncssh", specifier = ">=2.13.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.0" },
@@ -1763,7 +1784,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -3402,33 +3423,69 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-api"
-version = "1.41.0"
+name = "openinference-instrumentation"
+version = "0.1.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/54/ad2d006229e65501eb8895d65b89a27a1330833eda41bc6e407b991aa385/openinference_instrumentation-0.1.56.tar.gz", hash = "sha256:c43bea7f1f4460fe13c3c88aff092500cc3397aaffea37188d72246489dcbc9f", size = 39137, upload-time = "2026-07-31T06:23:43.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/09/25fc4ec6f7b05948bb8bf35810805f494ecea67d3c8c3e0befe3c477aa54/openinference_instrumentation-0.1.56-py3-none-any.whl", hash = "sha256:ae7ae74bd93c0f733cf2649056c94246e1a2d0432ddf9b675dd4e58718094b62", size = 46892, upload-time = "2026-07-31T06:23:41.955Z" },
+]
+
+[[package]]
+name = "openinference-semantic-conventions"
+version = "0.1.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/3e/8f96e000651a01c801d98736c63aaf4140dd5a68a325cad92045c53484dd/openinference_semantic_conventions-0.1.31.tar.gz", hash = "sha256:39bed2e6edabb5b8dd983e22d3d4914e660ff1f8a49d7df8ceae938af5bb5836", size = 13966, upload-time = "2026-08-01T16:13:21.334Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/d5/9d32686b8911ca79001dd0a352e89069a0b3749446b37859494805dd1bf1/openinference_semantic_conventions-0.1.31-py3-none-any.whl", hash = "sha256:ae7eee916622dc9f64ea14cae26911c78653b1c0d7a62a56788934d5830f3472", size = 11241, upload-time = "2026-08-01T16:13:20.153Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/45/7af37fe54e5d3e66e7dcd7ba8b8aeee73f202bfac909cc94b8c4e428f9ac/opentelemetry_exporter_otlp-1.44.0.tar.gz", hash = "sha256:af1cde7c33ea8ed624bf04ac49a885730fe44c1f1ad698656e592c38f70ce106", size = 6090, upload-time = "2026-07-16T15:25:34.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/c3/7b466a9463944e70b37b744072a0c1b88a425dade3fff0631adec66c9bcc/opentelemetry_exporter_otlp-1.44.0-py3-none-any.whl", hash = "sha256:4a498fa8d8fd8be9e8e2d175fe5524a3fe581ccffadd8509db86526a5fb97051", size = 6727, upload-time = "2026-07-16T15:25:14.445Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.41.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-grpc"
-version = "1.41.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -3439,48 +3496,66 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/46/d75a3f8c91915f2e58f61d0a2e4ada63891e7c7a37a20ff7949ba184a6b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0.tar.gz", hash = "sha256:f704201251c6f65772b11bddea1c948000554459101bdbb0116e0a01b70592f6", size = 25754, upload-time = "2026-04-09T14:38:37.423Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/f6/b09e2e0c9f0b5750cebc6eaf31527b910821453cef40a5a0fe93550422b2/opentelemetry_exporter_otlp_proto_grpc-1.41.0-py3-none-any.whl", hash = "sha256:3a1a86bd24806ccf136ec9737dbfa4c09b069f9130ff66b0acb014f9c5255fd1", size = 20299, upload-time = "2026-04-09T14:38:17.01Z" },
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.41.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.41.0"
+version = "1.44.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.62b0"
+version = "0.65b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `ArizeExporter(SpanExporter)` that batches and ships spans to Arize Phoenix via OTLP/HTTP
- Auto-enabled when `ARIZE_API_KEY` + `ARIZE_SPACE_ID` env vars are set
- `ObservabilityIntegration` emits `llm_call` spans on every `COST_UPDATE` event with model, token counts, cost, and provider metadata
- Background worker thread handles batching/flush (non-blocking to agent pipeline)
- Graceful degradation: no-op when credentials absent, logged warnings on export failure

## Stack
Part 4 of:
1. #127 — context shortener node
2. #126 — kubernetes sandbox
3. #130 — cwpro machine-mode
4. **this PR** — Arize observability

## Configuration
| Env Var | Purpose |
|---------|---------|
| `ARIZE_API_KEY` | Arize API key (required) |
| `ARIZE_SPACE_ID` | Arize workspace ID (required) |
| `ARIZE_ENDPOINT` | Override ingest URL (default: https://app.phoenix.arize.com) |
| `ARIZE_PROJECT_NAME` | Project name in Arize (default: "clearwing") |
| `ARIZE_BATCH_SIZE` | Spans per batch (default: 20) |

## Test plan
- [x] Unit tests: OTLP format, env wiring, span emission, disabled state (7 tests)
- [ ] Integration: set env vars and run a sourcehunt to verify spans appear in Arize dashboard