### PR TITLE
Fix proof-flow evidence logical_id collision on degenerate corpora (CVE-2026-4600)

### DIFF
--- a/clearwing/sourcehunt/proof/models.py
+++ b/clearwing/sourcehunt/proof/models.py
@@ -205,6 +205,17 @@ class Evidence(VersionedRecord):
             "artifact_digest": self.artifact_digest,
             "observations": self.observations,
             "provenance": self.provenance.model_dump(mode="json"),
+            # Evidence supporting/contradicting different claims (or
+            # obligations) is not the same logical evidence, even when the
+            # underlying observations coincide. Without these fields, a
+            # mechanical resolver firing the same deterministic rule over the
+            # same facts for two distinct obligations produces byte-identical
+            # identity payloads and thus a colliding logical_id — which the
+            # append-only ProofGraph rejects. This is reachable whenever many
+            # candidates converge on the same handful of facts (e.g. a single
+            # minified JS bundle).
+            "supports": list(self.supports),
+            "contradicts": list(self.contradicts),
         }
 
 

--- a/clearwing/sourcehunt/proof/resolvers.py
+++ b/clearwing/sourcehunt/proof/resolvers.py
@@ -1200,10 +1200,16 @@ def apply_resolution(
 ) -> Obligation:
     """Persist a resolver result and update the authoritative obligation."""
 
+    # Defensive: two resolutions may legitimately carry evidence/claims that
+    # reduce to the same append-only logical_id (identical rule over identical
+    # facts). Re-adding one raises in ProofGraph, which would otherwise abort
+    # the whole run instead of the single action. Reuse the existing record.
     for evidence in resolution.evidence:
-        graph.add_evidence(evidence)
+        if evidence.logical_id not in graph.evidence:
+            graph.add_evidence(evidence)
     for claim in resolution.claims:
-        graph.add_claim(claim)
+        if claim.logical_id not in graph.claims:
+            graph.add_claim(claim)
     for derivation in resolution.derivations:
         store.append(derivation)
     supporting = (

--- a/tests/test_sourcehunt_proof_investigation.py
+++ b/tests/test_sourcehunt_proof_investigation.py
@@ -814,3 +814,98 @@ async def test_exploration_can_only_emit_evidence_cited_candidates() -> None:
     assert candidates[0].experimental
     assert candidates[0].generator == "bounded-exploratory-lane"
     assert candidates[0].fact_ids == [packet["facts"][0]["id"]]
+
+
+def _sentinel_candidate(source_symbol: str, sentinel_fact_id: str) -> Candidate:
+    """A candidate whose only cited fact is one shared sentinel use.
+
+    Models the degenerate corpus (e.g. a single minified JS bundle) where many
+    distinct candidates converge on the same handful of facts. The candidates
+    differ (here by source symbol, part of the candidate identity) but resolve
+    off the identical fact.
+    """
+
+    return Candidate(
+        snapshot_id="snapshot-1",
+        title=f"sentinel candidate for {source_symbol}",
+        invariant_families=["representation_domain_safety"],
+        suspected_mechanism="reserved_value_collides_with_live_value",
+        source_symbols=[source_symbol],
+        state_sinks=["storage"],
+        generator="test",
+        fact_ids=[sentinel_fact_id],
+    )
+
+
+def _sentinel_obligation(candidate: Candidate) -> Obligation:
+    return Obligation(
+        snapshot_id="snapshot-1",
+        candidate_id=candidate.logical_id,
+        proof_plan_id="representation-domain-v1",
+        predicate="reserved_sentinel_established",
+    )
+
+
+def test_evidence_identity_distinguishes_supported_claims() -> None:
+    """Evidence supporting different claims must not collide.
+
+    Two mechanical resolutions firing the same deterministic rule over the
+    same fact — the jsrsasign / minified-bundle case for CVE-2026-4600 —
+    previously produced byte-identical Evidence identity payloads and thus a
+    colliding logical_id, which the append-only ProofGraph rejected.
+    """
+
+    sentinel = _fact("sentinel_use", 225, expression="var sentinel = 0xFFFF;")
+    first = _sentinel_candidate("alpha", sentinel.id)
+    second = _sentinel_candidate("beta", sentinel.id)
+    assert first.logical_id != second.logical_id
+
+    resolver = MechanicalResolver()
+    completeness = _completeness()
+    first_resolution = resolver.resolve(
+        first, _sentinel_obligation(first), [sentinel], completeness
+    )
+    second_resolution = resolver.resolve(
+        second, _sentinel_obligation(second), [sentinel], completeness
+    )
+    assert first_resolution is not None and second_resolution is not None
+
+    first_evidence = first_resolution.evidence[0]
+    second_evidence = second_resolution.evidence[0]
+    # Same kind, facts, and provenance...
+    assert first_evidence.kind == second_evidence.kind
+    assert first_evidence.observations == second_evidence.observations
+    # ...but distinct claims supported, so distinct logical evidence.
+    assert first_evidence.supports != second_evidence.supports
+    assert first_evidence.logical_id != second_evidence.logical_id
+
+
+def test_apply_resolution_tolerates_duplicate_evidence(tmp_path) -> None:
+    """A genuinely identical second resolution must not abort the run.
+
+    Even with distinct identities as the primary fix, apply_resolution stays
+    idempotent: re-applying the same resolution reuses the stored records
+    instead of raising out of the whole proof flow.
+    """
+
+    store = ProofStore(tmp_path / "session")
+    graph = ProofGraph(store, "snapshot-1")
+    sentinel = _fact("sentinel_use", 225, expression="var sentinel = 0xFFFF;")
+    candidate = _sentinel_candidate("shared candidate", sentinel.id)
+    graph.add_candidate(candidate)
+    obligation = _sentinel_obligation(candidate)
+    graph.add_obligation(obligation)
+
+    resolution = MechanicalResolver().resolve(
+        candidate, obligation, [sentinel], _completeness()
+    )
+    assert resolution is not None
+
+    apply_resolution(graph, store, obligation, resolution)
+    # Re-applying the identical resolution used to raise
+    # "Evidence ... already exists; append a successor revision instead".
+    apply_resolution(graph, store, obligation, resolution)
+
+    evidence_id = resolution.evidence[0].logical_id
+    assert evidence_id in graph.evidence
+    assert graph.obligations[obligation.logical_id].status == ObligationStatus.PROVEN


### PR DESCRIPTION
## Problem

Running the **proof flow** against **CVE-2026-4600** (jsrsasign) aborts with:

```
ERROR: Evidence evidencel-2c2c1cb37effa428 already exists; append a successor revision instead
```

### Root cause

Every `VersionedRecord` derives its `logical_id` by hashing an *identity payload*. For `Evidence` (`models.py`) that payload was only:

```python
{ "kind", "artifact_digest", "observations", "provenance" }
```

The **mechanical** obligation resolver (`resolvers.py::_resolution`) builds evidence from the matching facts, with a **constant** provenance (`producer="mechanical-obligation-resolver"`, no command / context packet) and observations keyed on `fact.id`. So when two *different* obligations (from two different candidates) resolve off the **same fact** via the **same deterministic rule**, all four identity fields are byte-identical → identical `logical_id`.

The append-only `ProofGraph._add` treats a repeat `logical_id` as "you must be revising" and raises. That raise is swallowed on the falsifier path (`engine.py:580`) but **not** on the resolver path — `apply_resolution` at `engine.py:856` is unguarded, so the `ValueError` propagates out of `arun()` and kills the whole run.

### Why it only surfaced now

Prior proof-flow targets were C (jq, etc.): multi-file trees where facts live at distinct ids/locations, so distinct obligations produce distinct evidence. jsrsasign's entire source is effectively **one minified line** (`jsrsasign-all-min.js`), so ~200 candidates converge on the same handful of `sentinel_use` facts — the first corpus degenerate enough for two mechanical resolutions to be *literally* identical evidence.

Confirmed from the run dir (`results/cve-2026-4600/sh-cbad7381/`): the colliding evidence's observations all cite `fact-d09dfc9df70fa9ae` at `jsrsasign-all-min.js:225`, kind `static_sentinel_definition`, constant mechanical provenance. Two obligations (`obligationl-f69a6adac865f0c2` and a sibling) claim it.

## Fix

1. **Widen `Evidence.identity_payload`** to include `supports` / `contradicts`. Evidence supporting different claims/obligations is genuinely *different* logical evidence, so it earns a distinct `logical_id`. (`Claim` identity already carries the candidate `subject` + obligation `scope`, so the supported claim ids differ per obligation.)
2. **Make `apply_resolution` idempotent** as a defensive net: if an evidence/claim `logical_id` is already in the graph, reuse it instead of re-adding — a genuine duplicate can never again abort a whole run.

## Tests

Two synchronous regression tests in `test_sourcehunt_proof_investigation.py` reproducing the jsrsasign scenario (two candidates, same shared fact):
- `test_evidence_identity_distinguishes_supported_claims` — same kind/observations, distinct supported claims ⇒ distinct evidence `logical_id`.
- `test_apply_resolution_tolerates_duplicate_evidence` — re-applying an identical resolution no longer raises.

## Verification

- New tests pass; `ruff` clean on all changed files.
- The 4 affected proof test files show an **identical** failure set with and without this change (13 pre-existing failures + my 2 new passes). The pre-existing failures are `@pytest.mark.asyncio` tests skipped because `pytest-asyncio` isn't active in this venv — environmental, unrelated to this change.

## Branch naming

Named `fix/proof-hunt-eval-patches` (not CVE-specific) intentionally — a landing spot for further proof-flow eval fixes surfaced by other CVEs.
