### PR TITLE
Fix sourcehunt preprocessor losing cloned tree to GC

### DIFF
--- a/clearwing/analysis/source_analyzer.py
+++ b/clearwing/analysis/source_analyzer.py
@@ -505,35 +505,69 @@ class SourceAnalyzer:
         if max_file_size is not None:
             self.MAX_FILE_SIZE = max_file_size
 
+    _COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
     def clone(self, git_url: str, branch: str = "main") -> str:
         """Clone a git repository to a temporary directory.
 
-        Args:
-            git_url: Git repository URL.
-            branch: Branch to clone.
-
-        Returns:
-            Path to the cloned repository.
+        ``branch`` accepts a branch name, tag name, OR a full 40-char commit
+        SHA. Branches/tags take the fast ``git clone --depth 1 --branch``
+        path. A full SHA triggers a blobless full-history clone followed by
+        ``git checkout <sha>`` — ``--depth 1 --branch`` does not accept SHAs.
         """
         self._temp_dir = tempfile.TemporaryDirectory(prefix="clearwing-src-")
         clone_path = self._temp_dir.name
-        try:
+
+        if self._COMMIT_SHA_RE.match(branch):
+            # Same shape as evaluations/cve-2026-27775.sh.
             subprocess.run(
-                ["git", "clone", "--depth", "1", "--branch", branch, git_url, clone_path],
+                [
+                    "git",
+                    "clone",
+                    "--filter=blob:none",
+                    "--no-checkout",
+                    git_url,
+                    clone_path,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", clone_path, "checkout", branch],
                 capture_output=True,
                 text=True,
                 timeout=120,
                 check=True,
             )
-        except subprocess.CalledProcessError:
-            # Try without --branch (default branch)
-            subprocess.run(
-                ["git", "clone", "--depth", "1", git_url, clone_path],
-                capture_output=True,
-                text=True,
-                timeout=120,
-                check=True,
-            )
+        else:
+            try:
+                subprocess.run(
+                    [
+                        "git",
+                        "clone",
+                        "--depth",
+                        "1",
+                        "--branch",
+                        branch,
+                        git_url,
+                        clone_path,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                    check=True,
+                )
+            except subprocess.CalledProcessError:
+                # Try without --branch (default branch)
+                subprocess.run(
+                    ["git", "clone", "--depth", "1", git_url, clone_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                    check=True,
+                )
         self.repo_path = clone_path
         return clone_path
 

--- a/clearwing/analysis/source_analyzer.py
+++ b/clearwing/analysis/source_analyzer.py
@@ -505,69 +505,35 @@ class SourceAnalyzer:
         if max_file_size is not None:
             self.MAX_FILE_SIZE = max_file_size
 
-    _COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
-
     def clone(self, git_url: str, branch: str = "main") -> str:
         """Clone a git repository to a temporary directory.
 
-        ``branch`` accepts a branch name, tag name, OR a full 40-char commit
-        SHA. Branches/tags take the fast ``git clone --depth 1 --branch``
-        path. A full SHA triggers a blobless full-history clone followed by
-        ``git checkout <sha>`` — ``--depth 1 --branch`` does not accept SHAs.
+        Args:
+            git_url: Git repository URL.
+            branch: Branch to clone.
+
+        Returns:
+            Path to the cloned repository.
         """
         self._temp_dir = tempfile.TemporaryDirectory(prefix="clearwing-src-")
         clone_path = self._temp_dir.name
-
-        if self._COMMIT_SHA_RE.match(branch):
-            # Same shape as evaluations/cve-2026-27775.sh.
+        try:
             subprocess.run(
-                [
-                    "git",
-                    "clone",
-                    "--filter=blob:none",
-                    "--no-checkout",
-                    git_url,
-                    clone_path,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=300,
-                check=True,
-            )
-            subprocess.run(
-                ["git", "-C", clone_path, "checkout", branch],
+                ["git", "clone", "--depth", "1", "--branch", branch, git_url, clone_path],
                 capture_output=True,
                 text=True,
                 timeout=120,
                 check=True,
             )
-        else:
-            try:
-                subprocess.run(
-                    [
-                        "git",
-                        "clone",
-                        "--depth",
-                        "1",
-                        "--branch",
-                        branch,
-                        git_url,
-                        clone_path,
-                    ],
-                    capture_output=True,
-                    text=True,
-                    timeout=120,
-                    check=True,
-                )
-            except subprocess.CalledProcessError:
-                # Try without --branch (default branch)
-                subprocess.run(
-                    ["git", "clone", "--depth", "1", git_url, clone_path],
-                    capture_output=True,
-                    text=True,
-                    timeout=120,
-                    check=True,
-                )
+        except subprocess.CalledProcessError:
+            # Try without --branch (default branch)
+            subprocess.run(
+                ["git", "clone", "--depth", "1", git_url, clone_path],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=True,
+            )
         self.repo_path = clone_path
         return clone_path
 

--- a/clearwing/analysis/source_analyzer.py
+++ b/clearwing/analysis/source_analyzer.py
@@ -517,23 +517,38 @@ class SourceAnalyzer:
         """
         self._temp_dir = tempfile.TemporaryDirectory(prefix="clearwing-src-")
         clone_path = self._temp_dir.name
-        try:
+        if re.fullmatch(r"[0-9a-f]{40}", branch):
             subprocess.run(
-                ["git", "clone", "--depth", "1", "--branch", branch, git_url, clone_path],
+                ["git", "clone", "--filter=blob:none", "--no-checkout", git_url, clone_path],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", clone_path, "checkout", branch],
                 capture_output=True,
                 text=True,
                 timeout=120,
                 check=True,
             )
-        except subprocess.CalledProcessError:
-            # Try without --branch (default branch)
-            subprocess.run(
-                ["git", "clone", "--depth", "1", git_url, clone_path],
-                capture_output=True,
-                text=True,
-                timeout=120,
-                check=True,
-            )
+        else:
+            try:
+                subprocess.run(
+                    ["git", "clone", "--depth", "1", "--branch", branch, git_url, clone_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                    check=True,
+                )
+            except subprocess.CalledProcessError:
+                subprocess.run(
+                    ["git", "clone", "--depth", "1", git_url, clone_path],
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                    check=True,
+                )
         self.repo_path = clone_path
         return clone_path
 

--- a/clearwing/sourcehunt/config.py
+++ b/clearwing/sourcehunt/config.py
@@ -17,7 +17,7 @@ class TargetConfig:
     """Where to find the code to hunt."""
 
     repo_url: str
-    branch: str = "main"  # branch name, tag, OR full 40-char commit SHA
+    branch: str = "main"
     local_path: str | None = None
     depth: str = "standard"  # quick | standard | deep
 

--- a/clearwing/sourcehunt/config.py
+++ b/clearwing/sourcehunt/config.py
@@ -17,7 +17,7 @@ class TargetConfig:
     """Where to find the code to hunt."""
 
     repo_url: str
-    branch: str = "main"
+    branch: str = "main"  # branch name, tag, OR full 40-char commit SHA
     local_path: str | None = None
     depth: str = "standard"  # quick | standard | deep
 

--- a/clearwing/sourcehunt/preprocessor.py
+++ b/clearwing/sourcehunt/preprocessor.py
@@ -257,11 +257,6 @@ class Preprocessor:
         self.max_imports_by_files = max_imports_by_files
         self.respect_gitignore = respect_gitignore
         self._analyzer: SourceAnalyzer | None = None
-        # Strong reference to the cloner analyzer. The cloner owns the
-        # TemporaryDirectory that holds the freshly cloned tree; if it goes out
-        # of scope, Python's tempfile machinery deletes the directory during
-        # GC and the subsequent file walk finds nothing. Keeping it alive on
-        # `self` ties the tempdir's lifetime to the Preprocessor instance.
         self._cloner: SourceAnalyzer | None = None
 
     def run(self) -> PreprocessResult:
@@ -550,8 +545,6 @@ class Preprocessor:
 
     def cleanup(self) -> None:
         """Clean up the cloned repo (if we cloned one)."""
-        # The cloner owns the TemporaryDirectory when we cloned; the analyzer
-        # bound after `_clone_or_use_local` does not. Clean both to be safe.
         for holder in (self._cloner, self._analyzer):
             if holder is None:
                 continue
@@ -569,11 +562,6 @@ class Preprocessor:
 
         # Heuristic: looks like a git URL?
         if self._is_git_url(self.repo_url):
-            # Store the cloner on `self._cloner` (not `self._analyzer`) so the
-            # reference survives when `run()` rebinds `self._analyzer` to a
-            # fresh analyzer configured with the target repo_path. Otherwise
-            # the cloner is GC'd, its TemporaryDirectory finalizer runs, and
-            # the freshly cloned tree is deleted before we walk it.
             self._cloner = SourceAnalyzer()
             return self._cloner.clone(self.repo_url, branch=self.branch)
 

--- a/clearwing/sourcehunt/preprocessor.py
+++ b/clearwing/sourcehunt/preprocessor.py
@@ -257,6 +257,12 @@ class Preprocessor:
         self.max_imports_by_files = max_imports_by_files
         self.respect_gitignore = respect_gitignore
         self._analyzer: SourceAnalyzer | None = None
+        # Strong reference to the cloner analyzer. The cloner owns the
+        # TemporaryDirectory that holds the freshly cloned tree; if it goes out
+        # of scope, Python's tempfile machinery deletes the directory during
+        # GC and the subsequent file walk finds nothing. Keeping it alive on
+        # `self` ties the tempdir's lifetime to the Preprocessor instance.
+        self._cloner: SourceAnalyzer | None = None
 
     def run(self) -> PreprocessResult:
         """Execute the full preprocess pipeline. See class docstring."""
@@ -544,9 +550,13 @@ class Preprocessor:
 
     def cleanup(self) -> None:
         """Clean up the cloned repo (if we cloned one)."""
-        if self._analyzer is not None:
+        # The cloner owns the TemporaryDirectory when we cloned; the analyzer
+        # bound after `_clone_or_use_local` does not. Clean both to be safe.
+        for holder in (self._cloner, self._analyzer):
+            if holder is None:
+                continue
             try:
-                self._analyzer.cleanup()
+                holder.cleanup()
             except Exception:
                 logger.debug("Preprocessor cleanup failed", exc_info=True)
 
@@ -559,8 +569,13 @@ class Preprocessor:
 
         # Heuristic: looks like a git URL?
         if self._is_git_url(self.repo_url):
-            self._analyzer = SourceAnalyzer()
-            return self._analyzer.clone(self.repo_url, branch=self.branch)
+            # Store the cloner on `self._cloner` (not `self._analyzer`) so the
+            # reference survives when `run()` rebinds `self._analyzer` to a
+            # fresh analyzer configured with the target repo_path. Otherwise
+            # the cloner is GC'd, its TemporaryDirectory finalizer runs, and
+            # the freshly cloned tree is deleted before we walk it.
+            self._cloner = SourceAnalyzer()
+            return self._cloner.clone(self.repo_url, branch=self.branch)
 
         # Otherwise treat repo_url as a local path
         if os.path.isdir(self.repo_url):

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1288,10 +1288,6 @@ def _handle_machine(descriptor: int) -> int:
     channel = MachineChannel(descriptor, "sourcehunt")
     try:
         request, routing = channel.read_start()
-        # Surface the raw request on stderr so bridge misconfigs (wrong
-        # subsystem paths, missing repo_url, unexpected branch defaults)
-        # show up in `kubectl logs`. Do NOT print `routing` — it carries
-        # the provider API key.
         print(f"sourcehunt machine-fd request: {request!r}", file=sys.stderr)
         parsed = _machine_request(request)
         install_runtime_routing(routing)

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -2,7 +2,6 @@
 
 import argparse
 import asyncio
-import json
 import logging
 import os
 import sys
@@ -1286,23 +1285,14 @@ def _handle_machine(descriptor: int) -> int:
     from ...sourcehunt.runner import SourceHuntRunner
     from ..machine import MachineChannel
 
-    log = logging.getLogger("clearwing.sourcehunt.machine")
-
     channel = MachineChannel(descriptor, "sourcehunt")
     try:
         request, routing = channel.read_start()
-        # Log the raw request payload before validation. Bridge callers land
-        # here with mystery misconfigurations (wrong subsystem paths, missing
-        # repo_url, unexpected branch defaults); dumping the wire format
-        # makes those obvious in `kubectl logs` / bridge stderr. Do NOT log
-        # `routing` — it carries the provider API key.
-        try:
-            log.info(
-                "sourcehunt machine-fd request: %s",
-                json.dumps(request, sort_keys=True, default=str),
-            )
-        except Exception:
-            log.info("sourcehunt machine-fd request (repr): %r", request)
+        # Surface the raw request on stderr so bridge misconfigs (wrong
+        # subsystem paths, missing repo_url, unexpected branch defaults)
+        # show up in `kubectl logs`. Do NOT print `routing` — it carries
+        # the provider API key.
+        print(f"sourcehunt machine-fd request: {request!r}", file=sys.stderr)
         parsed = _machine_request(request)
         install_runtime_routing(routing)
         provider_manager = ProviderManager.from_config(routing)

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -2,6 +2,7 @@
 
 import argparse
 import asyncio
+import json
 import logging
 import os
 import sys
@@ -1285,9 +1286,23 @@ def _handle_machine(descriptor: int) -> int:
     from ...sourcehunt.runner import SourceHuntRunner
     from ..machine import MachineChannel
 
+    log = logging.getLogger("clearwing.sourcehunt.machine")
+
     channel = MachineChannel(descriptor, "sourcehunt")
     try:
         request, routing = channel.read_start()
+        # Log the raw request payload before validation. Bridge callers land
+        # here with mystery misconfigurations (wrong subsystem paths, missing
+        # repo_url, unexpected branch defaults); dumping the wire format
+        # makes those obvious in `kubectl logs` / bridge stderr. Do NOT log
+        # `routing` — it carries the provider API key.
+        try:
+            log.info(
+                "sourcehunt machine-fd request: %s",
+                json.dumps(request, sort_keys=True, default=str),
+            )
+        except Exception:
+            log.info("sourcehunt machine-fd request (repr): %r", request)
         parsed = _machine_request(request)
         install_runtime_routing(routing)
         provider_manager = ProviderManager.from_config(routing)

--- a/tests/test_sourcehunt_preprocessor.py
+++ b/tests/test_sourcehunt_preprocessor.py
@@ -328,47 +328,8 @@ class TestPreprocessorClonePath:
 
         assert result.file_targets, (
             "file_targets is empty — the clone tempdir was GC'd before "
-            "the file walk ran (Bug 1)."
+            "the file walk ran."
         )
         assert any(
             ft.get("path") == "pkg/mod.py" for ft in result.file_targets
         ), f"expected pkg/mod.py in file_targets, got {[ft.get('path') for ft in result.file_targets]}"
-
-    def test_branch_accepts_commit_sha(self, tmp_path):
-        """A full 40-char SHA in `branch` triggers full-clone + checkout.
-
-        Fast shallow ``git clone --depth 1 --branch <ref>`` does not accept
-        commit SHAs. When ``branch`` looks like a full SHA, the cloner
-        switches to a blobless full clone followed by ``git checkout <sha>``.
-        """
-        src_repo = tmp_path / "src.git"
-        first_sha = _init_git_repo(
-            src_repo, {"only_v1.py": "V = 1\n"}
-        )
-        # Second commit adds a file. If we pin to first_sha we must not
-        # see this file.
-        (src_repo / "only_v2.py").write_text("V = 2\n")
-        subprocess.run(
-            ["git", "-C", str(src_repo), "add", "only_v2.py"],
-            check=True,
-            capture_output=True,
-        )
-        subprocess.run(
-            ["git", "-C", str(src_repo), "commit", "-m", "add v2"],
-            check=True,
-            capture_output=True,
-        )
-        assert len(first_sha) == 40
-
-        p = Preprocessor(repo_url=str(src_repo), branch=first_sha)
-        try:
-            result = p.run()
-        finally:
-            p.cleanup()
-
-        paths = {ft.get("path") for ft in result.file_targets}
-        assert "only_v1.py" in paths
-        assert "only_v2.py" not in paths, (
-            f"branch={first_sha[:8]} should pin to first commit; "
-            f"saw {paths}"
-        )

--- a/tests/test_sourcehunt_preprocessor.py
+++ b/tests/test_sourcehunt_preprocessor.py
@@ -7,6 +7,7 @@ semgrep_findings, fuzz_corpora) are present and default to None/empty.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -274,3 +275,100 @@ class TestIsGitUrl:
 
     def test_local_path_not_git(self):
         assert not Preprocessor._is_git_url("/tmp/some/dir")
+
+
+def _init_git_repo(path: Path, files: dict[str, str]) -> str:
+    """Init a git repo with the given files, return HEAD SHA."""
+    path.mkdir(parents=True, exist_ok=True)
+    for rel, content in files.items():
+        target = path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    run = lambda *args: subprocess.run(  # noqa: E731
+        ["git", "-C", str(path), *args], check=True, capture_output=True
+    )
+    run("init", "-b", "main")
+    run("config", "user.email", "test@example.com")
+    run("config", "user.name", "test")
+    run("add", ".")
+    run("commit", "-m", "initial")
+    result = subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+class TestPreprocessorClonePath:
+    """Regression tests for the git-clone code path.
+
+    These tests hit the real ``git clone`` machinery against a local bare-ish
+    repo (URL ending in ``.git`` so ``_is_git_url`` treats it as a URL).
+    """
+
+    def test_clone_survives_analyzer_rebind(self, tmp_path):
+        """Regression: Preprocessor.run() must not lose the cloned tree.
+
+        Before the GC-safe cloner ref, ``_clone_or_use_local`` stashed the
+        cloner on ``self._analyzer`` which ``run()`` then rebound, dropping
+        the only strong reference to the cloner's ``TemporaryDirectory``.
+        Python GC finalized the tempdir and the subsequent file walk saw an
+        empty tree — producing zero ``file_targets``.
+        """
+        src_repo = tmp_path / "src.git"
+        _init_git_repo(src_repo, {"pkg/mod.py": "def f():\n    return 1\n"})
+
+        p = Preprocessor(repo_url=str(src_repo), branch="main")
+        try:
+            result = p.run()
+        finally:
+            p.cleanup()
+
+        assert result.file_targets, (
+            "file_targets is empty — the clone tempdir was GC'd before "
+            "the file walk ran (Bug 1)."
+        )
+        assert any(
+            ft.get("path") == "pkg/mod.py" for ft in result.file_targets
+        ), f"expected pkg/mod.py in file_targets, got {[ft.get('path') for ft in result.file_targets]}"
+
+    def test_branch_accepts_commit_sha(self, tmp_path):
+        """A full 40-char SHA in `branch` triggers full-clone + checkout.
+
+        Fast shallow ``git clone --depth 1 --branch <ref>`` does not accept
+        commit SHAs. When ``branch`` looks like a full SHA, the cloner
+        switches to a blobless full clone followed by ``git checkout <sha>``.
+        """
+        src_repo = tmp_path / "src.git"
+        first_sha = _init_git_repo(
+            src_repo, {"only_v1.py": "V = 1\n"}
+        )
+        # Second commit adds a file. If we pin to first_sha we must not
+        # see this file.
+        (src_repo / "only_v2.py").write_text("V = 2\n")
+        subprocess.run(
+            ["git", "-C", str(src_repo), "add", "only_v2.py"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(src_repo), "commit", "-m", "add v2"],
+            check=True,
+            capture_output=True,
+        )
+        assert len(first_sha) == 40
+
+        p = Preprocessor(repo_url=str(src_repo), branch=first_sha)
+        try:
+            result = p.run()
+        finally:
+            p.cleanup()
+
+        paths = {ft.get("path") for ft in result.file_targets}
+        assert "only_v1.py" in paths
+        assert "only_v2.py" not in paths, (
+            f"branch={first_sha[:8]} should pin to first commit; "
+            f"saw {paths}"
+        )


### PR DESCRIPTION
## Summary
- **Bug fix:** `Preprocessor._clone_or_use_local` stashed the cloner `SourceAnalyzer` on `self._analyzer`, which `Preprocessor.run()` then rebinds to a fresh analyzer. The old cloner refcount hit zero, its `tempfile.TemporaryDirectory` finalizer ran, and the freshly cloned tree was `rmtree`'d before the file walk hit it — so any git-URL sourcehunt target produced zero `file_targets`. Fix binds the cloner to `self._cloner` so its lifetime tracks the `Preprocessor`.
- **Feature:** `SourceAnalyzer.clone()` accepts a full 40-char commit SHA in `branch` (cwpro bridge sends these). `git clone --depth 1 --branch <ref>` rejects SHAs, so a SHA branch triggers a blobless full clone + `git checkout <sha>`; names keep the fast shallow-clone path.
- **Chore:** Print the raw machine-fd sourcehunt request on stderr (routing redacted — it holds the provider key) so bridge misconfigurations surface in `kubectl logs`.

## Test plan
- [x] `python -m pytest tests/test_sourcehunt_preprocessor.py::TestPreprocessorClonePath -v` — `test_clone_survives_analyzer_rebind` walks a real local git repo through the git-URL code path and asserts `file_targets` is populated.
- [ ] Rerun the cwpro-bridge sourcehunt request that just came in against gitea @ `f6e2ca4388a531c4a5996fc8043c38f1cf57897f` and confirm the vulnerable-commit tree is scanned.