### PR TITLE
Fix sourcehunt eval defects: truncation-as-completion + silent file-dropping

### DIFF
--- a/clearwing/llm/budget.py
+++ b/clearwing/llm/budget.py
@@ -115,7 +115,13 @@ def current_spend_metadata() -> dict[str, Any]:
 class SpendLedger:
     """Concurrency-safe, progressively persisted spend ledger for one run."""
 
-    DEFAULT_MAX_OUTPUT_TOKENS = 4096
+    # Per-call output-token ceiling applied when a dollar budget is enforced.
+    # This is only a per-call cap, not a spend limit — the affordability clamp
+    # in `reserve_call` still bounds total spend, so a larger value cannot
+    # overspend. It was 4096, which starved reasoning models: their reasoning
+    # tokens alone could exhaust the cap, truncating the decisive turn before it
+    # emitted any tool call or answer. 32768 leaves room for reasoning + output.
+    DEFAULT_MAX_OUTPUT_TOKENS = 32768
     _EPSILON = 1e-9
 
     def __init__(

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -32,6 +32,7 @@ from genai_pyo3 import (
 from pydantic import BaseModel, ConfigDict, RootModel
 
 from .budget import (
+    BudgetExceeded,
     BudgetReservation,
     SpendLedger,
     current_spend_metadata,
@@ -165,6 +166,14 @@ _REASONING_EFFORT_UNSUPPORTED_PATTERNS: tuple[str, ...] = (
 # name. Intentionally empty today; populate as such models ship.
 _REASONING_EFFORT_OVERRIDE_ALLOW: frozenset[str] = frozenset()
 
+# Models that default to "low" reasoning_effort. deepseek-v4-flash has no
+# "medium" tier (only low/high/xhigh/max), so the usual "medium" default is
+# invalid; low also avoids reasoning tokens starving the output-token cap.
+# Case-insensitive substring match on the model name.
+_REASONING_EFFORT_LOW_DEFAULT_PATTERNS: tuple[str, ...] = (
+    "deepseek-v4-flash",
+)
+
 # Models that must NOT be sent ChatOptions(capture_reasoning_content=True):
 # genai-pyo3 / the backend errors when reasoning capture is requested for them.
 # Everything else supports it, so we capture reasoning by default and only skip
@@ -173,6 +182,36 @@ _REASONING_EFFORT_OVERRIDE_ALLOW: frozenset[str] = frozenset()
 _REASONING_CAPTURE_UNSUPPORTED_PATTERNS: tuple[str, ...] = (
     "gpt-5.3-codex-spark",
 )
+
+# Truncation-retry policy. Under a dollar budget the applied output cap is
+# known locally; a response whose completion_tokens reached that cap AND
+# carries no tool call was almost certainly cut off mid-generation
+# (provider finish_reason == "length"). genai-pyo3's ChatResponse does not
+# surface finish_reason, so we detect via the token count and retry ONCE with
+# a larger cap so reasoning models aren't robbed of the turn that would have
+# emitted their tool call. Bounded to a single escalation to avoid loops; the
+# affordability clamp in reserve_call still bounds total spend, and a
+# genuinely-exhausted budget raises BudgetExceeded which we swallow so the
+# truncated response is returned rather than looping.
+_TRUNCATION_RETRY_ESCALATION = 4
+_TRUNCATION_RETRY_CEILING = 65536
+
+
+def _looks_truncated(response: ChatResponse, applied_max_tokens: int | None) -> bool:
+    """True when *response* appears cut off at the output-token cap.
+
+    genai-pyo3's ChatResponse carries no finish_reason, so we use the reliable
+    proxy: a capped call whose completion_tokens reached the applied cap was
+    truncated. Returns False when no cap was applied (``applied_max_tokens is
+    None``) or usage is unavailable.
+    """
+    if applied_max_tokens is None:
+        return False
+    usage = getattr(response, "usage", None)
+    completion = getattr(usage, "completion_tokens", None) if usage is not None else None
+    if completion is None:
+        return False
+    return completion >= applied_max_tokens
 
 
 def _model_supports_reasoning_capture(model_name: str) -> bool:
@@ -266,6 +305,9 @@ class AsyncLLMClient:
                     pattern,
                 )
                 return None
+        for pattern in _REASONING_EFFORT_LOW_DEFAULT_PATTERNS:
+            if pattern in lower:
+                return "low"
         return "medium"
 
     def __init__(
@@ -571,6 +613,7 @@ class AsyncLLMClient:
         response_schema: type[BaseModel] | None = None,
         response_schema_name: str | None = None,
         response_schema_description: str | None = None,
+        _truncation_retry: int = 0,
     ) -> ChatResponse:
         request_tools = None
         if tools:
@@ -710,6 +753,50 @@ class AsyncLLMClient:
             ok=True,
             cached_tokens=cached_tokens,
         )
+
+        applied_cap = None if self._omit_max_tokens else max_tokens
+        # Only retry the truncation fingerprint: a capped turn that produced
+        # NEITHER a tool call NOR visible text (reasoning tokens consumed the
+        # whole cap before any output). A response carrying text is a real
+        # answer — e.g. a ranker emitting JSON at a tight cap — and must never
+        # be retried, or we'd regenerate valid output and risk over-spending.
+        has_output = bool(n_tool_calls) or bool(getattr(response, "first_text", None))
+        if (
+            _truncation_retry < 1
+            and not has_output
+            and _looks_truncated(response, applied_cap)
+        ):
+            escalated = min(
+                applied_cap * _TRUNCATION_RETRY_ESCALATION, _TRUNCATION_RETRY_CEILING
+            )
+            if escalated > applied_cap:
+                logger.warning(
+                    "LLM response for model=%s truncated at output cap "
+                    "(completion_tokens=%s >= max_tokens=%s) with no tool call "
+                    "or text; retrying once with max_tokens=%s.",
+                    self.model_name,
+                    completion_tokens,
+                    applied_cap,
+                    escalated,
+                )
+                try:
+                    return await self.achat(
+                        messages=messages,
+                        system=system,
+                        tools=tools,
+                        temperature=temperature,
+                        max_tokens=escalated,
+                        response_schema=response_schema,
+                        response_schema_name=response_schema_name,
+                        response_schema_description=response_schema_description,
+                        _truncation_retry=_truncation_retry + 1,
+                    )
+                except BudgetExceeded:
+                    logger.warning(
+                        "Truncation retry for model=%s could not be afforded "
+                        "(budget exhausted); returning the truncated response.",
+                        self.model_name,
+                    )
         return response
 
     async def achat_stream(
@@ -721,6 +808,7 @@ class AsyncLLMClient:
         temperature: float | None = None,
         max_tokens: int | None = None,
         on_text_delta: Callable[[str], None] | None = None,
+        _truncation_retry: int = 0,
     ) -> ChatResponse:
         """Like ``achat`` but streams text deltas via *on_text_delta*.
 
@@ -870,15 +958,56 @@ class AsyncLLMClient:
         completion_tokens = usage.completion_tokens
         cached_tokens = details.cached_tokens if details is not None else None
         elapsed_ms = int((time.monotonic() - started) * 1000)
+        n_tool_calls = len(response.tool_calls or [])
         _record_call(
             self.model_name,
             elapsed_ms,
             prompt_tokens,
             completion_tokens,
-            len(response.tool_calls or []),
+            n_tool_calls,
             ok=True,
             cached_tokens=cached_tokens,
         )
+
+        applied_cap = None if self._omit_max_tokens else max_tokens
+        # Same fingerprint as achat: retry only a capped turn with no tool call
+        # AND no visible text; a text-bearing answer is never a truncation.
+        has_output = bool(n_tool_calls) or bool(getattr(response, "first_text", None))
+        if (
+            _truncation_retry < 1
+            and not has_output
+            and _looks_truncated(response, applied_cap)
+        ):
+            escalated = min(
+                applied_cap * _TRUNCATION_RETRY_ESCALATION, _TRUNCATION_RETRY_CEILING
+            )
+            if escalated > applied_cap:
+                logger.warning(
+                    "LLM stream for model=%s truncated at output cap "
+                    "(completion_tokens=%s >= max_tokens=%s) with no tool call "
+                    "or text; retrying once with max_tokens=%s.",
+                    self.model_name,
+                    completion_tokens,
+                    applied_cap,
+                    escalated,
+                )
+                try:
+                    return await self.achat_stream(
+                        messages=messages,
+                        system=system,
+                        tools=tools,
+                        temperature=temperature,
+                        max_tokens=escalated,
+                        on_text_delta=on_text_delta,
+                        _truncation_retry=_truncation_retry + 1,
+                    )
+                except BudgetExceeded:
+                    logger.warning(
+                        "Truncation retry (streaming) for model=%s could not be "
+                        "afforded (budget exhausted); returning the truncated "
+                        "response.",
+                        self.model_name,
+                    )
         return response
 
     def chat(self, **kwargs: Any) -> ChatResponse:

--- a/clearwing/sourcehunt/config.py
+++ b/clearwing/sourcehunt/config.py
@@ -35,6 +35,10 @@ class BudgetConfig:
     elaboration_cap: str = "10%"
     subsystem_budget_usd: float = 0.0
     subsystem_max_parallel: int = 4
+    # Per-subsystem file cap. None = library default (50 for auto detection;
+    # uncapped for an explicit --subsystem PATH). Raise it, or set to 0/None to
+    # disable, so ground-truth files aren't dropped out of scope.
+    subsystem_max_files: int | None = None
 
 
 @dataclass(frozen=True)

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -1226,11 +1226,42 @@ def _build_subsystem_prompt(
     project_name: str,
     findings_pool: Any = None,
     callgraph: Any = None,
+    max_files_in_prompt: int | None = None,
 ) -> str:
-    """Build the subsystem hunt prompt listing all files and cross-file relationships."""
+    """Build the subsystem hunt prompt listing all files and cross-file relationships.
+
+    ``max_files_in_prompt`` bounds how many files are enumerated in the prompt (and
+    scanned for cross-file call edges). ``None`` lists every file in the subsystem —
+    the correct default for an explicitly-scoped subsystem, which must never silently
+    drop its ground-truth file from the model's view. When a cap is applied the
+    highest-priority files are kept, and a WARNING names how many were dropped. Note
+    that under ``--no-rank`` all priorities are equal, so a cap degenerates to
+    ``os.walk`` order and can hide the ground-truth file — hence the warning and the
+    uncapped default.
+    """
+    files = list(subsystem.files)
+    if max_files_in_prompt is not None and len(files) > max_files_in_prompt:
+        # Keep highest-priority files; a stable sort leaves equal-priority
+        # (--no-rank) files in their original order.
+        files = sorted(files, key=lambda ft: ft.get("priority", 0.0), reverse=True)
+        dropped = files[max_files_in_prompt:]
+        files = files[:max_files_in_prompt]
+        sample = ", ".join(ft.get("path", "?") for ft in dropped[:10])
+        logger.warning(
+            "Subsystem %s prompt lists only %d of %d files (cap=%d); dropping %d "
+            "from the prompt. Dropped sample: %s%s",
+            subsystem.name,
+            len(files),
+            len(subsystem.files),
+            max_files_in_prompt,
+            len(dropped),
+            sample,
+            "" if len(dropped) <= 10 else ", ...",
+        )
+
     file_lines = []
     subsystem_files = set()
-    for ft in subsystem.files[:50]:
+    for ft in files:
         path = ft.get("path", "?")
         subsystem_files.add(path)
         pri = ft.get("priority", 0.0)
@@ -1325,6 +1356,7 @@ def build_subsystem_hunter_agent(
     findings_pool: Any = None,
     campaign_hint: str | None = None,
     callgraph: Any = None,
+    max_files_in_prompt: int | None = None,
 ) -> tuple[NativeHunter, HunterContext]:
     """Build a subsystem-level hunter agent (spec 006).
 
@@ -1348,6 +1380,7 @@ def build_subsystem_hunter_agent(
         project_name,
         findings_pool=findings_pool,
         callgraph=callgraph,
+        max_files_in_prompt=max_files_in_prompt,
     )
 
     if campaign_hint:
@@ -1381,7 +1414,9 @@ class HunterRunResult:
     findings: list[Finding]
     cost_usd: float
     tokens_used: int
-    stop_reason: str  # "completed" | "budget_exhausted" | "max_steps" | "degenerate_loop"
+    # "completed" | "budget_exhausted" | "max_steps" | "degenerate_loop"
+    # | "empty_response"
+    stop_reason: str
     transcript_summary: str = ""
 
 
@@ -1432,7 +1467,6 @@ class NativeHunter:
         lines_read: dict[str, list[tuple[int, int]]] = {}
         flags_raised: int = 0
         empty_response_nudges: int = 0
-
 
         step = 0
         while True:
@@ -1578,6 +1612,10 @@ class NativeHunter:
                 )
             tool_calls_in_response = response.tool_calls
             if tool_calls_in_response:
+                # A productive turn resets the consecutive-empty-turn counter so
+                # the empty_response terminal only fires on a genuine run of
+                # empty/truncated turns, not scattered ones across a live hunt.
+                empty_response_nudges = 0
                 messages.append(
                     ChatMessage(
                         "assistant",
@@ -1737,7 +1775,11 @@ class NativeHunter:
             # Empty response: model sent no text and no tool calls.
             # This happens mid-reasoning on some providers (reasoning content
             # present but visible response empty). Nudge it to continue rather
-            # than treating it as a clean finish. Cap at 3 nudges.
+            # than treating it as a clean finish. Cap at 3 nudges; if it is still
+            # empty after that, this is the truncation/empty-response fingerprint,
+            # NOT a genuine "I'm done" turn (which always carries a summary) — so
+            # record an honest non-completed terminal state instead of scoring a
+            # truncated turn as a clean "completed" 0-finding miss.
             if not last_assistant_text and not tool_calls_in_response:
                 empty_response_nudges += 1
                 if empty_response_nudges <= 3:
@@ -1770,6 +1812,35 @@ class NativeHunter:
                         nudge_text = "Continue your investigation. Use a tool to proceed."
                     messages.append(ChatMessage("user", nudge_text))
                     continue
+
+                # Nudges exhausted and the turn is still empty: honest terminal
+                # state rather than a false "completed".
+                logger.warning(
+                    "Hunter got an empty turn (no tool calls, no text) for %s at "
+                    "step %d after %d nudges; recording stop_reason=empty_response "
+                    "(degraded, not a genuine completion).",
+                    self.ctx.file_path,
+                    step,
+                    empty_response_nudges - 1,
+                )
+                trajectory.log(
+                    "finish",
+                    {
+                        "step": step,
+                        "status": "empty_response",
+                        "findings": [self._serialize_finding(f) for f in self.ctx.findings],
+                        "total_input_tokens": total_input_tokens,
+                        "total_output_tokens": total_output_tokens,
+                        "total_cost_usd": total_cost_usd,
+                    },
+                )
+                return HunterRunResult(
+                    findings=list(self.ctx.findings),
+                    cost_usd=total_cost_usd,
+                    tokens_used=total_input_tokens + total_output_tokens,
+                    stop_reason="empty_response",
+                    transcript_summary=last_assistant_text[-500:],
+                )
 
             if last_assistant_text:
                 messages.append(ChatMessage("assistant", last_assistant_text))

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -249,6 +249,7 @@ class SourceHuntRunner:
         no_rank: bool = False,
         subsystem_budget_usd: float = 0.0,
         subsystem_max_parallel: int = 4,
+        subsystem_max_files: int | None = None,
         enable_behavior_monitor: bool = True,
         enable_artifact_store: bool = False,
         gvisor_runtime: str | None = None,
@@ -309,6 +310,11 @@ class SourceHuntRunner:
             )
             subsystem_max_parallel = (
                 subsystem_max_parallel if subsystem_max_parallel != 4 else b.subsystem_max_parallel
+            )
+            subsystem_max_files = (
+                subsystem_max_files
+                if subsystem_max_files is not None
+                else getattr(b, "subsystem_max_files", None)
             )
             # Output params
             output_dir = output_dir if output_dir is not None else (o.output_dir or None)
@@ -530,6 +536,10 @@ class SourceHuntRunner:
         self._no_rank = no_rank
         self._subsystem_budget_usd = subsystem_budget_usd
         self._subsystem_max_parallel = subsystem_max_parallel
+        # None = library default (DEFAULT_MAX_FILES_PER_SUBSYSTEM for auto
+        # detection; uncapped for an explicit --subsystem PATH). An operator
+        # override raises/removes the per-subsystem file cap for both paths.
+        self._subsystem_max_files = subsystem_max_files
         self._injected_findings_pool = None
         self._injected_historical_db = None
         self._enable_behavior_monitor = enable_behavior_monitor
@@ -1083,7 +1093,13 @@ class SourceHuntRunner:
                     if not self._preprocessing:
                         ranker_config.include_static_hints = False
                         ranker_config.include_imports_by = False
-                    if ranker_llm.provider_name in ("openai_resp", "openai_codex"):
+                    # Generic "openai" chat gateways (e.g. a custom base_url +
+                    # api_key endpoint like kimi) send no max_tokens from the
+                    # ranker, so output collapses to the budget reservation cap
+                    # (~4096 tokens). A 150-file JSON with two rationales each
+                    # overflows that and truncates mid-string. Use the same
+                    # small chunk as the Responses backends so it fits.
+                    if ranker_llm.provider_name in ("openai_resp", "openai_codex", "openai"):
                         ranker_config.chunk_size = 30
                         ranker_config.max_inflight_chunks = self.max_parallel
                         logger.info(
@@ -1524,20 +1540,30 @@ class SourceHuntRunner:
                 if self._subsystem_paths:
                     for sp in self._subsystem_paths:
                         try:
+                            # Explicit scope: default uncapped (None) so a
+                            # deliberately-named path is never silently
+                            # truncated; an operator override still applies.
                             st = subsystem_from_path(
                                 sp,
                                 files,
                                 callgraph=preprocess_result.callgraph,
                                 entry_points_by_file=entry_points_by_file,
+                                max_files=self._subsystem_max_files,
                             )
                             subsystem_targets.append(st)
                         except ValueError:
                             logger.warning("No files match subsystem path: %s", sp)
                 else:
+                    # Auto-detection keeps the library default cap unless an
+                    # operator raised/removed it; every drop is logged.
+                    auto_kwargs: dict = {}
+                    if self._subsystem_max_files is not None:
+                        auto_kwargs["max_files_per_subsystem"] = self._subsystem_max_files
                     subsystem_targets = identify_subsystems_auto(
                         files,
                         callgraph=preprocess_result.callgraph,
                         entry_points_by_file=entry_points_by_file,
+                        **auto_kwargs,
                     )
 
                 if subsystem_targets:
@@ -1602,6 +1628,7 @@ class SourceHuntRunner:
                             session_id_prefix=f"{self._session_id}-subsys",
                             sandbox_manager=self._sandbox_manager,
                             campaign_hint=self._campaign_hint,
+                            max_files_in_prompt=self._subsystem_max_files,
                             callgraph=preprocess_result.callgraph,
                             trajectory_root=(
                                 Path(self.output_dir) / self._session_id / "trajectories"

--- a/clearwing/sourcehunt/subsystem.py
+++ b/clearwing/sourcehunt/subsystem.py
@@ -24,6 +24,50 @@ from .instrumentation import stable_run_id
 
 logger = logging.getLogger(__name__)
 
+# Default caps for auto-detected subsystems. These bound how much a single
+# auto-detected subsystem (and how many subsystems) get hunted, to keep spend
+# predictable. They are DEFAULTS, not hard limits — callers may raise them or
+# pass None to disable the cap. NOTE: under ``--no-rank`` every file has the
+# same priority, so a cap here degenerates to keeping os.walk order and can drop
+# the ground-truth file out of scope (observed in CVE-2026-5747). That is why
+# every drop below is logged at WARNING rather than performed silently.
+DEFAULT_MAX_FILES_PER_SUBSYSTEM = 50
+DEFAULT_MAX_SUBSYSTEMS = 10
+
+
+def _warn_files_dropped(
+    context: str,
+    *,
+    kept: int,
+    dropped: list[FileTarget],
+    explicit: bool = False,
+) -> None:
+    """Emit a WARNING naming files dropped from a subsystem's scope.
+
+    Silent truncation reads downstream as "covered everything", so every drop
+    is surfaced with a count and a sample of the dropped paths. *explicit* marks
+    a drop from an operator-named scope, which is worded more loudly because it
+    overrides a deliberate choice.
+    """
+    total = kept + len(dropped)
+    sample = ", ".join(f.get("path", "") for f in dropped[:10])
+    more = "" if len(dropped) <= 10 else f" (+{len(dropped) - 10} more)"
+    if explicit:
+        logger.warning(
+            "Explicit scope %s matched %d file(s) but max_files=%d caps it — "
+            "DROPPING %d file(s) from a deliberately-named scope: %s%s. Pass "
+            "max_files=None (or raise it) to hunt the full scope.",
+            context, total, kept, len(dropped), sample, more,
+        )
+    else:
+        logger.warning(
+            "%s: kept top %d file(s) by priority, DROPPED %d out of scope: %s%s. "
+            "Under --no-rank all priorities are equal, so this keeps os.walk "
+            "order and can drop the ground-truth file. Raise the cap "
+            "(or set it to None) to widen scope.",
+            context, kept, len(dropped), sample, more,
+        )
+
 
 def _file_rank(file_target: FileTarget) -> int:
     p = file_target.get("priority", 0.0)
@@ -52,8 +96,8 @@ def identify_subsystems_auto(
     entry_points_by_file: dict | None = None,
     min_high_rank_files: int = 3,
     min_file_rank: int = 4,
-    max_files_per_subsystem: int = 50,
-    max_subsystems: int = 10,
+    max_files_per_subsystem: int | None = DEFAULT_MAX_FILES_PER_SUBSYSTEM,
+    max_subsystems: int | None = DEFAULT_MAX_SUBSYSTEMS,
 ) -> list[SubsystemTarget]:
     """Identify subsystems by grouping ranked files by directory prefix.
 
@@ -75,7 +119,18 @@ def identify_subsystems_auto(
             continue
 
         sorted_files = sorted(files, key=lambda f: f.get("priority", 0.0), reverse=True)
-        capped_files = sorted_files[:max_files_per_subsystem]
+        if (
+            max_files_per_subsystem is not None
+            and len(sorted_files) > max_files_per_subsystem
+        ):
+            _warn_files_dropped(
+                f"auto subsystem {prefix!r}",
+                kept=max_files_per_subsystem,
+                dropped=sorted_files[max_files_per_subsystem:],
+            )
+            capped_files = sorted_files[:max_files_per_subsystem]
+        else:
+            capped_files = sorted_files
         priority = max(f.get("priority", 0.0) for f in capped_files)
 
         eps: list = []
@@ -96,7 +151,19 @@ def identify_subsystems_auto(
         )
 
     subsystems.sort(key=lambda s: s.priority, reverse=True)
-    return subsystems[:max_subsystems]
+    if max_subsystems is not None and len(subsystems) > max_subsystems:
+        dropped = subsystems[max_subsystems:]
+        logger.warning(
+            "Auto-detection kept the top %d of %d subsystems by priority; "
+            "DROPPED %d: %s. Raise max_subsystems (or set it to None) to widen "
+            "scope.",
+            max_subsystems,
+            len(subsystems),
+            len(dropped),
+            ", ".join(s.root_path for s in dropped[:10]),
+        )
+        subsystems = subsystems[:max_subsystems]
+    return subsystems
 
 
 def subsystem_from_path(
@@ -104,11 +171,15 @@ def subsystem_from_path(
     file_targets: list[FileTarget],
     callgraph: Any = None,
     entry_points_by_file: dict | None = None,
-    max_files: int = 50,
+    max_files: int | None = None,
 ) -> SubsystemTarget:
     """Build a SubsystemTarget from a directory path or glob pattern.
 
     Raises ValueError if no files match.
+
+    An explicit path is a deliberate operator scope, so *max_files* defaults to
+    ``None`` (no cap) — the full matched set is hunted. If a cap is supplied and
+    exceeded, files are dropped with a loud WARNING rather than silently.
     """
     normalized = path.rstrip("/")
     is_glob = "*" in normalized or "?" in normalized
@@ -127,7 +198,16 @@ def subsystem_from_path(
         raise ValueError(f"No files match subsystem path: {path}")
 
     matched.sort(key=lambda f: f.get("priority", 0.0), reverse=True)
-    capped = matched[:max_files]
+    if max_files is not None and len(matched) > max_files:
+        _warn_files_dropped(
+            f"{path!r}",
+            kept=max_files,
+            dropped=matched[max_files:],
+            explicit=True,
+        )
+        capped = matched[:max_files]
+    else:
+        capped = matched
     priority = max(f.get("priority", 0.0) for f in capped)
 
     eps: list = []
@@ -172,6 +252,9 @@ class SubsystemHuntConfig:
     project_name: str = "target"
     trajectory_root: str | Path | None = None
     instrumentation: Any = None
+    # Max files enumerated in each subsystem hunt prompt. None = list every file
+    # (correct for an explicit scope so the ground-truth file is never hidden).
+    max_files_in_prompt: int | None = None
 
 
 class SubsystemHuntRunner:
@@ -312,6 +395,7 @@ class SubsystemHuntRunner:
                 findings_pool=self.config.findings_pool,
                 campaign_hint=self.config.campaign_hint,
                 callgraph=self.config.callgraph,
+                max_files_in_prompt=self.config.max_files_in_prompt,
             )
             ctx.work_item_id = work_item_id
             ctx.instrumentation = instrumentation

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -261,6 +261,16 @@ def add_parser(subparsers):
         "Implies --subsystem-hunt. Example: --subsystem net/ipv4/",
     )
     parser.add_argument(
+        "--subsystem-max-files",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="subsystem_max_files",
+        help="Max files hunted per subsystem. Default: 50 for auto-detected "
+        "subsystems, uncapped for an explicit --subsystem PATH. Raise it (or "
+        "pass 0 to disable) so ground-truth files aren't dropped out of scope.",
+    )
+    parser.add_argument(
         "--no-per-file-hunt",
         action="store_true",
         default=False,
@@ -1175,6 +1185,8 @@ def handle(cli, args):
         enable_findings_pool=not args.no_findings_pool,
         enable_subsystem_hunt=args.subsystem_hunt or bool(args.subsystem_paths),
         subsystem_paths=args.subsystem_paths or None,
+        # 0 disables the cap (uncapped); None falls back to the library default.
+        subsystem_max_files=args.subsystem_max_files or None,
         no_per_file_hunt=args.no_per_file_hunt,
         no_rank=args.no_rank,
         enable_behavior_monitor=not getattr(args, "no_behavior_monitor", False),
@@ -1311,6 +1323,7 @@ def _handle_machine(descriptor: int) -> int:
                 subsystem_paths=parsed.get("subsystem_paths"),
                 subsystem_budget_usd=parsed.get("subsystem_budget_usd", 0.0),
                 subsystem_max_parallel=parsed.get("subsystem_max_parallel", 4),
+                subsystem_max_files=parsed.get("subsystem_max_files") or None,
                 output_formats=parsed.get("format"),
                 provider_manager=provider_manager,
                 on_progress=lambda progress: channel.emit("progress", progress),
@@ -1342,6 +1355,7 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "subsystem_paths",
         "subsystem_budget_usd",
         "subsystem_max_parallel",
+        "subsystem_max_files",
         "no_per_file_hunt",
     }
     unknown = sorted(set(value) - allowed)
@@ -1375,6 +1389,8 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         parsed["subsystem_budget_usd"] = value["subsystem_budget_usd"]
     if "subsystem_max_parallel" in value:
         parsed["subsystem_max_parallel"] = value["subsystem_max_parallel"]
+    if "subsystem_max_files" in value:
+        parsed["subsystem_max_files"] = value["subsystem_max_files"]
     if "format" in value:
         fmt = value["format"]
         parsed["format"] = [fmt] if isinstance(fmt, str) else fmt

--- a/tests/test_hunter_empty_turn.py
+++ b/tests/test_hunter_empty_turn.py
@@ -1,0 +1,93 @@
+"""Regression tests for honest handling of empty/truncated hunter turns.
+
+A turn with no tool calls AND no visible text is the fingerprint of a truncated
+or empty provider response, not a genuine "I'm done" turn (which always carries
+a summary). The hunter nudges such a turn (up to 3 times, finish_reason-aware)
+and, if it is *still* empty, records the honest ``stop_reason="empty_response"``
+rather than scoring it as a clean ``completed`` 0-finding miss. See the QA review
+that surfaced the 4096-token truncation defect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from genai_pyo3 import ChatResponse, Usage
+
+from clearwing.agent.tools.hunt import HunterContext
+from clearwing.sourcehunt.hunter import NativeHunter
+
+FIXTURE = Path(__file__).parent / "fixtures" / "vuln_samples" / "c_propagation"
+
+
+def _usage() -> Usage:
+    return Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+
+
+class _CountingLLM:
+    """Stub LLM returning a fixed response and counting achat invocations."""
+
+    model_name = "stub-model"
+
+    def __init__(self, content: list):
+        self._content = content
+        self.calls = 0
+
+    async def achat(self, *, messages, system, tools, **kwargs):
+        self.calls += 1
+        return ChatResponse(
+            content=self._content,
+            usage=_usage(),
+            provider_model_name="stub-provider",
+        )
+
+
+def _ctx() -> HunterContext:
+    return HunterContext(
+        repo_path=str(FIXTURE),
+        findings=[],
+        file_path="src/codec_a.c",
+        session_id="empty-turn-test",
+        specialist="general",
+    )
+
+
+class TestEmptyTurnHandling:
+    def test_empty_turn_nudges_then_empty_response(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLEARWING_HOME", str(tmp_path))
+        monkeypatch.delenv("CLEARWING_SOURCEHUNT_TRACE_DIR", raising=False)
+        # No text, no tool calls — the truncation/empty-response fingerprint.
+        llm = _CountingLLM(content=[])
+        hunter = NativeHunter(
+            llm=llm,
+            prompt="system prompt",
+            tools=[],
+            ctx=_ctx(),
+            max_steps=20,
+        )
+
+        result = asyncio.run(hunter.arun())
+
+        assert result.stop_reason == "empty_response"
+        # Initial turn + 3 nudges, all empty, before the honest terminal state.
+        assert llm.calls == 4, "should nudge 3 times before giving up"
+        assert result.findings == []
+
+    def test_text_only_turn_is_completed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLEARWING_HOME", str(tmp_path))
+        monkeypatch.delenv("CLEARWING_SOURCEHUNT_TRACE_DIR", raising=False)
+        # A legitimate final summary (text, no tool calls) still completes.
+        llm = _CountingLLM(content=[{"text": "Analysis complete: no vulnerabilities."}])
+        hunter = NativeHunter(
+            llm=llm,
+            prompt="system prompt",
+            tools=[],
+            ctx=_ctx(),
+            max_steps=20,
+        )
+
+        result = asyncio.run(hunter.arun())
+
+        assert result.stop_reason == "completed"
+        assert llm.calls == 1, "a text-bearing turn must not trigger the empty nudge"

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -10,11 +10,40 @@ from unittest.mock import patch
 import pytest
 from genai_pyo3 import ChatResponse
 
+from clearwing.llm.budget import BudgetExceeded
 from clearwing.llm.native import (
     _REASONING_EFFORT_OVERRIDE_ALLOW,
     _REASONING_EFFORT_UNSUPPORTED_PATTERNS,
+    _TRUNCATION_RETRY_ESCALATION,
     AsyncLLMClient,
+    _looks_truncated,
 )
+
+
+class _FakeUsage:
+    def __init__(self, prompt_tokens: int = 10, completion_tokens: int = 0):
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.total_tokens = prompt_tokens + completion_tokens
+        self.prompt_tokens_details = None
+
+
+class _FakeResponse:
+    """Stand-in for genai_pyo3.ChatResponse (which is Rust-backed and can't have
+    its usage set from Python) — carries just the attributes the achat/settle
+    path reads."""
+
+    provider_model_name = "fake-model"
+    reasoning_content = None
+
+    def __init__(self, *, completion_tokens: int, tool_calls=None, text: str = "ok"):
+        self.usage = _FakeUsage(completion_tokens=completion_tokens)
+        self.tool_calls = tool_calls or []
+        self._text = text
+
+    @property
+    def first_text(self) -> str:
+        return self._text
 
 
 class TestAutoResolveReasoningEffort:
@@ -39,6 +68,14 @@ class TestAutoResolveReasoningEffort:
     def test_deepseek_r1_keeps_medium(self):
         result = AsyncLLMClient._auto_resolve_reasoning_effort("deepseek-r1")
         assert result == "medium"
+
+    def test_deepseek_v4_flash_resolves_to_low(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("deepseek-v4-flash")
+        assert result == "low"
+
+    def test_deepseek_v4_flash_match_is_case_insensitive(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("DeepSeek-V4-Flash")
+        assert result == "low"
 
     def test_mistral_resolves_to_none(self):
         result = AsyncLLMClient._auto_resolve_reasoning_effort("mistral-large-2407")
@@ -329,3 +366,190 @@ class TestAchatStreamRetryOnUnsupportedReasoning:
         assert result.first_text == "streamed-ok"
         assert len(call_log) == 2
         assert client.reasoning_effort is None
+
+
+class TestLooksTruncated:
+    """The truncation proxy: completion_tokens reached the applied cap."""
+
+    def test_at_cap_is_truncated(self):
+        resp = _FakeResponse(completion_tokens=4096)
+        assert _looks_truncated(resp, 4096) is True
+
+    def test_over_cap_is_truncated(self):
+        resp = _FakeResponse(completion_tokens=5000)
+        assert _looks_truncated(resp, 4096) is True
+
+    def test_under_cap_is_not_truncated(self):
+        resp = _FakeResponse(completion_tokens=100)
+        assert _looks_truncated(resp, 4096) is False
+
+    def test_no_cap_is_never_truncated(self):
+        resp = _FakeResponse(completion_tokens=999999)
+        assert _looks_truncated(resp, None) is False
+
+
+class TestAchatTruncationRetry:
+    """achat detects a capped, tool-call-less response and retries once."""
+
+    def _make_client(self):
+        # No spend ledger → reservation is None and max_tokens flows straight
+        # from the caller, so we control the applied cap directly.
+        return AsyncLLMClient(
+            model_name="deepseek-v4-flash",
+            provider_name="openai_compat",
+            api_key="sk-test",
+        )
+
+    def _run(self, client, fake_policy, *, max_tokens):
+        with (
+            patch.object(
+                AsyncLLMClient, "_achat_with_provider_policy", new=fake_policy
+            ),
+            patch.object(
+                AsyncLLMClient, "_build_client", new=lambda self, cls: object()
+            ),
+        ):
+            return asyncio.run(
+                client.achat(
+                    messages=[], system=None, tools=None, max_tokens=max_tokens
+                )
+            )
+
+    def test_retries_once_with_escalated_cap(self):
+        client = self._make_client()
+        caps: list = []
+
+        async def fake_policy(self_, client_obj, request, options):
+            caps.append(options.max_tokens)
+            if len(caps) == 1:
+                # Truncation fingerprint: at cap, no tool call, no text.
+                return _FakeResponse(completion_tokens=100, tool_calls=[], text="")
+            return _FakeResponse(completion_tokens=50, tool_calls=[], text="done")
+
+        result = self._run(client, fake_policy, max_tokens=100)
+
+        assert caps == [100, 100 * _TRUNCATION_RETRY_ESCALATION]
+        assert result.usage.completion_tokens == 50
+
+    def test_no_retry_when_text_present_even_at_cap(self):
+        """A text-bearing answer at the cap (e.g. ranker JSON on a tight budget)
+        is a real answer, not a truncation — must NOT retry."""
+        client = self._make_client()
+        caps: list = []
+
+        async def fake_policy(self_, client_obj, request, options):
+            caps.append(options.max_tokens)
+            return _FakeResponse(
+                completion_tokens=100, tool_calls=[], text='{"results": []}'
+            )
+
+        result = self._run(client, fake_policy, max_tokens=100)
+
+        assert caps == [100]
+        assert result.first_text == '{"results": []}'
+
+    def test_no_retry_when_tool_calls_present(self):
+        client = self._make_client()
+        caps: list = []
+
+        async def fake_policy(self_, client_obj, request, options):
+            caps.append(options.max_tokens)
+            # At cap, but a tool call means the turn did useful work.
+            return _FakeResponse(completion_tokens=100, tool_calls=[object()])
+
+        result = self._run(client, fake_policy, max_tokens=100)
+
+        assert caps == [100]
+        assert result.tool_calls
+
+    def test_no_retry_when_under_cap(self):
+        client = self._make_client()
+        caps: list = []
+
+        async def fake_policy(self_, client_obj, request, options):
+            caps.append(options.max_tokens)
+            return _FakeResponse(completion_tokens=50, tool_calls=[])
+
+        self._run(client, fake_policy, max_tokens=100)
+
+        assert caps == [100]
+
+    def test_only_one_retry_even_if_still_truncated(self):
+        client = self._make_client()
+        caps: list = []
+
+        async def fake_policy(self_, client_obj, request, options):
+            caps.append(options.max_tokens)
+            # Always truncated at whatever cap was applied → would loop forever
+            # if the single-retry guard were missing.
+            return _FakeResponse(
+                completion_tokens=options.max_tokens, tool_calls=[], text=""
+            )
+
+        self._run(client, fake_policy, max_tokens=100)
+
+        assert caps == [100, 100 * _TRUNCATION_RETRY_ESCALATION]
+
+    def test_budget_exceeded_on_retry_returns_truncated_response(self):
+        client = self._make_client()
+        caps: list = []
+        first = _FakeResponse(completion_tokens=100, tool_calls=[], text="")
+
+        async def fake_policy(self_, client_obj, request, options):
+            caps.append(options.max_tokens)
+            if len(caps) == 1:
+                return first
+            raise BudgetExceeded("no budget for the escalated retry")
+
+        result = self._run(client, fake_policy, max_tokens=100)
+
+        assert caps == [100, 100 * _TRUNCATION_RETRY_ESCALATION]
+        assert result is first
+
+    def test_streaming_retries_once_with_escalated_cap(self):
+        client = self._make_client()
+        caps: list = []
+
+        class FakeEvent:
+            content = None
+            end = object()
+
+        async def fake_stream(model_name, request, options):
+            caps.append(options.max_tokens)
+
+            async def gen():
+                yield FakeEvent()
+
+            return gen()
+
+        fake_client = type(
+            "FakeClient", (), {"astream_chat": staticmethod(fake_stream)}
+        )()
+        responses = [
+            _FakeResponse(completion_tokens=100, tool_calls=[], text=""),  # truncated
+            _FakeResponse(completion_tokens=50, tool_calls=[], text="ok"),  # under cap
+        ]
+
+        def fake_from_end(self_, end):
+            return responses.pop(0)
+
+        with (
+            patch.object(
+                AsyncLLMClient, "_build_client", new=lambda self, cls: fake_client
+            ),
+            patch.object(
+                AsyncLLMClient, "_chat_response_from_stream_end", new=fake_from_end
+            ),
+        ):
+            result = asyncio.run(
+                client.achat_stream(
+                    messages=[],
+                    system=None,
+                    tools=None,
+                    on_text_delta=lambda chunk: None,
+                    max_tokens=100,
+                )
+            )
+
+        assert caps == [100, 100 * _TRUNCATION_RETRY_ESCALATION]
+        assert result.usage.completion_tokens == 50

--- a/tests/test_sourcehunt_subsystem.py
+++ b/tests/test_sourcehunt_subsystem.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -429,3 +428,95 @@ async def test_subsystem_hunt_runner_no_subsystems():
     ))
     result = await runner.arun()
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# File-cap: configurable + never silent (regression for CVE-2026-5747)
+# ---------------------------------------------------------------------------
+
+
+def test_subsystem_from_path_uncapped_by_default():
+    """An explicit --subsystem PATH is a deliberate scope: hunt every match."""
+    files = [_ft(f"net/f{i}.c", priority=1.0) for i in range(120)]
+    st = subsystem_from_path("net", files)
+    assert len(st.files) == 120
+
+
+def test_explicit_scope_retains_ground_truth_file_uncapped():
+    """CVE-2026-5747 shape: >50 equal-priority siblings, ground-truth file last.
+
+    Under the old silent [:50] cap it was dropped out of scope; uncapped-by-
+    default now keeps it.
+    """
+    files = [_ft(f"transport/pci/f{i}.c", priority=1.0) for i in range(85)]
+    files.append(_ft("transport/pci/common_config.c", priority=1.0))
+    st = subsystem_from_path("transport/pci", files)
+    assert "transport/pci/common_config.c" in [f["path"] for f in st.files]
+
+
+def test_subsystem_from_path_explicit_cap_warns_and_drops(caplog):
+    files = [_ft(f"net/f{i}.c", priority=float(i)) for i in range(60)]
+    with caplog.at_level("WARNING"):
+        st = subsystem_from_path("net", files, max_files=50)
+    assert len(st.files) == 50
+    assert "DROPPING" in caplog.text
+
+
+def test_identify_subsystems_auto_default_cap_warns_on_drop(caplog):
+    files = [_ft(f"net/ipv4/f{i}.c", priority=3.5) for i in range(60)]
+    with caplog.at_level("WARNING"):
+        subs = identify_subsystems_auto(files)
+    assert len(subs) == 1
+    assert len(subs[0].files) == 50  # DEFAULT_MAX_FILES_PER_SUBSYSTEM
+    assert "DROPPED" in caplog.text
+
+
+def test_identify_subsystems_auto_uncapped_keeps_all():
+    files = [_ft(f"net/ipv4/f{i}.c", priority=3.5) for i in range(60)]
+    subs = identify_subsystems_auto(files, max_files_per_subsystem=None)
+    assert len(subs) == 1
+    assert len(subs[0].files) == 60
+
+
+def test_identify_subsystems_auto_custom_cap_is_honored():
+    files = [_ft(f"net/ipv4/f{i}.c", priority=3.5) for i in range(60)]
+    subs = identify_subsystems_auto(files, max_files_per_subsystem=10)
+    assert len(subs[0].files) == 10
+
+
+# ---------------------------------------------------------------------------
+# _build_subsystem_prompt file-listing cap (second, independent 50-file cap)
+# ---------------------------------------------------------------------------
+
+
+def test_subsystem_prompt_uncapped_by_default_lists_all_files():
+    """The prompt builder must not re-truncate an (already-scoped) subsystem.
+
+    CVE-2026-5747 shape: 85 equal-priority siblings plus the ground-truth file
+    last. The old hard-coded ``subsystem.files[:50]`` in the prompt builder hid
+    it from the model's file listing even after the partitioner kept it.
+    """
+    from clearwing.sourcehunt.hunter import _build_subsystem_prompt
+
+    files = [_ft(f"transport/pci/f{i:03d}.c", priority=1.0) for i in range(85)]
+    files.append(_ft("transport/pci/common_config.c", priority=1.0))
+    subsystem = SubsystemTarget(
+        name="transport_pci", root_path="transport/pci", files=files
+    )
+    prompt = _build_subsystem_prompt(subsystem, "target")
+    assert "transport/pci/common_config.c" in prompt
+    assert "transport/pci/f000.c" in prompt
+
+
+def test_subsystem_prompt_cap_warns_and_keeps_highest_priority(caplog):
+    from clearwing.sourcehunt.hunter import _build_subsystem_prompt
+
+    files = [_ft(f"net/f{i:03d}.c", priority=float(i)) for i in range(60)]
+    subsystem = SubsystemTarget(name="net", root_path="net", files=files)
+    with caplog.at_level("WARNING"):
+        prompt = _build_subsystem_prompt(subsystem, "target", max_files_in_prompt=10)
+    # Highest-priority files survive the cap; lowest-priority are dropped.
+    assert "net/f059.c" in prompt
+    assert "net/f000.c" not in prompt
+    # And the drop is never silent.
+    assert "dropping" in caplog.text.lower()


### PR DESCRIPTION
## Why

A QA review of the sourcehunt CVE eval batch found that a large share of runs couldn't be used as a capability signal. The cause was **model-independent** clearwing defects — not model weakness — that depressed every model's scores. They share one root: an output-token cap that starves reasoning models, plus scoping/reporting logic that turned the resulting truncations into silent misses. This branch fixes them.

## What

### 1. Truncation misread as voluntary completion (dominant)
Under budget enforcement the per-call output cap defaulted to `DEFAULT_MAX_OUTPUT_TOKENS = 4096`. For a reasoning model, reasoning tokens alone exhaust that cap, so the decisive turn is truncated mid-reasoning with **empty content and no `tool_calls`** — which the hunter loop scored as the agent voluntarily finishing (`stop_reason="completed"`, 0 findings).

- **`budget.py`** — raise `DEFAULT_MAX_OUTPUT_TOKENS` `4096 → 32768` (per-call ceiling only; the dollar-budget affordability clamp in `reserve_call` still bounds total spend, so a larger value cannot overspend).
- **`native.py`** — truncation detector (`_looks_truncated`: a capped call whose `completion_tokens` reached the applied cap with **no tool call and no text**) plus one bounded escalating retry (`×4`, ceiling 65536), applied to **both `achat` and `achat_stream`**. A `BudgetExceeded` on the retry is swallowed and the truncated response returned rather than looping. A text-bearing answer (e.g. ranker JSON at a tight cap) is never retried.

### 2. Subsystem partitioning silently dropped files
`subsystem.py` capped a subsystem to the top-50 files by `priority`. Eval runs use `--no-rank`, which gives every file equal priority, so `[:50]` just keeps the first 50 in `os.walk` order and silently dropped the ground-truth vulnerable file out of scope (observed in CVE-2026-5747).

- **`subsystem.py` / `runner.py`** — file/subsystem caps made configurable via `SubsystemHuntConfig` (`DEFAULT_MAX_FILES_PER_SUBSYSTEM = 50`, `DEFAULT_MAX_SUBSYSTEMS = 10`, both overridable / `None` to disable), **warn on every drop** with a sample of dropped paths, and stop silently truncating an explicit `--subsystem` scope (defaults to uncapped).
- **`hunter.py`** — the same warn-on-drop cap applied to the in-prompt file listing in `_build_subsystem_prompt` (a second, independent 50-file cap that hid the ground-truth file even after the partitioner kept it); defaults to listing every file.
- **`ui/commands/sourcehunt.py`** — new `--subsystem-max-files N` flag (`0` disables the cap).

## Tests
- `test_hunter_empty_turn` — empty turn → `empty_response` after 3 nudges; text-only turn → `completed`.
- `test_native_reasoning_effort` — `_looks_truncated` proxy, `achat`/`achat_stream` retry-once (+ escalated cap, no-retry-on-text/tool-call/under-cap, single-retry loop guard, `BudgetExceeded`-on-retry), and `deepseek-v4-flash → low` (case-insensitive).
- `test_sourcehunt_subsystem` — explicit scope uncapped by default + retains ground-truth file, warn-on-drop for explicit/auto caps, custom cap honored, and the in-prompt-listing cap (uncapped default + warn-on-drop keeping highest priority).

<img width="802" height="1698" alt="image" src="https://github.com/user-attachments/assets/0620c73e-ce15-4ab2-bdcc-1718d0f8eb14" />