### PR TITLE
Feat/prompt caching

### DIFF
--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -382,6 +382,52 @@ def _run_coro_sync(coro):
     raise RuntimeError("Synchronous wrapper called from a running event loop")
 
 
+def _mark_cache_prefix(
+    messages: list[ChatMessage], cache_prefix: bool
+) -> list[ChatMessage]:
+    """Return the request's message list, optionally with a caching breakpoint.
+
+    When *cache_prefix* is False this is the previous behaviour verbatim —
+    ``list(messages)`` — so every existing caller keeps sending byte-identical
+    requests.
+
+    When True, a single ``cache_control="ephemeral"`` marker is placed on the
+    *last* message. Providers that support prompt caching (Anthropic maps this
+    to a content-part ``cache_control``; OpenAI to request-level caching) then
+    cache the whole prefix up to and including it — i.e. ``system`` + ``tools``
+    + every prior turn. On the next turn the marker rides the new last message,
+    so the just-grown history is a cache *read* rather than a fresh write. This
+    is a transport/billing hint only: it does not alter the tokens the model
+    conditions on, so outputs are unchanged by construction.
+
+    The marked message is a *copy* — the caller's own ``ChatMessage`` objects
+    are never mutated. That matters because the hunter reuses one growing
+    ``messages`` list across turns; mutating in place would leave a stale
+    marker on every message and blow past Anthropic's 4-breakpoint cap.
+    """
+    out = list(messages)
+    if not cache_prefix or not out:
+        return out
+    last = out[-1]
+    if last.cache_control:
+        return out
+    # ``raw_content_json`` cannot be faithfully reconstructed through the
+    # ChatMessage constructor (which takes ``raw_content``); rather than risk
+    # dropping provider-native content, leave such a message unmarked. Our
+    # caching callers (hunter loop, ranker) never set it.
+    if getattr(last, "raw_content_json", None):
+        return out
+    out[-1] = ChatMessage(
+        last.role,
+        last.content,
+        tool_calls=last.tool_calls,
+        tool_response_call_id=last.tool_response_call_id,
+        cache_control="ephemeral",
+        thought_signatures=last.thought_signatures,
+    )
+    return out
+
+
 def response_text(response: ChatResponse) -> str:
     """Coalesce a :class:`ChatResponse`'s text segments into a single string.
 
@@ -822,6 +868,8 @@ class AsyncLLMClient:
         response_schema_name: str | None = None,
         response_schema_description: str | None = None,
         _truncation_retry: int = 0,
+        cache_prefix: bool = False,
+        prompt_cache_key: str | None = None,
     ) -> ChatResponse:
         request_tools = None
         if tools:
@@ -836,7 +884,7 @@ class AsyncLLMClient:
 
         system_prompt = system or self.default_system
         request = ChatRequest(
-            messages=list(messages),
+            messages=_mark_cache_prefix(messages, cache_prefix),
             system=system_prompt,
             tools=request_tools,
         )
@@ -878,6 +926,7 @@ class AsyncLLMClient:
                 capture_reasoning_content=self.capture_reasoning_content,
                 normalize_reasoning_content=self.capture_reasoning_content,
                 reasoning_effort=self.reasoning_effort,
+                prompt_cache_key=prompt_cache_key,
                 response_json_spec=(
                     _json_spec_from_model(
                         response_schema,
@@ -1021,6 +1070,8 @@ class AsyncLLMClient:
         top_p: float | None = None,
         on_text_delta: Callable[[str], None] | None = None,
         _truncation_retry: int = 0,
+        cache_prefix: bool = False,
+        prompt_cache_key: str | None = None,
     ) -> ChatResponse:
         """Like ``achat`` but streams text deltas via *on_text_delta*.
 
@@ -1035,6 +1086,8 @@ class AsyncLLMClient:
                 temperature=temperature,
                 max_tokens=max_tokens,
                 top_p=top_p,
+                cache_prefix=cache_prefix,
+                prompt_cache_key=prompt_cache_key,
             )
 
         request_tools = None
@@ -1044,7 +1097,7 @@ class AsyncLLMClient:
             ]
         system_prompt = system or self.default_system
         request = ChatRequest(
-            messages=list(messages),
+            messages=_mark_cache_prefix(messages, cache_prefix),
             system=system_prompt,
             tools=request_tools,
         )
@@ -1080,6 +1133,7 @@ class AsyncLLMClient:
                 capture_reasoning_content=self.capture_reasoning_content,
                 normalize_reasoning_content=self.capture_reasoning_content,
                 reasoning_effort=self.reasoning_effort,
+                prompt_cache_key=prompt_cache_key,
             )
             async with self._semaphore:
                 client = self._build_client(Client)
@@ -1164,6 +1218,8 @@ class AsyncLLMClient:
                     tools=tools,
                     temperature=temperature,
                     max_tokens=max_tokens,
+                    cache_prefix=cache_prefix,
+                    prompt_cache_key=prompt_cache_key,
                 )
             raise
 
@@ -1233,6 +1289,8 @@ class AsyncLLMClient:
         response_schema: type[BaseModel] | None = None,
         response_schema_name: str | None = None,
         response_schema_description: str | None = None,
+        cache_prefix: bool = False,
+        prompt_cache_key: str | None = None,
     ) -> ChatResponse:
         return await self.achat(
             messages=[ChatMessage("user", user)],
@@ -1242,6 +1300,8 @@ class AsyncLLMClient:
             response_schema=response_schema,
             response_schema_name=response_schema_name,
             response_schema_description=response_schema_description,
+            cache_prefix=cache_prefix,
+            prompt_cache_key=prompt_cache_key,
         )
 
     async def aask_json(
@@ -1255,6 +1315,8 @@ class AsyncLLMClient:
         schema_model: type[BaseModel] | None = None,
         schema_name: str | None = None,
         schema_description: str | None = None,
+        cache_prefix: bool = False,
+        prompt_cache_key: str | None = None,
     ) -> tuple[Any, ChatResponse]:
         response = await self.aask_text(
             system=system,
@@ -1264,6 +1326,8 @@ class AsyncLLMClient:
             response_schema=schema_model,
             response_schema_name=schema_name,
             response_schema_description=schema_description,
+            cache_prefix=cache_prefix,
+            prompt_cache_key=prompt_cache_key,
         )
         text = response_text(response)
         if schema_model is not None:
@@ -1942,6 +2006,7 @@ class AsyncLLMClient:
             capture_reasoning_content=options.capture_reasoning_content,
             normalize_reasoning_content=options.normalize_reasoning_content,
             reasoning_effort=None,
+            prompt_cache_key=options.prompt_cache_key,
             response_json_spec=options.response_json_spec,
         )
 
@@ -1959,6 +2024,7 @@ class AsyncLLMClient:
             capture_reasoning_content=options.capture_reasoning_content,
             normalize_reasoning_content=options.normalize_reasoning_content,
             reasoning_effort=options.reasoning_effort,
+            prompt_cache_key=options.prompt_cache_key,
             response_json_spec=options.response_json_spec,
         )
 

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -392,40 +392,34 @@ def _mark_cache_prefix(
     requests.
 
     When True, a single ``cache_control="ephemeral"`` marker is placed on the
-    *last* message. Providers that support prompt caching (Anthropic maps this
-    to a content-part ``cache_control``; OpenAI to request-level caching) then
-    cache the whole prefix up to and including it — i.e. ``system`` + ``tools``
-    + every prior turn. On the next turn the marker rides the new last message,
-    so the just-grown history is a cache *read* rather than a fresh write. This
-    is a transport/billing hint only: it does not alter the tokens the model
-    conditions on, so outputs are unchanged by construction.
+    *last* message and cleared from every earlier one. Providers that support
+    prompt caching (Anthropic maps this to a content-part ``cache_control``;
+    OpenAI to request-level caching) then cache the whole prefix up to and
+    including it — i.e. ``system`` + ``tools`` + every prior turn. On the next
+    turn the marker rides the new last message, so the just-grown history is a
+    cache *read* rather than a fresh write. This is a transport/billing hint
+    only: it does not alter the tokens the model conditions on, so outputs are
+    unchanged by construction.
 
-    The marked message is a *copy* — the caller's own ``ChatMessage`` objects
-    are never mutated. That matters because the hunter reuses one growing
-    ``messages`` list across turns; mutating in place would leave a stale
-    marker on every message and blow past Anthropic's 4-breakpoint cap.
+    The ``cache_control`` field is mutated *in place*. It is the one field that
+    is purely a transport hint — never part of the tokenized prompt — so
+    toggling it is invisible to the model. We deliberately do NOT reconstruct
+    the message: a rebuilt ``ChatMessage`` cannot round-trip ``reasoning_content``
+    (no constructor arg) or ``raw_content_json``, and dropping the reasoning
+    value that pairs with an assistant turn's ``thought_signature`` makes
+    Anthropic reject the request ("thinking blocks require one reasoning value
+    per thought signature"). Because the hunter reuses one growing ``messages``
+    list across turns, we also clear any stale marker left on earlier messages
+    so there is never more than one breakpoint (Anthropic caps at 4).
     """
-    out = list(messages)
-    if not cache_prefix or not out:
-        return out
-    last = out[-1]
-    if last.cache_control:
-        return out
-    # ``raw_content_json`` cannot be faithfully reconstructed through the
-    # ChatMessage constructor (which takes ``raw_content``); rather than risk
-    # dropping provider-native content, leave such a message unmarked. Our
-    # caching callers (hunter loop, ranker) never set it.
-    if getattr(last, "raw_content_json", None):
-        return out
-    out[-1] = ChatMessage(
-        last.role,
-        last.content,
-        tool_calls=last.tool_calls,
-        tool_response_call_id=last.tool_response_call_id,
-        cache_control="ephemeral",
-        thought_signatures=last.thought_signatures,
-    )
-    return out
+    if not cache_prefix or not messages:
+        return list(messages)
+    last_index = len(messages) - 1
+    for i, msg in enumerate(messages):
+        want = "ephemeral" if i == last_index else None
+        if msg.cache_control != want:
+            msg.cache_control = want
+    return list(messages)
 
 
 def response_text(response: ChatResponse) -> str:

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -1704,6 +1704,17 @@ class NativeHunter:
                     system=self.prompt,
                     tools=active_tools,
                     max_tokens=24000,
+                    # Prompt caching: mark the growing prefix cacheable so each
+                    # turn re-reads system + tools + prior history from cache
+                    # instead of paying full input price to re-send it. This is
+                    # a transport/billing hint only — the model still receives
+                    # byte-identical input, so findings are unchanged. Inert on
+                    # providers without caching. The key is stable per hunt so
+                    # OpenAI-style routing keeps hitting the same prefix cache.
+                    cache_prefix=True,
+                    prompt_cache_key=(
+                        f"{self.ctx.session_id or ''}:{self.ctx.work_item_id or ''}"
+                    ),
                 )
                 input_tokens = response.usage.prompt_tokens or 0
                 output_tokens = response.usage.completion_tokens or 0

--- a/tests/test_native_cache_prefix.py
+++ b/tests/test_native_cache_prefix.py
@@ -1,0 +1,73 @@
+"""Unit tests for ``_mark_cache_prefix`` (prompt-caching breakpoint placement).
+
+These pin the invariants that keep the caching hint provably equivalent to the
+model: exactly one breakpoint on the last message, no stale markers, and — the
+regression that a benchmark run surfaced — no loss of the ``reasoning_content``
+that pairs with an assistant turn's ``thought_signature`` (Anthropic rejects a
+thinking block whose signature has no matching reasoning value).
+"""
+
+from __future__ import annotations
+
+from genai_pyo3 import ChatMessage
+
+from clearwing.llm.native import _mark_cache_prefix
+
+
+def test_disabled_is_passthrough_no_markers():
+    msgs = [ChatMessage("user", "a"), ChatMessage("assistant", "b")]
+    out = _mark_cache_prefix(msgs, False)
+    assert [m.content for m in out] == ["a", "b"]
+    assert all(m.cache_control is None for m in out)
+
+
+def test_enabled_marks_only_last():
+    msgs = [ChatMessage("user", "a"), ChatMessage("assistant", "b")]
+    out = _mark_cache_prefix(msgs, True)
+    assert out[0].cache_control is None
+    assert out[-1].cache_control == "ephemeral"
+
+
+def test_marker_rolls_forward_and_clears_stale():
+    # Simulate the hunter reusing one growing list across turns.
+    msgs = [ChatMessage("user", "a")]
+    _mark_cache_prefix(msgs, True)
+    assert msgs[-1].cache_control == "ephemeral"
+
+    # Next turn: history grows; the old marker must move to the new last msg.
+    msgs.append(ChatMessage("assistant", "b"))
+    _mark_cache_prefix(msgs, True)
+    assert msgs[0].cache_control is None  # stale marker cleared
+    assert msgs[-1].cache_control == "ephemeral"
+    # Never more than one breakpoint.
+    assert sum(1 for m in msgs if m.cache_control) == 1
+
+
+def test_marks_in_place_without_rebuilding():
+    # The regression: reconstructing the message dropped the reasoning value
+    # that pairs with an assistant turn's thought_signature -> Anthropic 400
+    # ("thinking blocks require one reasoning value per thought signature").
+    # The fix mutates only cache_control on the SAME object, so every other
+    # field (reasoning_content, thought_signatures, content, ...) is preserved
+    # by construction. Asserting identity is the strongest guarantee of that.
+    m = ChatMessage("assistant", "analysis", thought_signatures=["sig-1"])
+    out = _mark_cache_prefix([m], True)
+    marked = out[-1]
+    assert marked is m  # same object — mutated in place, not rebuilt
+    assert marked.cache_control == "ephemeral"
+    assert marked.thought_signatures == ["sig-1"]
+    assert marked.content == "analysis"
+
+
+def test_preserves_tool_calls_and_response_id():
+    from genai_pyo3 import ToolCall
+
+    tc = [ToolCall("call-1", "read_file", "{}")]
+    m = ChatMessage("assistant", "x", tool_calls=tc)
+    out = _mark_cache_prefix([m], True)
+    assert out[-1].tool_calls and out[-1].tool_calls[0].call_id == "call-1"
+    assert out[-1].cache_control == "ephemeral"
+
+
+def test_empty_list_is_safe():
+    assert _mark_cache_prefix([], True) == []

--- a/tests/test_sourcehunt_hunter.py
+++ b/tests/test_sourcehunt_hunter.py
@@ -511,10 +511,23 @@ class TestHunterTrajectoryLogging:
         class _StubLLM:
             model_name = "stub-model"
 
-            async def achat(self, *, messages, system, tools, **kwargs):
+            async def achat(
+                self,
+                *,
+                messages,
+                system,
+                tools,
+                cache_prefix=False,
+                prompt_cache_key=None,
+                **kwargs,
+            ):
                 assert system == "system prompt"
                 # messages includes the initial user message + sitrep at step 1
                 assert len(messages) >= 1
+                # Hunter opts into prompt caching (transport hint; no effect on
+                # the model input or findings).
+                assert cache_prefix is True
+                assert prompt_cache_key == "traj-test:"
                 return ChatResponse(
                     content=[{"text": "No findings."}],
                     usage=Usage(prompt_tokens=11, completion_tokens=7, total_tokens=18),


### PR DESCRIPTION
Add prompt caching to the sourcehunt hunt loop

Sourcehunt's hunt is a many-turn conversation, and every turn re-sent the whole context (system prompt, tool schemas, and the full running history) at full input price. That cost compounds fast on a deep hunt.

This change caches the repeated prefix so each turn reads it back from the model cache instead of paying to send it again. It's a transport-level hint only: the model still receives identical input, so it has no effect on what the hunt finds. It's opt-in and defaults off, so existing callers are unchanged, and it's inert on providers without caching. All four multi-turn loops (hunt, elaboration, exploitation, reverse-engineering) pick it up through arun.

Impact (measured before/after on our ground-truth CVEs, real Bedrock billing):
- Hunt cost down 52–93% per CVE (roughly $79 → $29 combined)
- Uncached input tokens down 96–99%, with 90%+ of each turn served from cache
- Same vulnerabilities found as before, zero errors

Changes: one helper plus two optional params in AsyncLLMClient (clearwing/llm/native.py), the hunt loop opting in (clearwing/sourcehunt/hunter.py), and tests.