### PR TITLE
Add OrcaRouter provider preset to the setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The challenge:  Produce similar results as Glasswing - using models everyone has
 
 **Autonomous vulnerability scanner and source-code hunter.** Built on
 `genai-pyo3`, a native Rust-backed LLM runtime speaking every major
-provider (Anthropic, OpenAI, OpenRouter, Ollama, LM Studio, Together,
-Groq, DeepSeek, MiniMax, Gemini, any OpenAI-compatible endpoint).
+provider (Anthropic, OpenAI, OpenRouter, OrcaRouter, Ollama, LM Studio,
+Together, Groq, DeepSeek, MiniMax, Gemini, any OpenAI-compatible endpoint).
 
 Clearwing is a dual-mode offensive-security tool:
 
@@ -87,11 +87,16 @@ Or skip the wizard and configure directly:
 # Anthropic direct
 export ANTHROPIC_API_KEY=sk-ant-...
 
-# Or any OpenAI-compatible endpoint — OpenRouter, Ollama, LM Studio,
-# vLLM, Together, Groq, DeepSeek, OpenAI:
+# Or any OpenAI-compatible endpoint — OpenRouter, OrcaRouter, Ollama,
+# LM Studio, vLLM, Together, Groq, DeepSeek, OpenAI:
 export CLEARWING_BASE_URL=https://openrouter.ai/api/v1
 export CLEARWING_API_KEY=sk-or-...
 export CLEARWING_MODEL=anthropic/claude-opus-4
+
+# OrcaRouter (OpenAI-compatible gateway, keys start with sk-orca-):
+export CLEARWING_BASE_URL=https://api.orcarouter.ai/v1
+export CLEARWING_API_KEY=sk-orca-...
+export CLEARWING_MODEL=anthropic/claude-sonnet-4.6
 ```
 
 See [`docs/providers.md`](docs/providers.md) for provider-specific

--- a/clearwing/providers/catalog.py
+++ b/clearwing/providers/catalog.py
@@ -137,6 +137,25 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         provider_adapter="openai",
     ),
     ProviderPreset(
+        key="orcarouter",
+        display_name="OrcaRouter",
+        description="OpenAI-compatible multi-model gateway. One key, 190+ models — "
+        "Claude / GPT / Gemini / DeepSeek / Qwen via "
+        "`anthropic/...` / `openai/...` model names.",
+        docs_url="https://www.orcarouter.ai",
+        default_base_url="https://api.orcarouter.ai/v1",
+        default_model="anthropic/claude-sonnet-4.6",
+        api_key_env_var="ORCAROUTER_API_KEY",
+        alt_models=(
+            "orcarouter/auto",
+            "openai/gpt-5.5",
+            "openai/gpt-4o",
+            "deepseek/deepseek-chat",
+            "anthropic/claude-haiku-4.5",
+        ),
+        provider_adapter="openai",
+    ),
+    ProviderPreset(
         key="ollama",
         display_name="Ollama (local, native adapter)",
         description="Local models, free, no API key. Uses the native "

--- a/clearwing/ui/commands/setup.py
+++ b/clearwing/ui/commands/setup.py
@@ -48,7 +48,7 @@ def add_parser(subparsers):
         metavar="KEY",
         help=(
             "Skip the menu and configure this provider directly "
-            "(e.g. openrouter, ollama, lmstudio, anthropic, openai, "
+            "(e.g. openrouter, orcarouter, ollama, lmstudio, anthropic, openai, "
             "openai-oauth, together, groq, deepseek, fireworks, custom)"
         ),
     )

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -423,6 +423,7 @@ extras (`pip install -e '.[web]'`).
 ```bash
 clearwing setup                              # menu-driven
 clearwing setup --provider openrouter        # skip the menu
+clearwing setup --provider orcarouter        # OrcaRouter preset
 clearwing setup --provider ollama --no-test  # skip the live test
 clearwing setup -y                           # skip confirmations
 clearwing init                               # alias — same wizard
@@ -430,8 +431,8 @@ clearwing init                               # alias — same wizard
 
 Walks through LLM backend selection, credential entry, optional
 connection testing, and persistence to `~/.clearwing/config.yaml`.
-The menu currently lists Anthropic, OpenRouter, Ollama, LM Studio,
-OpenAI, Together, Groq, Fireworks, DeepSeek, and a "custom
+The menu currently lists Anthropic, OpenRouter, OrcaRouter, Ollama,
+LM Studio, OpenAI, Together, Groq, Fireworks, DeepSeek, and a "custom
 OpenAI-compatible endpoint" catch-all. Safe to re-run — existing
 config is shown and can be overwritten.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -18,7 +18,7 @@ Backends covered below:
 - **OpenAI (Responses API)** — GPT-5.x / o-series via `/v1/responses`
   (`openai_resp` adapter). Required for GPT-5.x and o-series.
 - **OpenAI OAuth (ChatGPT)** — Plus/Pro login via Codex backend (`openai_codex`).
-- **OpenRouter, Together, Groq, Fireworks, DeepSeek, LM Studio, vLLM, custom** —
+- **OpenRouter, OrcaRouter, Together, Groq, Fireworks, DeepSeek, LM Studio, vLLM, custom** —
   anything that speaks `/v1/chat/completions` (`openai` adapter).
 - **MiniMax** — M2.7 / M2.5 via the Anthropic-compatible endpoint
   (`anthropic` adapter at `api.minimax.io/anthropic`).
@@ -211,6 +211,57 @@ at runtime — don't commit real secrets to the YAML. Clearwing's
 `config set-provider` quotes the literal for you; if you edit the
 YAML by hand, quote it so the shell doesn't eat the `$`.
 
+## OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible
+multi-model gateway. Model names follow the same `provider/model`
+convention as OpenRouter: `anthropic/claude-sonnet-4.6`,
+`openai/gpt-5.5`, `deepseek/deepseek-chat`, or `orcarouter/auto` for
+automatic routing. Grab a key from the [OrcaRouter site](https://www.orcarouter.ai)
+(keys start with `sk-orca-`) and point Clearwing at it with the
+`openai` adapter — it is a preset in the setup wizard, so you can also
+just run `clearwing setup --provider orcarouter`.
+
+### Per-command (flags)
+
+```bash
+clearwing sourcehunt /path/to/repo \
+    --base-url https://api.orcarouter.ai/v1 \
+    --api-key "$ORCAROUTER_API_KEY" \
+    --model anthropic/claude-sonnet-4.6
+```
+
+### Per-session (env vars)
+
+```bash
+export CLEARWING_BASE_URL=https://api.orcarouter.ai/v1
+export CLEARWING_API_KEY=$ORCAROUTER_API_KEY
+export CLEARWING_MODEL=anthropic/claude-sonnet-4.6
+
+# Every command picks this up automatically
+clearwing interactive
+clearwing sourcehunt /path/to/repo
+```
+
+### Persistent (config file)
+
+```bash
+clearwing config --set-provider \
+    base_url=https://api.orcarouter.ai/v1 \
+    api_key='${ORCAROUTER_API_KEY}' \
+    model=anthropic/claude-sonnet-4.6
+```
+
+This writes `~/.clearwing/config.yaml` with:
+
+```yaml
+provider:
+  base_url: https://api.orcarouter.ai/v1
+  api_key: ${ORCAROUTER_API_KEY}
+  model: anthropic/claude-sonnet-4.6
+  adapter: openai
+```
+
 ## Ollama
 
 Ollama is spoken natively by `rust-genai` via its own adapter — no
@@ -363,13 +414,16 @@ providers:
   openrouter:
     base_url: https://openrouter.ai/api/v1
     api_key: ${OPENROUTER_API_KEY}
+  orcarouter:
+    base_url: https://api.orcarouter.ai/v1
+    api_key: ${ORCAROUTER_API_KEY}
   local_qwen:
     base_url: http://localhost:11434/v1
     api_key: ollama
 
 routes:
   default: openrouter
-  ranker: openrouter
+  ranker: orcarouter
   hunter: openrouter
   verifier: local_qwen              # Independence via cross-provider
   sourcehunt_exploit: openrouter
@@ -405,6 +459,7 @@ Models that definitely work (tested during Phase 5):
 
 - Anthropic: `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`
 - OpenRouter: any `anthropic/*`, `openai/gpt-4o`, `openai/gpt-4o-mini`
+- OrcaRouter: any `anthropic/*`, `openai/gpt-5.5`, `openai/gpt-4o`, `deepseek/deepseek-chat`, `orcarouter/auto`
 - OpenAI direct: `gpt-4o`, `gpt-4o-mini`, `o1-preview` (no tool calling on o1)
 - Ollama (qwen2.5-coder:32b, llama3.3:70b with function-calling prompts)
 - Groq: `llama-3.3-70b-versatile`, `qwen-2.5-coder-32b`

--- a/tests/test_setup_and_doctor.py
+++ b/tests/test_setup_and_doctor.py
@@ -77,6 +77,15 @@ class TestProviderCatalog:
         assert preset_by_key("openai_oauth").key == "openai-oauth"
         assert preset_by_key("unknown-provider") is None
 
+    def test_orcarouter_preset(self):
+        preset = preset_by_key("orcarouter")
+        assert preset is not None
+        assert preset.display_name == "OrcaRouter"
+        assert preset.default_base_url == "https://api.orcarouter.ai/v1"
+        assert preset.api_key_env_var == "ORCAROUTER_API_KEY"
+        assert preset.provider_adapter == "openai"
+        assert preset.is_openai_compat
+
     def test_openai_oauth_preset_is_not_openai_compat(self):
         preset = preset_by_key("openai-oauth")
         assert preset is not None


### PR DESCRIPTION
Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `clearwing/providers/catalog.py`: registers the `orcarouter` preset in `PROVIDER_PRESETS` (base URL `https://api.orcarouter.ai/v1`, auth via `ORCAROUTER_API_KEY`, `openai` adapter, `anthropic/claude-sonnet-4.6` default model).
- `clearwing/ui/commands/setup.py`: documents `clearwing setup --provider orcarouter` in the `--provider` help text.
- `tests/test_setup_and_doctor.py`: unit test covering the preset's key fields and the OpenAI-compat flag.
- `docs/providers.md`, `README.md`, `docs/cli.md`: provider docs alongside the existing OpenRouter coverage.

## Why a named provider rather than the generic OpenAI-compatible endpoint

This mirrors how OpenRouter is already wired in this repo. A named preset carries the correct base URL, adapter, env-var name and model defaults, so the setup wizard, doctor and docs stay consistent for users instead of relying on the custom-endpoint escape hatch.

## How to use it

1. Get an API key at https://www.orcarouter.ai (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. Run `clearwing setup --provider orcarouter`, pick "OrcaRouter" from the wizard menu, or set `CLEARWING_BASE_URL=https://api.orcarouter.ai/v1` with a model such as `anthropic/claude-sonnet-4.6`.

## Verification

- Unit tests: `tests/test_setup_and_doctor.py` 34 passed, `tests/test_providers.py` + `tests/test_providers_env.py` 63 passed (97 total). `ruff check` reports no new errors versus main.
- Live API: exercised the real library path with a real key. `preset_by_key("orcarouter")` resolves correctly, and `AsyncLLMClient` (provider `openai`, base URL `https://api.orcarouter.ai/v1`) returns 200 `PONG` for both `anthropic/claude-sonnet-4.6` and `orcarouter/auto`. An invalid key fails loudly with HTTP 401.
- Ran locally: `python -m pytest tests/test_setup_and_doctor.py tests/test_providers.py tests/test_providers_env.py` and the L3 live script against the real API.
