### PR TITLE
Add Kimi Code provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The challenge:  Produce similar results as Glasswing - using models everyone has
 **Autonomous vulnerability scanner and source-code hunter.** Built on
 `genai-pyo3`, a native Rust-backed LLM runtime speaking every major
 provider (Anthropic, OpenAI, OpenRouter, OrcaRouter, Ollama, LM Studio,
-Together, Groq, DeepSeek, MiniMax, Gemini, any OpenAI-compatible endpoint).
+Together, Groq, DeepSeek, Kimi, MiniMax, Gemini, any OpenAI-compatible endpoint).
 
 Clearwing is a dual-mode offensive-security tool:
 
@@ -92,7 +92,7 @@ Or skip the wizard and configure directly:
 export ANTHROPIC_API_KEY=sk-ant-...
 
 # Or any OpenAI-compatible endpoint — OpenRouter, OrcaRouter, Ollama,
-# LM Studio, vLLM, Together, Groq, DeepSeek, OpenAI:
+# LM Studio, vLLM, Together, Groq, DeepSeek, Kimi, OpenAI:
 export CLEARWING_BASE_URL=https://openrouter.ai/api/v1
 export CLEARWING_API_KEY=sk-or-...
 export CLEARWING_MODEL=anthropic/claude-opus-4
@@ -319,7 +319,7 @@ Deep dives live in [`docs/`](docs/):
 |---|---|
 | [`docs/index.md`](docs/index.md) | Landing page + table of contents |
 | [`docs/quickstart.md`](docs/quickstart.md) | Full install + first run walkthrough |
-| [`docs/providers.md`](docs/providers.md) | OpenRouter / Ollama / LM Studio / vLLM / Together / Groq recipes, per-task routing, env-var precedence |
+| [`docs/providers.md`](docs/providers.md) | OpenRouter / Ollama / LM Studio / vLLM / Kimi / Together / Groq recipes, per-task routing, env-var precedence |
 | [`docs/architecture.md`](docs/architecture.md) | Both pipelines, substrate, capability gating, tool layout |
 | [`docs/cli.md`](docs/cli.md) | Every subcommand flag, grouped by workflow |
 | [`docs/api.md`](docs/api.md) | API reference (mkdocstrings autogen) |

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -287,6 +287,16 @@ _REASONING_EFFORT_LOW_DEFAULT_PATTERNS: tuple[str, ...] = (
     "qwen3.8",
 )
 
+# Per-model defaults for APIs whose accepted reasoning-effort values do not
+# include Clearwing's generic "medium" default. Kimi K3 accepts low/high/max.
+_REASONING_EFFORT_MODEL_DEFAULTS: dict[str, str | None] = {
+    "kimi-k3": "high",
+    "k3": "high",
+    "k3-256k": "high",
+    "kimi-for-coding": None,
+    "kimi-for-coding-highspeed": None,
+}
+
 # Models that must NOT be sent ChatOptions(capture_reasoning_content=True):
 # genai-pyo3 / the backend errors when reasoning capture is requested for them.
 # Everything else supports it, so we capture reasoning by default and only skip
@@ -517,12 +527,15 @@ class AsyncLLMClient:
     def _auto_resolve_reasoning_effort(model_name: str) -> str | None:
         """Return the effective reasoning_effort for *model_name*.
 
-        Returns ``None`` (i.e. omit the parameter) when the model name matches
-        a pattern in :data:`_REASONING_EFFORT_UNSUPPORTED_PATTERNS` and is not
+        Uses a model-specific supported value when one is registered. Returns
+        ``None`` (i.e. omit the parameter) when the model name matches a
+        pattern in :data:`_REASONING_EFFORT_UNSUPPORTED_PATTERNS` and is not
         in :data:`_REASONING_EFFORT_OVERRIDE_ALLOW`. Returns ``"medium"``
         otherwise — the previous default for all callers.
         """
         lower = model_name.lower()
+        if lower in _REASONING_EFFORT_MODEL_DEFAULTS:
+            return _REASONING_EFFORT_MODEL_DEFAULTS[lower]
         if lower in _REASONING_EFFORT_OVERRIDE_ALLOW:
             return "medium"
         for pattern in _REASONING_EFFORT_UNSUPPORTED_PATTERNS:

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -293,6 +293,8 @@ _REASONING_EFFORT_MODEL_DEFAULTS: dict[str, str | None] = {
     "kimi-k3": "high",
     "k3": "high",
     "k3-256k": "high",
+    "kimi-k2.7-code": None,
+    "kimi-k2.7-code-highspeed": None,
     "kimi-for-coding": None,
     "kimi-for-coding-highspeed": None,
 }

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -288,13 +288,11 @@ _REASONING_EFFORT_LOW_DEFAULT_PATTERNS: tuple[str, ...] = (
 )
 
 # Per-model defaults for APIs whose accepted reasoning-effort values do not
-# include Clearwing's generic "medium" default. Kimi K3 accepts low/high/max.
+# include Clearwing's generic "medium" default. Kimi Code K3 accepts
+# low/high/max.
 _REASONING_EFFORT_MODEL_DEFAULTS: dict[str, str | None] = {
-    "kimi-k3": "high",
     "k3": "high",
     "k3-256k": "high",
-    "kimi-k2.7-code": None,
-    "kimi-k2.7-code-highspeed": None,
     "kimi-for-coding": None,
     "kimi-for-coding-highspeed": None,
 }

--- a/clearwing/providers/catalog.py
+++ b/clearwing/providers/catalog.py
@@ -319,22 +319,6 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         provider_adapter="openai",
     ),
     ProviderPreset(
-        key="kimi",
-        display_name="Kimi Open Platform (pay-as-you-go)",
-        description="Kimi K3 and Kimi coding models via Moonshot AI's global "
-        "OpenAI-compatible API. Uses Open Platform billing and keys.",
-        docs_url="https://platform.kimi.ai/console/api-keys",
-        default_base_url="https://api.moonshot.ai/v1",
-        default_model="kimi-k3",
-        api_key_env_var="MOONSHOT_API_KEY",
-        alt_models=(
-            "kimi-k2.7-code",
-            "kimi-k2.7-code-highspeed",
-            "kimi-k2.6",
-        ),
-        provider_adapter="openai",
-    ),
-    ProviderPreset(
         key="kimi-code",
         display_name="Kimi Code (membership)",
         description="Kimi coding models using a Kimi Code membership key from "

--- a/clearwing/providers/catalog.py
+++ b/clearwing/providers/catalog.py
@@ -319,6 +319,38 @@ PROVIDER_PRESETS: tuple[ProviderPreset, ...] = (
         provider_adapter="openai",
     ),
     ProviderPreset(
+        key="kimi",
+        display_name="Kimi Open Platform (pay-as-you-go)",
+        description="Kimi K3 and Kimi coding models via Moonshot AI's global "
+        "OpenAI-compatible API. Uses Open Platform billing and keys.",
+        docs_url="https://platform.kimi.ai/console/api-keys",
+        default_base_url="https://api.moonshot.ai/v1",
+        default_model="kimi-k3",
+        api_key_env_var="MOONSHOT_API_KEY",
+        alt_models=(
+            "kimi-k2.7-code",
+            "kimi-k2.7-code-highspeed",
+            "kimi-k2.6",
+        ),
+        provider_adapter="openai",
+    ),
+    ProviderPreset(
+        key="kimi-code",
+        display_name="Kimi Code (membership)",
+        description="Kimi coding models using a Kimi Code membership key from "
+        "kimi.com/code. Separate from Open Platform keys and billing.",
+        docs_url="https://www.kimi.com/code/console",
+        default_base_url="https://api.kimi.com/coding/v1",
+        default_model="k3-256k",
+        api_key_env_var="KIMI_CODE_API_KEY",
+        alt_models=(
+            "k3",
+            "kimi-for-coding",
+            "kimi-for-coding-highspeed",
+        ),
+        provider_adapter="openai",
+    ),
+    ProviderPreset(
         key="minimax",
         display_name="MiniMax",
         description="MiniMax M2.7 / M2.5 reasoning models via the Anthropic-compatible "
@@ -366,6 +398,7 @@ def preset_by_key(key: str) -> ProviderPreset | None:
         "anthropic_oauth": "anthropic-oauth",
         "claude-code": "anthropic-oauth",
         "claude_code": "anthropic-oauth",
+        "kimi_code": "kimi-code",
     }
     key_lower = aliases.get(key_lower, key_lower)
     for preset in PROVIDER_PRESETS:

--- a/clearwing/providers/env.py
+++ b/clearwing/providers/env.py
@@ -117,7 +117,7 @@ class LLMEndpoint:
         """True if this endpoint talks the OpenAI-compatible dialect.
 
         That covers: OpenRouter, Ollama (via /v1), LM Studio, vLLM,
-        Together, Fireworks, Groq, Anyscale, SiliconFlow, DeepSeek,
+        Together, Fireworks, Groq, Anyscale, SiliconFlow, DeepSeek, Kimi,
         and OpenAI direct. ChatGPT/Codex OAuth is not OpenAI-compatible.
         """
         return self.provider == "openai_compat"
@@ -534,6 +534,10 @@ def _default_openai_compat_model(base_url: str) -> str:
         return "gpt-4o"
     if "api.deepseek.com" in host:
         return "deepseek-chat"
+    if "api.moonshot.ai" in host:
+        return "kimi-k3"
+    if "api.kimi.com" in host and "/coding" in host:
+        return "k3-256k"
     # Catch-all
     return "default"
 

--- a/clearwing/providers/env.py
+++ b/clearwing/providers/env.py
@@ -534,8 +534,6 @@ def _default_openai_compat_model(base_url: str) -> str:
         return "gpt-4o"
     if "api.deepseek.com" in host:
         return "deepseek-chat"
-    if "api.moonshot.ai" in host:
-        return "kimi-k3"
     if "api.kimi.com" in host and "/coding" in host:
         return "k3-256k"
     # Catch-all

--- a/clearwing/ui/commands/setup.py
+++ b/clearwing/ui/commands/setup.py
@@ -49,7 +49,7 @@ def add_parser(subparsers):
         help=(
             "Skip the menu and configure this provider directly "
             "(e.g. openrouter, orcarouter, ollama, lmstudio, anthropic, openai, "
-            "openai-oauth, together, groq, deepseek, kimi, kimi-code, "
+            "openai-oauth, together, groq, deepseek, kimi-code, "
             "fireworks, custom)"
         ),
     )
@@ -639,15 +639,7 @@ def _run_test_invoke(
     except Exception as exc:
         console.print(f"\n[red]Test failed: {exc}[/red]")
         error_text = str(exc).lower()
-        if preset.key == "kimi" and ("401" in error_text or "invalid authentication" in error_text):
-            console.print(
-                "[yellow]Kimi API keys are isolated by product and region. "
-                "Use an Open Platform key created at "
-                "https://platform.kimi.ai/console/api-keys with the default "
-                "https://api.moonshot.ai/v1 endpoint. Kimi Code, Membership, "
-                "and keys from other regional platforms are not interchangeable.[/yellow]"
-            )
-        elif preset.key == "kimi-code" and (
+        if preset.key == "kimi-code" and (
             "401" in error_text or "invalid authentication" in error_text
         ):
             console.print(

--- a/clearwing/ui/commands/setup.py
+++ b/clearwing/ui/commands/setup.py
@@ -49,7 +49,8 @@ def add_parser(subparsers):
         help=(
             "Skip the menu and configure this provider directly "
             "(e.g. openrouter, orcarouter, ollama, lmstudio, anthropic, openai, "
-            "openai-oauth, together, groq, deepseek, fireworks, custom)"
+            "openai-oauth, together, groq, deepseek, kimi, kimi-code, "
+            "fireworks, custom)"
         ),
     )
     parser.add_argument(
@@ -462,6 +463,7 @@ def _write_config(
 
     existing["provider"] = provider_section
     path.write_text(yaml.safe_dump(existing, default_flow_style=False, sort_keys=True))
+    path.chmod(0o600)
 
     # Keep the in-memory Config object in sync for the current process.
     cli.config.set("provider", value=provider_section)
@@ -632,12 +634,28 @@ def _run_test_invoke(
 
         client = ProviderManager.for_endpoint(endpoint).get_native_client("default")
         start = time.monotonic()
-        resp = asyncio.run(
-            client.aask_text(system="", user="Reply with exactly the word PONG.")
-        )
+        resp = asyncio.run(client.aask_text(system="", user="Reply with exactly the word PONG."))
         elapsed_ms = int((time.monotonic() - start) * 1000)
     except Exception as exc:
         console.print(f"\n[red]Test failed: {exc}[/red]")
+        error_text = str(exc).lower()
+        if preset.key == "kimi" and ("401" in error_text or "invalid authentication" in error_text):
+            console.print(
+                "[yellow]Kimi API keys are isolated by product and region. "
+                "Use an Open Platform key created at "
+                "https://platform.kimi.ai/console/api-keys with the default "
+                "https://api.moonshot.ai/v1 endpoint. Kimi Code, Membership, "
+                "and keys from other regional platforms are not interchangeable.[/yellow]"
+            )
+        elif preset.key == "kimi-code" and (
+            "401" in error_text or "invalid authentication" in error_text
+        ):
+            console.print(
+                "[yellow]Kimi Code keys are separate from Open Platform keys. "
+                "Use a membership key created at https://www.kimi.com/code/console "
+                "with the default https://api.kimi.com/coding/v1 endpoint, and "
+                "confirm that your membership tier includes the selected model.[/yellow]"
+            )
         console.print(
             "[yellow]The config was still written. "
             "Run `clearwing doctor` for a fuller diagnosis.[/yellow]"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -456,8 +456,7 @@ clearwing init                               # alias — same wizard
 Walks through LLM backend selection, credential entry, optional
 connection testing, and persistence to `~/.clearwing/config.yaml`.
 The menu currently lists Anthropic, OpenRouter, OrcaRouter, Ollama,
-LM Studio, OpenAI, Together, Groq, Fireworks, DeepSeek, Kimi Open Platform,
-Kimi Code, MiniMax, and a "custom
+OpenAI, Together, Groq, Fireworks, DeepSeek, Kimi Code, MiniMax, and a "custom
 OpenAI-compatible endpoint" catch-all. Safe to re-run — existing
 config is shown and can be overwritten.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -456,7 +456,8 @@ clearwing init                               # alias — same wizard
 Walks through LLM backend selection, credential entry, optional
 connection testing, and persistence to `~/.clearwing/config.yaml`.
 The menu currently lists Anthropic, OpenRouter, OrcaRouter, Ollama,
-LM Studio, OpenAI, Together, Groq, Fireworks, DeepSeek, and a "custom
+LM Studio, OpenAI, Together, Groq, Fireworks, DeepSeek, Kimi Open Platform,
+Kimi Code, MiniMax, and a "custom
 OpenAI-compatible endpoint" catch-all. Safe to re-run — existing
 config is shown and can be overwritten.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 **Autonomous vulnerability scanner and source-code hunter.** Built on
 `genai-pyo3`, a native Rust-backed LLM runtime speaking every major
 provider (Anthropic, OpenAI, OpenRouter, Ollama, LM Studio, Together,
-Groq, DeepSeek, MiniMax, Gemini, any OpenAI-compatible endpoint).
+Groq, DeepSeek, Kimi, MiniMax, Gemini, any OpenAI-compatible endpoint).
 
 Clearwing is a dual-mode offensive-security tool:
 
@@ -27,7 +27,7 @@ Clearwing is a dual-mode offensive-security tool:
 | Page | What you'll learn |
 |---|---|
 | [**Quickstart**](quickstart.md) | Install, run a network scan, run a sourcehunt pass, read the results |
-| [**LLM providers**](providers.md) | OpenRouter / Ollama / LM Studio / vLLM / Together / Groq / DeepSeek / OpenAI — CLI + env + config.yaml recipes for each |
+| [**LLM providers**](providers.md) | OpenRouter / Ollama / LM Studio / vLLM / Kimi / Together / Groq / DeepSeek / OpenAI — CLI + env + config.yaml recipes for each |
 | [**Sourcehunt evaluation and rollout**](eval_rollout.md) | Run the paired proof/legacy empirical campaign, evaluate cutover gates, and roll out proof flow safely |
 | [**Architecture**](architecture.md) | How the ReAct loops, sandboxes, capabilities layer, Finding dataclass, and knowledge graph fit together |
 | [**CLI reference**](cli.md) | Every `clearwing <subcommand>` flag, with examples |

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -409,7 +409,10 @@ provider:
 The model picker also offers `kimi-k2.7-code`,
 `kimi-k2.7-code-highspeed`, and `kimi-k2.6`. Kimi K3 always uses
 thinking mode; Clearwing sends the supported `high` reasoning effort
-instead of its generic `medium` default.
+instead of its generic `medium` default. K2.7 Code uses its own
+permanently enabled thinking mode and does not accept
+`reasoning_effort`, so Clearwing omits that parameter for both K2.7
+Code variants.
 
 ### Kimi Code (membership)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -18,8 +18,8 @@ Backends covered below:
 - **OpenAI (Responses API)** — GPT-5.x / o-series via `/v1/responses`
   (`openai_resp` adapter). Required for GPT-5.x and o-series.
 - **OpenAI OAuth (ChatGPT)** — Plus/Pro login via Codex backend (`openai_codex`).
-- **OpenRouter, OrcaRouter, Together, Groq, Fireworks, DeepSeek, LM Studio, vLLM, custom** —
-  anything that speaks `/v1/chat/completions` (`openai` adapter).
+- **OpenRouter, OrcaRouter, Together, Groq, Fireworks, DeepSeek, Kimi, LM Studio,
+  vLLM, custom** — anything that speaks `/v1/chat/completions` (`openai` adapter).
 - **MiniMax** — M2.7 / M2.5 via the Anthropic-compatible endpoint
   (`anthropic` adapter at `api.minimax.io/anthropic`).
 - **Ollama** — local models via the native rust-genai Ollama adapter
@@ -47,6 +47,7 @@ Direct variants:
 
 ```bash
 clearwing setup --provider openrouter
+clearwing setup --provider kimi
 clearwing setup --provider ollama --no-test
 clearwing init   # alias
 ```
@@ -371,6 +372,70 @@ export CLEARWING_MODEL=deepseek-chat
 For OpenAI itself, use the [Chat Completions](#openai-chat-completions-api)
 or [Responses](#openai-responses-api) section above — the model
 generation decides which.
+
+## Kimi
+
+Kimi has two separate API products. Their credentials, billing, base
+URLs, and model IDs are not interchangeable, so Clearwing exposes one
+setup choice for each.
+
+### Kimi Open Platform (pay-as-you-go)
+
+Kimi's API speaks the OpenAI Chat Completions protocol and supports
+tool calling. The setup preset uses Kimi K3, Moonshot AI's flagship
+model with a 1M-token context window, by default.
+
+```bash
+export MOONSHOT_API_KEY=your-key
+clearwing setup --provider kimi
+```
+
+Create the key in the [Kimi API Open Platform](https://platform.kimi.ai/console/api-keys).
+Kimi Open Platform, Kimi Code, Membership, and regional platforms use
+independent credentials; mixing a key from another product or region
+with `api.moonshot.ai` returns HTTP 401.
+
+The wizard detects `MOONSHOT_API_KEY` and offers to keep the secret out
+of the config file. It writes:
+
+```yaml
+provider:
+  base_url: https://api.moonshot.ai/v1
+  api_key: ${MOONSHOT_API_KEY}
+  model: kimi-k3
+  adapter: openai
+```
+
+The model picker also offers `kimi-k2.7-code`,
+`kimi-k2.7-code-highspeed`, and `kimi-k2.6`. Kimi K3 always uses
+thinking mode; Clearwing sends the supported `high` reasoning effort
+instead of its generic `medium` default.
+
+### Kimi Code (membership)
+
+Use this option for API keys created in the Kimi Code Console and backed
+by a Kimi Code membership:
+
+```bash
+export KIMI_CODE_API_KEY=your-key
+clearwing setup --provider kimi-code
+```
+
+The generated provider section uses Kimi Code's separate endpoint and
+model IDs:
+
+```yaml
+provider:
+  base_url: https://api.kimi.com/coding/v1
+  api_key: ${KIMI_CODE_API_KEY}
+  model: k3-256k
+  adapter: openai
+```
+
+`k3-256k` is the recommended default because it provides K3 capability
+while consuming less membership quota than the 1M-context `k3` model.
+The model picker also offers `k3`, `kimi-for-coding`, and
+`kimi-for-coding-highspeed`; availability depends on membership tier.
 
 ## MiniMax
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -47,7 +47,7 @@ Direct variants:
 
 ```bash
 clearwing setup --provider openrouter
-clearwing setup --provider kimi
+clearwing setup --provider kimi-code
 clearwing setup --provider ollama --no-test
 clearwing init   # alias
 ```
@@ -373,48 +373,7 @@ For OpenAI itself, use the [Chat Completions](#openai-chat-completions-api)
 or [Responses](#openai-responses-api) section above — the model
 generation decides which.
 
-## Kimi
-
-Kimi has two separate API products. Their credentials, billing, base
-URLs, and model IDs are not interchangeable, so Clearwing exposes one
-setup choice for each.
-
-### Kimi Open Platform (pay-as-you-go)
-
-Kimi's API speaks the OpenAI Chat Completions protocol and supports
-tool calling. The setup preset uses Kimi K3, Moonshot AI's flagship
-model with a 1M-token context window, by default.
-
-```bash
-export MOONSHOT_API_KEY=your-key
-clearwing setup --provider kimi
-```
-
-Create the key in the [Kimi API Open Platform](https://platform.kimi.ai/console/api-keys).
-Kimi Open Platform, Kimi Code, Membership, and regional platforms use
-independent credentials; mixing a key from another product or region
-with `api.moonshot.ai` returns HTTP 401.
-
-The wizard detects `MOONSHOT_API_KEY` and offers to keep the secret out
-of the config file. It writes:
-
-```yaml
-provider:
-  base_url: https://api.moonshot.ai/v1
-  api_key: ${MOONSHOT_API_KEY}
-  model: kimi-k3
-  adapter: openai
-```
-
-The model picker also offers `kimi-k2.7-code`,
-`kimi-k2.7-code-highspeed`, and `kimi-k2.6`. Kimi K3 always uses
-thinking mode; Clearwing sends the supported `high` reasoning effort
-instead of its generic `medium` default. K2.7 Code uses its own
-permanently enabled thinking mode and does not accept
-`reasoning_effort`, so Clearwing omits that parameter for both K2.7
-Code variants.
-
-### Kimi Code (membership)
+## Kimi Code (membership)
 
 Use this option for API keys created in the Kimi Code Console and backed
 by a Kimi Code membership:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 Or use an OpenAI-compatible endpoint (OpenRouter, Ollama, LM Studio,
-vLLM, Together, Groq, DeepSeek, OpenAI, ...):
+vLLM, Together, Groq, DeepSeek, Kimi, OpenAI, ...):
 
 ```bash
 # Per-command
@@ -137,4 +137,4 @@ make gate          # full CI gate locally: lint + type + test + build
 - [**Architecture**](architecture.md) — how the pieces fit together.
 - [**CLI reference**](cli.md) — every flag, with examples.
 - [**LLM providers**](providers.md) — OpenRouter, Ollama, LM Studio,
-  vLLM, Together, Groq, DeepSeek, OpenAI direct.
+  vLLM, Kimi, Together, Groq, DeepSeek, OpenAI direct.

--- a/tests/test_kimi_compat.py
+++ b/tests/test_kimi_compat.py
@@ -1,0 +1,95 @@
+"""Tests for the Kimi provider preset and endpoint resolution."""
+
+from __future__ import annotations
+
+from clearwing.providers.catalog import preset_by_key
+from clearwing.providers.env import _default_openai_compat_model, resolve_llm_endpoint
+
+
+class TestKimiOpenPlatformCatalog:
+    def test_preset_uses_official_api_defaults(self):
+        preset = preset_by_key("kimi")
+
+        assert preset is not None
+        assert preset.display_name == "Kimi Open Platform (pay-as-you-go)"
+        assert preset.default_base_url == "https://api.moonshot.ai/v1"
+        assert preset.default_model == "kimi-k3"
+        assert preset.api_key_env_var == "MOONSHOT_API_KEY"
+        assert preset.provider_adapter == "openai"
+        assert preset.is_openai_compat
+        assert preset.docs_url == "https://platform.kimi.ai/console/api-keys"
+
+    def test_preset_offers_current_coding_models(self):
+        preset = preset_by_key("kimi")
+
+        assert preset is not None
+        assert "kimi-k2.7-code" in preset.alt_models
+        assert "kimi-k2.7-code-highspeed" in preset.alt_models
+
+
+class TestKimiCodeCatalog:
+    def test_preset_uses_official_coding_api_defaults(self):
+        preset = preset_by_key("kimi-code")
+
+        assert preset is not None
+        assert preset.display_name == "Kimi Code (membership)"
+        assert preset.default_base_url == "https://api.kimi.com/coding/v1"
+        assert preset.default_model == "k3-256k"
+        assert preset.api_key_env_var == "KIMI_CODE_API_KEY"
+        assert preset.provider_adapter == "openai"
+        assert preset.is_openai_compat
+        assert preset.docs_url == "https://www.kimi.com/code/console"
+
+    def test_preset_offers_current_coding_model_ids(self):
+        preset = preset_by_key("kimi-code")
+
+        assert preset is not None
+        assert preset.alt_models == (
+            "k3",
+            "kimi-for-coding",
+            "kimi-for-coding-highspeed",
+        )
+
+    def test_underscore_alias_is_supported(self):
+        preset = preset_by_key("kimi_code")
+
+        assert preset is not None
+        assert preset.key == "kimi-code"
+
+
+class TestKimiEndpointResolution:
+    def test_moonshot_url_has_kimi_default(self):
+        assert _default_openai_compat_model("https://api.moonshot.ai/v1") == "kimi-k3"
+
+    def test_kimi_code_url_has_membership_default(self):
+        assert _default_openai_compat_model("https://api.kimi.com/coding/v1") == "k3-256k"
+
+    def test_cli_flags_route_to_openai_adapter(self):
+        endpoint = resolve_llm_endpoint(
+            cli_base_url="https://api.moonshot.ai/v1",
+            cli_api_key="test-key",
+            config_provider={},
+        )
+
+        assert endpoint.provider == "openai_compat"
+        assert endpoint.base_url == "https://api.moonshot.ai/v1"
+        assert endpoint.model == "kimi-k3"
+        assert endpoint.api_key == "test-key"
+        assert endpoint.is_openai_compat
+
+    def test_setup_style_config_preserves_explicit_adapter(self, monkeypatch):
+        for name in ("CLEARWING_BASE_URL", "CLEARWING_API_KEY", "CLEARWING_MODEL"):
+            monkeypatch.delenv(name, raising=False)
+
+        endpoint = resolve_llm_endpoint(
+            config_provider={
+                "base_url": "https://api.moonshot.ai/v1",
+                "api_key": "test-key",
+                "model": "kimi-k2.7-code",
+                "adapter": "openai",
+            },
+        )
+
+        assert endpoint.provider == "openai_compat"
+        assert endpoint.model == "kimi-k2.7-code"
+        assert endpoint.adapter == "openai"

--- a/tests/test_kimi_compat.py
+++ b/tests/test_kimi_compat.py
@@ -1,30 +1,9 @@
-"""Tests for the Kimi provider preset and endpoint resolution."""
+"""Tests for the Kimi Code provider preset and endpoint resolution."""
 
 from __future__ import annotations
 
 from clearwing.providers.catalog import preset_by_key
 from clearwing.providers.env import _default_openai_compat_model, resolve_llm_endpoint
-
-
-class TestKimiOpenPlatformCatalog:
-    def test_preset_uses_official_api_defaults(self):
-        preset = preset_by_key("kimi")
-
-        assert preset is not None
-        assert preset.display_name == "Kimi Open Platform (pay-as-you-go)"
-        assert preset.default_base_url == "https://api.moonshot.ai/v1"
-        assert preset.default_model == "kimi-k3"
-        assert preset.api_key_env_var == "MOONSHOT_API_KEY"
-        assert preset.provider_adapter == "openai"
-        assert preset.is_openai_compat
-        assert preset.docs_url == "https://platform.kimi.ai/console/api-keys"
-
-    def test_preset_offers_current_coding_models(self):
-        preset = preset_by_key("kimi")
-
-        assert preset is not None
-        assert "kimi-k2.7-code" in preset.alt_models
-        assert "kimi-k2.7-code-highspeed" in preset.alt_models
 
 
 class TestKimiCodeCatalog:
@@ -58,22 +37,19 @@ class TestKimiCodeCatalog:
 
 
 class TestKimiEndpointResolution:
-    def test_moonshot_url_has_kimi_default(self):
-        assert _default_openai_compat_model("https://api.moonshot.ai/v1") == "kimi-k3"
-
     def test_kimi_code_url_has_membership_default(self):
         assert _default_openai_compat_model("https://api.kimi.com/coding/v1") == "k3-256k"
 
     def test_cli_flags_route_to_openai_adapter(self):
         endpoint = resolve_llm_endpoint(
-            cli_base_url="https://api.moonshot.ai/v1",
+            cli_base_url="https://api.kimi.com/coding/v1",
             cli_api_key="test-key",
             config_provider={},
         )
 
         assert endpoint.provider == "openai_compat"
-        assert endpoint.base_url == "https://api.moonshot.ai/v1"
-        assert endpoint.model == "kimi-k3"
+        assert endpoint.base_url == "https://api.kimi.com/coding/v1"
+        assert endpoint.model == "k3-256k"
         assert endpoint.api_key == "test-key"
         assert endpoint.is_openai_compat
 
@@ -83,13 +59,13 @@ class TestKimiEndpointResolution:
 
         endpoint = resolve_llm_endpoint(
             config_provider={
-                "base_url": "https://api.moonshot.ai/v1",
+                "base_url": "https://api.kimi.com/coding/v1",
                 "api_key": "test-key",
-                "model": "kimi-k2.7-code",
+                "model": "kimi-for-coding",
                 "adapter": "openai",
             },
         )
 
         assert endpoint.provider == "openai_compat"
-        assert endpoint.model == "kimi-k2.7-code"
+        assert endpoint.model == "kimi-for-coding"
         assert endpoint.adapter == "openai"

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -88,10 +88,6 @@ class TestAutoResolveReasoningEffort:
     def test_qwen3_8_variants_resolve_to_low(self, model_name):
         assert AsyncLLMClient._auto_resolve_reasoning_effort(model_name) == "low"
 
-    def test_kimi_k3_uses_supported_high_effort(self):
-        result = AsyncLLMClient._auto_resolve_reasoning_effort("kimi-k3")
-        assert result == "high"
-
     @pytest.mark.parametrize("model", ["k3", "k3-256k"])
     def test_kimi_code_k3_uses_supported_high_effort(self, model):
         result = AsyncLLMClient._auto_resolve_reasoning_effort(model)
@@ -100,8 +96,6 @@ class TestAutoResolveReasoningEffort:
     @pytest.mark.parametrize(
         "model",
         [
-            "kimi-k2.7-code",
-            "kimi-k2.7-code-highspeed",
             "kimi-for-coding",
             "kimi-for-coding-highspeed",
         ],

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -97,8 +97,16 @@ class TestAutoResolveReasoningEffort:
         result = AsyncLLMClient._auto_resolve_reasoning_effort(model)
         assert result == "high"
 
-    @pytest.mark.parametrize("model", ["kimi-for-coding", "kimi-for-coding-highspeed"])
-    def test_kimi_code_k2_7_omits_reasoning_effort(self, model):
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "kimi-k2.7-code",
+            "kimi-k2.7-code-highspeed",
+            "kimi-for-coding",
+            "kimi-for-coding-highspeed",
+        ],
+    )
+    def test_kimi_k2_7_models_omit_reasoning_effort(self, model):
         result = AsyncLLMClient._auto_resolve_reasoning_effort(model)
         assert result is None
 

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -88,6 +88,20 @@ class TestAutoResolveReasoningEffort:
     def test_qwen3_8_variants_resolve_to_low(self, model_name):
         assert AsyncLLMClient._auto_resolve_reasoning_effort(model_name) == "low"
 
+    def test_kimi_k3_uses_supported_high_effort(self):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort("kimi-k3")
+        assert result == "high"
+
+    @pytest.mark.parametrize("model", ["k3", "k3-256k"])
+    def test_kimi_code_k3_uses_supported_high_effort(self, model):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort(model)
+        assert result == "high"
+
+    @pytest.mark.parametrize("model", ["kimi-for-coding", "kimi-for-coding-highspeed"])
+    def test_kimi_code_k2_7_omits_reasoning_effort(self, model):
+        result = AsyncLLMClient._auto_resolve_reasoning_effort(model)
+        assert result is None
+
     def test_mistral_resolves_to_none(self):
         result = AsyncLLMClient._auto_resolve_reasoning_effort("mistral-large-2407")
         assert result is None

--- a/tests/test_setup_and_doctor.py
+++ b/tests/test_setup_and_doctor.py
@@ -20,8 +20,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from rich.console import Console
 import yaml
+from rich.console import Console
 
 from clearwing.providers import KNOWN_PROVIDERS, preset_by_key
 from clearwing.ui.commands import doctor, setup
@@ -32,7 +32,7 @@ from clearwing.ui.commands.doctor import (
     DoctorCheck,
     DoctorSection,
 )
-from clearwing.ui.commands.setup import _mask_secret, _write_config
+from clearwing.ui.commands.setup import _mask_secret, _run_test_invoke, _write_config
 
 # --- Provider catalog ------------------------------------------------------
 
@@ -214,6 +214,7 @@ class TestWriteConfig:
         )
         path = tmp_cli.config.DEFAULT_CONFIG_PATH
         assert path.exists()
+        assert path.stat().st_mode & 0o777 == 0o600
         data = yaml.safe_load(path.read_text())
         assert data == {
             "provider": {
@@ -292,6 +293,46 @@ class TestWriteConfig:
         assert data["provider"]["model"] == "claude-sonnet-4-6"
         assert data["provider"]["api_key"] == "sk-ant-test"
 
+    def test_writes_kimi_provider_section(self, tmp_cli):
+        preset = preset_by_key("kimi")
+        _write_config(
+            tmp_cli,
+            preset,
+            base_url="https://api.moonshot.ai/v1",
+            api_key_literal="${MOONSHOT_API_KEY}",
+            model="kimi-k3",
+        )
+
+        data = yaml.safe_load(tmp_cli.config.DEFAULT_CONFIG_PATH.read_text())
+        assert data == {
+            "provider": {
+                "base_url": "https://api.moonshot.ai/v1",
+                "api_key": "${MOONSHOT_API_KEY}",
+                "model": "kimi-k3",
+                "adapter": "openai",
+            }
+        }
+
+    def test_writes_kimi_code_provider_section(self, tmp_cli):
+        preset = preset_by_key("kimi-code")
+        _write_config(
+            tmp_cli,
+            preset,
+            base_url="https://api.kimi.com/coding/v1",
+            api_key_literal="${KIMI_CODE_API_KEY}",
+            model="k3-256k",
+        )
+
+        data = yaml.safe_load(tmp_cli.config.DEFAULT_CONFIG_PATH.read_text())
+        assert data == {
+            "provider": {
+                "base_url": "https://api.kimi.com/coding/v1",
+                "api_key": "${KIMI_CODE_API_KEY}",
+                "model": "k3-256k",
+                "adapter": "openai",
+            }
+        }
+
     def test_openai_oauth_writes_auth_marker_without_api_key(self, tmp_cli):
         preset = preset_by_key("openai-oauth")
         _write_config(
@@ -310,6 +351,52 @@ class TestWriteConfig:
                 "adapter": "openai_codex",
             }
         }
+
+
+class TestRunTestInvoke:
+    def test_kimi_401_explains_product_and_region_key_isolation(self):
+        stream = io.StringIO()
+        console = Console(file=stream, force_terminal=False)
+        preset = preset_by_key("kimi")
+
+        with patch(
+            "clearwing.providers.ProviderManager.for_endpoint",
+            side_effect=RuntimeError("HTTP 401: Invalid Authentication"),
+        ):
+            _run_test_invoke(
+                console,
+                preset,
+                base_url="https://api.moonshot.ai/v1",
+                api_key_literal="sk-test",
+                model="kimi-k3",
+            )
+
+        output = stream.getvalue()
+        assert "isolated by product and region" in output
+        assert "platform.kimi.ai/console/api-keys" in output
+        assert "Kimi Code, Membership" in output
+
+    def test_kimi_code_401_explains_membership_key_isolation(self):
+        stream = io.StringIO()
+        console = Console(file=stream, force_terminal=False)
+        preset = preset_by_key("kimi-code")
+
+        with patch(
+            "clearwing.providers.ProviderManager.for_endpoint",
+            side_effect=RuntimeError("HTTP 401: Invalid Authentication"),
+        ):
+            _run_test_invoke(
+                console,
+                preset,
+                base_url="https://api.kimi.com/coding/v1",
+                api_key_literal="sk-test",
+                model="k3-256k",
+            )
+
+        output = stream.getvalue()
+        assert "separate from Open Platform keys" in output
+        assert "www.kimi.com/code/console" in output
+        assert "membership tier" in output
 
 
 # --- Doctor: DoctorCheck + DoctorSection aggregation ---------------------

--- a/tests/test_setup_and_doctor.py
+++ b/tests/test_setup_and_doctor.py
@@ -293,26 +293,6 @@ class TestWriteConfig:
         assert data["provider"]["model"] == "claude-sonnet-4-6"
         assert data["provider"]["api_key"] == "sk-ant-test"
 
-    def test_writes_kimi_provider_section(self, tmp_cli):
-        preset = preset_by_key("kimi")
-        _write_config(
-            tmp_cli,
-            preset,
-            base_url="https://api.moonshot.ai/v1",
-            api_key_literal="${MOONSHOT_API_KEY}",
-            model="kimi-k3",
-        )
-
-        data = yaml.safe_load(tmp_cli.config.DEFAULT_CONFIG_PATH.read_text())
-        assert data == {
-            "provider": {
-                "base_url": "https://api.moonshot.ai/v1",
-                "api_key": "${MOONSHOT_API_KEY}",
-                "model": "kimi-k3",
-                "adapter": "openai",
-            }
-        }
-
     def test_writes_kimi_code_provider_section(self, tmp_cli):
         preset = preset_by_key("kimi-code")
         _write_config(
@@ -354,28 +334,6 @@ class TestWriteConfig:
 
 
 class TestRunTestInvoke:
-    def test_kimi_401_explains_product_and_region_key_isolation(self):
-        stream = io.StringIO()
-        console = Console(file=stream, force_terminal=False)
-        preset = preset_by_key("kimi")
-
-        with patch(
-            "clearwing.providers.ProviderManager.for_endpoint",
-            side_effect=RuntimeError("HTTP 401: Invalid Authentication"),
-        ):
-            _run_test_invoke(
-                console,
-                preset,
-                base_url="https://api.moonshot.ai/v1",
-                api_key_literal="sk-test",
-                model="kimi-k3",
-            )
-
-        output = stream.getvalue()
-        assert "isolated by product and region" in output
-        assert "platform.kimi.ai/console/api-keys" in output
-        assert "Kimi Code, Membership" in output
-
     def test_kimi_code_401_explains_membership_key_isolation(self):
         stream = io.StringIO()
         console = Console(file=stream, force_terminal=False)


### PR DESCRIPTION
## Summary

- add a `kimi-code` setup preset for Kimi Code membership credentials and the `https://api.kimi.com/coding/v1` endpoint
- offer only the four model IDs verified through the live endpoint: `k3-256k`, `k3`, `kimi-for-coding`, and `kimi-for-coding-highspeed`
- use valid `high` reasoning effort for K3 models and omit unsupported `reasoning_effort` for the K2.7-backed coding aliases
- explain Kimi Code/Open Platform key isolation after 401 responses and write provider config files with mode `0600`
- document the setup flow and add catalog, endpoint, setup, permissions, diagnostics, and reasoning regression coverage

## Verification

- live completion returned exactly `PONG` for all four advertised Kimi Code models
- the exact committed PR snapshot passes `157` focused provider, setup, fallback, budget, and reasoning tests
- scoped Ruff lint and format checks passed on the committed snapshot
- `git diff --check` passed; no credentials are included in this PR

## Scope

Kimi Open Platform is intentionally not included because its credentials are isolated from Kimi Code and no Open Platform key was available for live validation.

## Repository baseline notes

- the strict full-suite command currently stops during collection because the existing `integration` marker is not registered
- the normal full suite reached `2913 passed, 26 skipped`; its 18 failures are existing sandbox tests that require a locally available Docker executable
- repo-wide Ruff, scoped mypy, and strict docs checks also have existing failures in untouched files
