### PR TITLE
Add CyberPi sourcehunt engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,16 @@ clearwing scan 192.168.1.10 -p 22,80,443 --detect-services
 clearwing sourcehunt https://github.com/example/project \
     --depth standard
 
-# CyberPi — minimal Pi harness for sandboxed per-file discovery.
-# Requires Node.js 22.19+ and the one-time sidecar install shown below.
-(cd clearwing/sourcehunt/cyberpi_sidecar && npm ci --omit=dev)
+# CyberPi — install, diagnose, and smoke-test the pinned Pi harness.
+clearwing cyberpi install
+clearwing cyberpi doctor
+clearwing cyberpi smoke
 clearwing sourcehunt https://github.com/example/project \
     --depth deep \
     --hunt-engine cyberpi
+
+# Paired native-vs-CyberPi harness benchmark with JSONL trajectories
+clearwing cyberpi benchmark --runs 3
 
 # Proof-carrying hunt — typed facts, obligations, evidence, falsification,
 # and auditable finding/rejection/incomplete certificates

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ clearwing scan 192.168.1.10 -p 22,80,443 --detect-services
 clearwing sourcehunt https://github.com/example/project \
     --depth standard
 
+# CyberPi — minimal Pi harness for sandboxed per-file discovery.
+# Requires Node.js 22.19+ and the one-time sidecar install shown below.
+(cd clearwing/sourcehunt/cyberpi_sidecar && npm ci --omit=dev)
+clearwing sourcehunt https://github.com/example/project \
+    --depth deep \
+    --hunt-engine cyberpi
+
 # Proof-carrying hunt — typed facts, obligations, evidence, falsification,
 # and auditable finding/rejection/incomplete certificates
 clearwing sourcehunt /path/to/project \

--- a/clearwing/bench/cyberpi.py
+++ b/clearwing/bench/cyberpi.py
@@ -1,0 +1,509 @@
+"""Small paired harness benchmark for native Sourcehunt and CyberPi."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+from clearwing.agent.tools.hunt.sandbox import HunterContext
+from clearwing.findings.types import Finding
+from clearwing.llm import AsyncLLMClient, NativeToolSpec
+from clearwing.sourcehunt.cyberpi import CyberPiHuntEngine
+from clearwing.sourcehunt.hunt_engine import HuntAssignment
+from clearwing.sourcehunt.hunter import NativeHunter
+from clearwing.sourcehunt.native_hunt_engine import NativeHuntEngine
+
+_SYSTEM_PROMPT = """You are auditing one C source file for memory-safety vulnerabilities.
+Read /workspace/fixture.c before deciding. Trace attacker-controlled sizes to memory operations.
+Call record_finding only for a concrete vulnerability in the supplied source. Use CWE-122 for a
+heap-buffer overflow. Safe code is a valid outcome: if bounds checks make the operation safe,
+finish without calling record_finding. Do not invent missing code, runtime evidence, or findings."""
+
+
+@dataclass(frozen=True, slots=True)
+class CyberPiFixture:
+    """A source snippet with a deliberately narrow expected outcome."""
+
+    name: str
+    source: str
+    vulnerable: bool
+    expected_cwe: str | None = None
+    expected_line: int | None = None
+
+
+BUILTIN_FIXTURES = (
+    CyberPiFixture(
+        name="heap-overflow",
+        source="""#include <stdlib.h>
+#include <string.h>
+
+void copy_packet(const unsigned char *packet, size_t packet_length) {
+    char *destination = malloc(16);
+    if (destination == NULL) return;
+    memcpy(destination, packet, packet_length);
+    free(destination);
+}
+""",
+        vulnerable=True,
+        expected_cwe="CWE-122",
+        expected_line=7,
+    ),
+    CyberPiFixture(
+        name="bounded-copy",
+        source="""#include <stdlib.h>
+#include <string.h>
+
+void copy_packet(const unsigned char *packet, size_t packet_length) {
+    if (packet_length > 16) return;
+    char *destination = malloc(16);
+    if (destination == NULL) return;
+    memcpy(destination, packet, packet_length);
+    free(destination);
+}
+""",
+        vulnerable=False,
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkObservation:
+    engine: Literal["native", "cyberpi"]
+    fixture: str
+    replicate: int
+    passed: bool
+    findings: tuple[dict[str, Any], ...]
+    tokens_used: int
+    cost_usd: float
+    cost_basis: str
+    duration_seconds: float
+    stop_reason: str
+    trajectory: str
+    error: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class CyberPiBenchmarkReport:
+    benchmark_id: str
+    created_at: str
+    model: str
+    base_url: str
+    max_turns: int
+    max_output_tokens: int
+    observations: tuple[BenchmarkObservation, ...]
+
+    @property
+    def successful(self) -> bool:
+        return all(not observation.error for observation in self.observations)
+
+    def metrics(self) -> dict[str, dict[str, Any]]:
+        metrics: dict[str, dict[str, Any]] = {}
+        for engine in ("native", "cyberpi"):
+            observations = [item for item in self.observations if item.engine == engine]
+            if not observations:
+                continue
+            metrics[engine] = {
+                "passed": sum(item.passed for item in observations),
+                "cases": len(observations),
+                "pass_rate": sum(item.passed for item in observations) / len(observations),
+                "tokens": sum(item.tokens_used for item in observations),
+                "cost_usd": sum(item.cost_usd for item in observations),
+                "cost_basis": ", ".join(sorted({item.cost_basis for item in observations})),
+                "duration_seconds": sum(item.duration_seconds for item in observations),
+                "errors": sum(bool(item.error) for item in observations),
+            }
+        return metrics
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "benchmark_id": self.benchmark_id,
+            "created_at": self.created_at,
+            "model": self.model,
+            "base_url": self.base_url,
+            "max_turns": self.max_turns,
+            "max_output_tokens": self.max_output_tokens,
+            "metrics": self.metrics(),
+            "observations": [asdict(observation) for observation in self.observations],
+        }
+
+    def markdown(self) -> str:
+        lines = [
+            "# CyberPi harness benchmark",
+            "",
+            f"- Benchmark: `{self.benchmark_id}`",
+            f"- Model: `{self.model}`",
+            f"- Endpoint: `{self.base_url}`",
+            f"- Maximum turns per case: {self.max_turns}",
+            f"- Maximum output tokens per turn: {self.max_output_tokens}",
+            "",
+            "| Engine | Passed | Cases | Pass rate | Tokens | Reported cost* | Duration | Errors |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+        for engine, values in self.metrics().items():
+            lines.append(
+                f"| {engine} | {values['passed']} | {values['cases']} | "
+                f"{float(values['pass_rate']):.0%} | {values['tokens']} | "
+                f"${float(values['cost_usd']):.4f} | "
+                f"{float(values['duration_seconds']):.1f}s | {values['errors']} |"
+            )
+        lines.extend(
+            [
+                "",
+                "## Cases",
+                "",
+                "| Engine | Fixture | Run | Result | Findings | Stop | Trajectory |",
+                "| --- | --- | ---: | --- | ---: | --- | --- |",
+            ]
+        )
+        for item in self.observations:
+            result = f"error: {item.error}" if item.error else ("pass" if item.passed else "miss")
+            lines.append(
+                f"| {item.engine} | {item.fixture} | {item.replicate} | {result} | "
+                f"{len(item.findings)} | {item.stop_reason} | `{item.trajectory}` |"
+            )
+        lines.extend(
+            [
+                "",
+                "\\* Native cost is Clearwing's pricing-table estimate; CyberPi cost is Pi's "
+                "provider/model report. Compare tokens unless both arms use configured endpoint pricing.",
+                "",
+                "This is a deterministic-fixture harness comparison, not a CVE recall claim. "
+                "Use multiple runs and inspect the JSONL trajectories before changing prompts.",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+    def write(self, output_dir: str | Path) -> tuple[Path, Path]:
+        destination = Path(output_dir).expanduser()
+        destination.mkdir(parents=True, exist_ok=True)
+        json_path = destination / f"{self.benchmark_id}.json"
+        markdown_path = destination / f"{self.benchmark_id}.md"
+        json_path.write_text(json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n")
+        markdown_path.write_text(self.markdown(), encoding="utf-8")
+        return json_path, markdown_path
+
+
+class CyberPiBenchmark:
+    """Run both harnesses with the same model, prompt, tools, cases, and turn cap."""
+
+    def __init__(
+        self,
+        llm: AsyncLLMClient,
+        *,
+        output_dir: str | Path,
+        max_turns: int = 4,
+        max_output_tokens: int = 4096,
+    ) -> None:
+        self.llm = llm
+        self.output_dir = Path(output_dir).expanduser()
+        self.max_turns = max_turns
+        self.max_output_tokens = max_output_tokens
+
+    async def arun(
+        self,
+        *,
+        replicates: int = 1,
+        engines: tuple[Literal["native", "cyberpi"], ...] = ("native", "cyberpi"),
+        fixtures: tuple[CyberPiFixture, ...] = BUILTIN_FIXTURES,
+    ) -> CyberPiBenchmarkReport:
+        benchmark_id = (
+            "cyberpi-"
+            + datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            + f"-{uuid4().hex[:6]}"
+        )
+        observations: list[BenchmarkObservation] = []
+        for replicate in range(1, replicates + 1):
+            engine_order = engines if replicate % 2 else tuple(reversed(engines))
+            for fixture in fixtures:
+                for engine_name in engine_order:
+                    observations.append(
+                        await self._run_one(benchmark_id, engine_name, fixture, replicate)
+                    )
+        return CyberPiBenchmarkReport(
+            benchmark_id=benchmark_id,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            model=self.llm.model_name,
+            base_url=self._safe_base_url(self.llm.base_url or "https://api.anthropic.com"),
+            max_turns=self.max_turns,
+            max_output_tokens=self.max_output_tokens,
+            observations=tuple(observations),
+        )
+
+    async def _run_one(
+        self,
+        benchmark_id: str,
+        engine_name: Literal["native", "cyberpi"],
+        fixture: CyberPiFixture,
+        replicate: int,
+    ) -> BenchmarkObservation:
+        work_item_id = f"{engine_name}-{fixture.name}-{replicate}"
+        trajectory_dir = self.output_dir / benchmark_id / "trajectories" / work_item_id
+        assignment = HuntAssignment(
+            file_target={"path": "/workspace/fixture.c"},
+            session_id=benchmark_id,
+            work_item_id=work_item_id,
+        )
+
+        def build_hunter(_assignment: HuntAssignment, _sandbox: object):
+            return self._build_hunter(fixture, trajectory_dir, benchmark_id, work_item_id)
+
+        engine = (
+            NativeHuntEngine(build_hunter)
+            if engine_name == "native"
+            else CyberPiHuntEngine(build_hunter)
+        )
+        started = time.monotonic()
+        try:
+            outcome = await engine.hunt(assignment, object())
+            findings = tuple(self._finding_dict(finding) for finding in outcome.findings)
+            return BenchmarkObservation(
+                engine=engine_name,
+                fixture=fixture.name,
+                replicate=replicate,
+                passed=self._passed(fixture, findings),
+                findings=findings,
+                tokens_used=outcome.tokens_used,
+                cost_usd=outcome.cost_usd,
+                cost_basis=(
+                    "clearwing_estimate" if engine_name == "native" else "provider_reported"
+                ),
+                duration_seconds=time.monotonic() - started,
+                stop_reason=outcome.stop_reason,
+                trajectory=str(trajectory_dir / "transcript.jsonl"),
+            )
+        except Exception as exc:  # keep the paired experiment and its artifacts intact
+            return BenchmarkObservation(
+                engine=engine_name,
+                fixture=fixture.name,
+                replicate=replicate,
+                passed=False,
+                findings=(),
+                tokens_used=0,
+                cost_usd=0.0,
+                cost_basis=(
+                    "clearwing_estimate" if engine_name == "native" else "provider_reported"
+                ),
+                duration_seconds=time.monotonic() - started,
+                stop_reason="error",
+                trajectory=str(trajectory_dir / "transcript.jsonl"),
+                error=self._safe_error(exc),
+            )
+
+    def _build_hunter(
+        self,
+        fixture: CyberPiFixture,
+        trajectory_dir: Path,
+        session_id: str,
+        work_item_id: str,
+    ) -> tuple[NativeHunter, HunterContext]:
+        context = HunterContext(
+            repo_path="/workspace",
+            file_path="/workspace/fixture.c",
+            session_id=session_id,
+            agent_mode="deep",
+            trajectory_dir=trajectory_dir,
+            work_item_id=work_item_id,
+        )
+
+        async def read_file(path: str, offset: int = 0, limit: int = 500) -> str:
+            if not path.endswith("fixture.c"):
+                return json.dumps({"error": "the benchmark exposes only /workspace/fixture.c"})
+            lines = fixture.source.splitlines()
+            selected = lines[max(offset, 0) : max(offset, 0) + max(limit, 1)]
+            return "\n".join(
+                f"{number}: {line}" for number, line in enumerate(selected, start=max(offset, 0) + 1)
+            )
+
+        async def execute(command: str) -> dict[str, str]:
+            return {"error": f"execution is disabled in this source-only fixture: {command[:80]}"}
+
+        async def write_file(path: str, contents: str) -> str:
+            if path != "/scratch/notes.txt":
+                return json.dumps({"error": "the fixture permits only /scratch/notes.txt"})
+            return f"stored {len(contents)} bytes"
+
+        async def record_trace_step(
+            file: str, line: int, function: str = "", note: str = ""
+        ) -> str:
+            context.trace_steps.append(
+                {"file": file, "line": line, "function": function, "note": note}
+            )
+            return "trace step recorded"
+
+        async def record_finding(
+            file: str,
+            line_number: int,
+            finding_type: str,
+            severity: str,
+            cwe: str,
+            description: str,
+        ) -> str:
+            context.findings.append(
+                Finding(
+                    file=file,
+                    line_number=line_number,
+                    finding_type=finding_type,
+                    severity=severity,  # type: ignore[arg-type]
+                    cwe=cwe.upper(),
+                    description=description,
+                    discovered_by="cyberpi-benchmark",
+                )
+            )
+            return "finding recorded"
+
+        tools = [
+            NativeToolSpec(
+                "read_file",
+                "Read the benchmark source with 0-based offset and line limit.",
+                _schema(
+                    {
+                        "path": {"type": "string"},
+                        "offset": {"type": "integer"},
+                        "limit": {"type": "integer"},
+                    },
+                    ["path"],
+                ),
+                read_file,
+            ),
+            NativeToolSpec(
+                "execute",
+                "Execution is unavailable in this source-only benchmark.",
+                _schema({"command": {"type": "string"}}, ["command"]),
+                execute,
+            ),
+            NativeToolSpec(
+                "write_file",
+                "Optionally write notes to /scratch/notes.txt.",
+                _schema(
+                    {"path": {"type": "string"}, "contents": {"type": "string"}},
+                    ["path", "contents"],
+                ),
+                write_file,
+            ),
+            NativeToolSpec(
+                "record_trace_step",
+                "Record one source step supporting a finding.",
+                _schema(
+                    {
+                        "file": {"type": "string"},
+                        "line": {"type": "integer"},
+                        "function": {"type": "string"},
+                        "note": {"type": "string"},
+                    },
+                    ["file", "line"],
+                ),
+                record_trace_step,
+            ),
+            NativeToolSpec(
+                "record_finding",
+                "Record a concrete vulnerability found in the supplied source.",
+                _schema(
+                    {
+                        "file": {"type": "string"},
+                        "line_number": {"type": "integer"},
+                        "finding_type": {"type": "string"},
+                        "severity": {
+                            "type": "string",
+                            "enum": ["critical", "high", "medium", "low", "info"],
+                        },
+                        "cwe": {"type": "string"},
+                        "description": {"type": "string"},
+                    },
+                    ["file", "line_number", "finding_type", "severity", "cwe", "description"],
+                ),
+                record_finding,
+            ),
+        ]
+        return (
+            NativeHunter(
+                llm=self.llm,
+                prompt=_SYSTEM_PROMPT,
+                tools=tools,
+                ctx=context,
+                max_steps=self.max_turns,
+                agent_mode="deep",
+                initial_user_message=(
+                    "Audit /workspace/fixture.c. Read it, reason about the copy bound, and record "
+                    "only a concrete vulnerability."
+                ),
+                max_output_tokens=self.max_output_tokens,
+            ),
+            context,
+        )
+
+    @staticmethod
+    def _passed(fixture: CyberPiFixture, findings: tuple[dict[str, Any], ...]) -> bool:
+        if not fixture.vulnerable:
+            return not findings
+        expected_cwe = CyberPiBenchmark._normalize_cwe(fixture.expected_cwe or "")
+        expected_line = fixture.expected_line
+        return any(
+            (
+                not expected_cwe
+                or CyberPiBenchmark._normalize_cwe(str(finding.get("cwe") or ""))
+                == expected_cwe
+            )
+            and (
+                expected_line is None
+                or abs(int(finding.get("line_number") or -1000) - expected_line) <= 1
+            )
+            for finding in findings
+        )
+
+    @staticmethod
+    def _finding_dict(finding: Finding) -> dict[str, Any]:
+        return {
+            "file": finding.file,
+            "line_number": finding.line_number,
+            "finding_type": finding.finding_type,
+            "severity": finding.severity,
+            "cwe": finding.cwe,
+            "description": finding.description,
+        }
+
+    def _safe_error(self, exc: Exception) -> str:
+        message = f"{type(exc).__name__}: {exc}"
+        if self.llm.api_key:
+            message = message.replace(self.llm.api_key, "[REDACTED]")
+        return message[:2000]
+
+    @staticmethod
+    def _normalize_cwe(value: str) -> str:
+        normalized = value.upper().strip().replace("_", "-")
+        number = normalized.removeprefix("CWE-").removeprefix("CWE")
+        return f"CWE-{number.lstrip('0') or '0'}" if number.isdigit() else normalized
+
+    @staticmethod
+    def _safe_base_url(value: str) -> str:
+        parsed = urlsplit(value)
+        if not parsed.hostname:
+            return value.split("?", 1)[0].split("#", 1)[0]
+        hostname = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        netloc = f"{hostname}:{parsed.port}" if parsed.port is not None else hostname
+        return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
+
+
+def _schema(properties: dict[str, Any], required: list[str]) -> dict[str, Any]:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+__all__ = [
+    "BUILTIN_FIXTURES",
+    "BenchmarkObservation",
+    "CyberPiBenchmark",
+    "CyberPiBenchmarkReport",
+    "CyberPiFixture",
+]

--- a/clearwing/sourcehunt/config.py
+++ b/clearwing/sourcehunt/config.py
@@ -78,6 +78,7 @@ class FeatureFlags:
     exploit_mode: bool = False
     agent_mode: str = "auto"  # "auto" | "constrained" | "deep"
     prompt_mode: str = "unconstrained"  # "unconstrained" | "specialist"
+    hunt_engine: str = "native"  # "native" | "cyberpi"
 
 
 @dataclass(frozen=True)

--- a/clearwing/sourcehunt/cyberpi.py
+++ b/clearwing/sourcehunt/cyberpi.py
@@ -1,0 +1,694 @@
+"""CyberPi anti-corruption adapter for Sourcehunt discovery."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import os
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from importlib.resources import files
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from clearwing.llm import AsyncLLMClient, NativeToolSpec
+from clearwing.llm.budget import BudgetReservation, current_spend_metadata
+
+from .hunt_engine import HuntAssignment, HuntOutcome
+
+logger = logging.getLogger(__name__)
+
+_PROTOCOL_VERSION = 1
+_MAX_MESSAGE_BYTES = 10 * 1024 * 1024
+_ALLOWED_TOOLS = frozenset(
+    {"execute", "read_file", "write_file", "record_trace_step", "record_finding"}
+)
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"invalid JSON constant: {value}")
+
+
+class CyberPiError(RuntimeError):
+    """Raised when the CyberPi sidecar violates its protocol or cannot run."""
+
+
+@dataclass(frozen=True, slots=True)
+class CyberPiModel:
+    provider: str
+    model: str
+    api: str
+    base_url: str
+    api_key: str
+    reasoning: bool
+    cost: dict[str, float]
+
+
+class CyberPiHuntEngine:
+    """Run Pi with only Clearwing-owned tools and state transitions."""
+
+    def __init__(
+        self,
+        build_hunter: Callable[[HuntAssignment, Any], Any],
+        *,
+        command: Sequence[str] | None = None,
+        environ: Mapping[str, str] | None = None,
+    ) -> None:
+        self._build_hunter = build_hunter
+        self._command = tuple(command) if command is not None else self.default_command()
+        self._environ = dict(environ) if environ is not None else None
+
+    @staticmethod
+    def default_command() -> tuple[str, ...]:
+        sidecar = files("clearwing.sourcehunt.cyberpi_sidecar").joinpath("index.mjs")
+        return (os.environ.get("CLEARWING_CYBERPI_NODE", "node"), str(sidecar))
+
+    async def hunt(self, assignment: HuntAssignment, sandbox: Any) -> HuntOutcome:
+        if sandbox is None:
+            raise CyberPiError("CyberPi requires an isolated Sourcehunt sandbox")
+
+        native_hunter, context = self._build_hunter(assignment, sandbox)
+        process: asyncio.subprocess.Process | None = None
+        active_reservations: dict[str, BudgetReservation] = {}
+        active_calls: set[str] = set()
+        stderr_task: asyncio.Task[None] | None = None
+        runtime_dir = tempfile.TemporaryDirectory(prefix="clearwing-cyberpi-")
+        try:
+            model = self._model_from_client(native_hunter.llm)
+            tools = [tool for tool in native_hunter.tools if tool.name in _ALLOWED_TOOLS]
+            missing_tools = {"execute", "read_file", "record_trace_step", "record_finding"} - {
+                tool.name for tool in tools
+            }
+            if missing_tools:
+                raise CyberPiError(
+                    "CyberPi requires Clearwing's deep hunt tools; missing "
+                    + ", ".join(sorted(missing_tools))
+                )
+            process = await self._start_process(model.api_key, cwd=runtime_dir.name)
+            assert process.stdin is not None
+            assert process.stdout is not None
+            assert process.stderr is not None
+            stderr_task = asyncio.create_task(self._drain_stderr(process.stderr))
+
+            await self._write_message(
+                process.stdin,
+                {
+                    "type": "start",
+                    "protocol": _PROTOCOL_VERSION,
+                    "assignment": {
+                        "session_id": assignment.session_id,
+                        "target": assignment.file_target.get("path", ""),
+                        "work_item_id": assignment.work_item_id,
+                        "budget_usd": assignment.budget_usd,
+                    },
+                    "model": {
+                        "provider": model.provider,
+                        "id": model.model,
+                        "api": model.api,
+                        "base_url": model.base_url,
+                        "reasoning": model.reasoning,
+                        "thinking_level": "max",
+                        "temperature": 1.0,
+                        "top_p": 0.95,
+                        "cost": model.cost,
+                        "max_output_tokens": self._max_output_tokens(native_hunter.llm),
+                    },
+                    "system_prompt": native_hunter.prompt,
+                    "user_message": self._initial_user_message(native_hunter, assignment),
+                    "max_turns": native_hunter.max_steps,
+                    "tools": [self._serialize_tool(tool) for tool in tools],
+                },
+            )
+            outcome = await self._run_protocol(
+                assignment=assignment,
+                native_hunter=native_hunter,
+                context=context,
+                tools=tools,
+                process=process,
+                active_reservations=active_reservations,
+                active_calls=active_calls,
+            )
+
+            try:
+                process.stdin.close()
+                await process.stdin.wait_closed()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            return_code = await process.wait()
+            await stderr_task
+            stderr_task = None
+            if return_code != 0:
+                raise CyberPiError(self._process_error(return_code))
+            return outcome
+        except BaseException as exc:
+            self._fail_active_reservations(native_hunter.llm, active_reservations, exc)
+            raise
+        finally:
+            if process is not None and process.returncode is None:
+                process.kill()
+                await process.wait()
+            if stderr_task is not None:
+                stderr_task.cancel()
+                await asyncio.gather(stderr_task, return_exceptions=True)
+            active_calls.clear()
+            try:
+                context.cleanup_variants()
+            except Exception:
+                logger.debug("Variant sandbox cleanup failed", exc_info=True)
+            runtime_dir.cleanup()
+
+    async def _run_protocol(
+        self,
+        *,
+        assignment: HuntAssignment,
+        native_hunter: Any,
+        context: Any,
+        tools: list[NativeToolSpec],
+        process: asyncio.subprocess.Process,
+        active_reservations: dict[str, BudgetReservation],
+        active_calls: set[str],
+    ) -> HuntOutcome:
+        assert process.stdin is not None
+        assert process.stdout is not None
+
+        usage = self._empty_usage()
+        while True:
+            message = await self._read_message(process.stdout)
+            message_type = message.get("type")
+            if message_type == "tool_call":
+                await self._write_message(process.stdin, await self._invoke_tool(tools, message))
+                continue
+            if message_type == "model_call":
+                request_id = self._message_id(message, "model call")
+                if request_id in active_calls:
+                    raise CyberPiError(f"Duplicate CyberPi model call id: {request_id}")
+                authorization, reservation = self._authorize_model_call(native_hunter.llm, message)
+                active_calls.add(request_id)
+                if reservation is not None:
+                    active_reservations[request_id] = reservation
+                await self._write_message(process.stdin, authorization)
+                continue
+            if message_type == "model_result":
+                call_usage = self._require_usage(message.get("usage"))
+                succeeded = message.get("ok")
+                if not isinstance(succeeded, bool):
+                    raise CyberPiError("CyberPi model result is missing its status")
+                if succeeded and assignment.budget_usd > 0 and int(call_usage["total_tokens"]) < 1:
+                    raise CyberPiError("CyberPi returned unmetered usage for a budgeted hunt")
+                self._accumulate_usage(usage, call_usage)
+                cost = self._settle_model_call(
+                    native_hunter.llm,
+                    active_reservations,
+                    active_calls,
+                    message,
+                    call_usage,
+                    succeeded=succeeded,
+                )
+                usage["cost_usd"] += cost
+                request_id = self._message_id(message, "model result")
+                await self._write_message(
+                    process.stdin,
+                    {"type": "model_result_ack", "id": request_id},
+                )
+                if not succeeded:
+                    detail = str(message.get("error") or "provider request failed")
+                    raise CyberPiError(f"CyberPi model call failed: {detail[:2000]}")
+                continue
+            if message_type == "complete":
+                if active_calls:
+                    raise CyberPiError("CyberPi completed with an unsettled model call")
+                model_calls = message.get("model_calls")
+                if (
+                    not isinstance(model_calls, int)
+                    or isinstance(model_calls, bool)
+                    or model_calls < 1
+                ):
+                    raise CyberPiError("CyberPi completed without a model call")
+                return HuntOutcome(
+                    findings=tuple(context.findings),
+                    cost_usd=float(usage["cost_usd"]),
+                    tokens_used=int(usage["total_tokens"]),
+                    stop_reason=self._stop_reason(message, native_hunter.max_steps),
+                )
+            if message_type == "error":
+                detail = str(message.get("message") or "CyberPi sidecar failed")
+                raise CyberPiError(detail[:2000])
+            raise CyberPiError(f"Unexpected CyberPi message type: {message_type!r}")
+
+    async def _start_process(self, api_key: str, *, cwd: str) -> asyncio.subprocess.Process:
+        self._check_runtime_installed()
+        if self._environ is not None:
+            env = dict(self._environ)
+        else:
+            inherited = (
+                "ALL_PROXY",
+                "HTTP_PROXY",
+                "HTTPS_PROXY",
+                "NO_PROXY",
+                "NODE_EXTRA_CA_CERTS",
+                "PATH",
+                "SSL_CERT_DIR",
+                "SSL_CERT_FILE",
+                "TMPDIR",
+            )
+            env = {name: os.environ[name] for name in inherited if name in os.environ}
+        env["HOME"] = cwd
+        env["PI_OFFLINE"] = "1"
+        env["CLEARWING_CYBERPI_API_KEY"] = api_key
+        try:
+            return await asyncio.create_subprocess_exec(
+                *self._command,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+                cwd=cwd,
+                limit=_MAX_MESSAGE_BYTES + 1,
+            )
+        except FileNotFoundError as exc:
+            raise CyberPiError(
+                "CyberPi runtime is not installed. Run `npm ci --omit=dev` in "
+                "clearwing/sourcehunt/cyberpi_sidecar."
+            ) from exc
+
+    def _check_runtime_installed(self) -> None:
+        if len(self._command) < 2 or Path(self._command[1]).name != "index.mjs":
+            return
+        package_dir = Path(self._command[1]).parent
+        dependency = package_dir / "node_modules" / "@earendil-works" / "pi-coding-agent"
+        if dependency.is_dir():
+            return
+        raise CyberPiError(
+            f"CyberPi runtime is not installed. Run `npm ci --omit=dev` in {package_dir}."
+        )
+
+    @staticmethod
+    def _model_from_client(client: Any) -> CyberPiModel:
+        if not isinstance(client, AsyncLLMClient):
+            raise CyberPiError("CyberPi requires a configured native LLM client")
+        provider = client.provider_name.strip().lower()
+        if provider in {"openai", "openai_compat", "openai_resp"}:
+            target = f"{client.base_url or ''} {client.model_name}".lower()
+            if "token-plan.cn-beijing.maas.aliyuncs.com" in target:
+                provider = "qwen-token-plan-cn"
+            elif "token-plan.ap-southeast-1.maas.aliyuncs.com" in target:
+                provider = (
+                    "qwen-token-plan-individual"
+                    if client.model_name == "deepseek-v4-flash-0731"
+                    else "qwen-token-plan"
+                )
+            elif "openrouter.ai" in target:
+                provider = "openrouter"
+            elif "fireworks.ai" in target:
+                provider = "fireworks"
+            elif "together.xyz" in target or "together.ai" in target:
+                provider = "together"
+            elif "deepseek" in target:
+                provider = "deepseek"
+            else:
+                provider = "openai"
+        api = "openai-responses" if client.provider_name == "openai_resp" else "openai-completions"
+        if provider == "anthropic":
+            api = "anthropic-messages"
+        if provider == "gemini":
+            provider = "google"
+            api = "google-generative-ai"
+        base_url = client.base_url or {
+            "anthropic": "https://api.anthropic.com",
+            "deepseek": "https://api.deepseek.com",
+            "google": "https://generativelanguage.googleapis.com",
+            "openai": "https://api.openai.com/v1",
+            "openrouter": "https://openrouter.ai/api/v1",
+        }.get(provider, "")
+        if provider not in {
+            "anthropic",
+            "deepseek",
+            "fireworks",
+            "google",
+            "openai",
+            "openrouter",
+            "qwen-token-plan",
+            "qwen-token-plan-cn",
+            "qwen-token-plan-individual",
+            "together",
+        }:
+            raise CyberPiError(f"CyberPi does not support provider {client.provider_name!r}")
+        ledger = client.spend_ledger
+        if ledger is not None and ledger.enforcing:
+            pricing = ledger.validate_model(
+                model=client.model_name,
+                provider=client.provider_name,
+                supports_output_limit=True,
+            )
+            cost = {
+                "input": pricing.input_per_million,
+                "output": pricing.output_per_million,
+                "cacheRead": pricing.cached_input_per_million,
+                "cacheWrite": pricing.input_per_million,
+            }
+        else:
+            cost = {}
+        return CyberPiModel(
+            provider=provider,
+            model=client.model_name,
+            api=api,
+            base_url=base_url,
+            api_key=client.api_key,
+            reasoning=bool(client.reasoning_effort),
+            cost=cost,
+        )
+
+    @staticmethod
+    def _max_output_tokens(client: AsyncLLMClient) -> int | None:
+        ledger = client.spend_ledger
+        if ledger is not None and ledger.enforcing:
+            return int(ledger.default_max_output_tokens)
+        return None
+
+    @staticmethod
+    def _initial_user_message(native_hunter: Any, assignment: HuntAssignment) -> str:
+        return native_hunter.initial_user_message or (
+            f"Hunt for vulnerabilities in {assignment.file_target.get('path', 'unknown')}."
+        )
+
+    @staticmethod
+    def _serialize_tool(tool: NativeToolSpec) -> dict[str, Any]:
+        if tool.name not in _ALLOWED_TOOLS:
+            raise CyberPiError(f"Tool is not authorized for CyberPi: {tool.name}")
+        return {"name": tool.name, "description": tool.description, "schema": tool.schema}
+
+    @staticmethod
+    async def _invoke_tool(tools: list[NativeToolSpec], message: dict[str, Any]) -> dict[str, Any]:
+        request_id = message.get("id")
+        name = message.get("name")
+        if not isinstance(request_id, str) or not request_id:
+            raise CyberPiError("CyberPi tool call is missing a valid id")
+        if not isinstance(name, str):
+            raise CyberPiError("CyberPi tool call is missing a valid name")
+        tool = next((candidate for candidate in tools if candidate.name == name), None)
+        if tool is None:
+            return {
+                "type": "tool_result",
+                "id": request_id,
+                "ok": False,
+                "result": {"error": f"unknown tool: {name}"},
+            }
+        arguments = message.get("arguments")
+        if not isinstance(arguments, dict):
+            return {
+                "type": "tool_result",
+                "id": request_id,
+                "ok": False,
+                "result": {"error": "tool arguments must be a JSON object"},
+            }
+        allowed = set(tool.schema.get("properties", {}))
+        required = set(tool.schema.get("required", []))
+        unknown = sorted(set(arguments) - allowed)
+        missing = sorted(required - set(arguments))
+        invalid = sorted(
+            key
+            for key, value in arguments.items()
+            if key in allowed
+            and not CyberPiHuntEngine._matches_schema(
+                value, tool.schema["properties"][key], tool.schema
+            )
+        )
+        if unknown:
+            result: Any = {"error": f"unknown arguments: {', '.join(unknown)}"}
+            ok = False
+        elif missing:
+            result = {"error": f"missing required arguments: {', '.join(missing)}"}
+            ok = False
+        elif invalid:
+            result = {"error": f"invalid argument types: {', '.join(invalid)}"}
+            ok = False
+        elif name == "write_file" and not CyberPiHuntEngine._is_scratch_path(arguments.get("path")):
+            result = {"error": "write_file is restricted to /scratch"}
+            ok = False
+        else:
+            try:
+                result = await tool.ainvoke(arguments)
+                ok = not (isinstance(result, dict) and "error" in result)
+            except Exception as exc:
+                result = {"error": f"{type(exc).__name__}: {exc}"}
+                ok = False
+        return {"type": "tool_result", "id": request_id, "ok": ok, "result": result}
+
+    @staticmethod
+    def _matches_schema(value: Any, schema: dict[str, Any], root: dict[str, Any]) -> bool:
+        reference = schema.get("$ref")
+        if isinstance(reference, str) and reference.startswith("#/$defs/"):
+            resolved = root.get("$defs", {}).get(reference.rsplit("/", 1)[-1])
+            return isinstance(resolved, dict) and CyberPiHuntEngine._matches_schema(
+                value, resolved, root
+            )
+        variants = schema.get("anyOf")
+        if isinstance(variants, list):
+            return any(
+                isinstance(variant, dict)
+                and CyberPiHuntEngine._matches_schema(value, variant, root)
+                for variant in variants
+            )
+        if "enum" in schema and value not in schema["enum"]:
+            return False
+        expected = schema.get("type")
+        if expected == "null":
+            return value is None
+        if expected == "string":
+            return isinstance(value, str)
+        if expected == "boolean":
+            return isinstance(value, bool)
+        if expected == "integer":
+            return isinstance(value, int) and not isinstance(value, bool)
+        if expected == "number":
+            return isinstance(value, (int, float)) and not isinstance(value, bool)
+        if expected == "array":
+            item_schema = schema.get("items")
+            return isinstance(value, list) and (
+                not isinstance(item_schema, dict)
+                or all(CyberPiHuntEngine._matches_schema(item, item_schema, root) for item in value)
+            )
+        if expected == "object":
+            return isinstance(value, dict)
+        return True
+
+    @staticmethod
+    def _is_scratch_path(value: Any) -> bool:
+        if not isinstance(value, str):
+            return False
+        path = PurePosixPath(value)
+        scratch = PurePosixPath("/scratch")
+        return (
+            path.is_absolute()
+            and ".." not in path.parts
+            and (path == scratch or scratch in path.parents)
+        )
+
+    @staticmethod
+    async def _write_message(writer: asyncio.StreamWriter, message: dict[str, Any]) -> None:
+        encoded = json.dumps(message, separators=(",", ":"), default=str, allow_nan=False).encode(
+            "utf-8"
+        )
+        if len(encoded) > _MAX_MESSAGE_BYTES:
+            raise CyberPiError("CyberPi message exceeds the protocol size limit")
+        writer.write(encoded + b"\n")
+        await writer.drain()
+
+    @staticmethod
+    async def _read_message(reader: asyncio.StreamReader) -> dict[str, Any]:
+        try:
+            line = await reader.readline()
+        except ValueError as exc:
+            raise CyberPiError("CyberPi message exceeds the protocol size limit") from exc
+        if not line:
+            raise CyberPiError("CyberPi sidecar closed before returning a result")
+        if len(line) > _MAX_MESSAGE_BYTES:
+            raise CyberPiError("CyberPi message exceeds the protocol size limit")
+        try:
+            message = json.loads(line, parse_constant=_reject_json_constant)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise CyberPiError("CyberPi sidecar emitted malformed JSON") from exc
+        if not isinstance(message, dict):
+            raise CyberPiError("CyberPi sidecar message must be a JSON object")
+        return message
+
+    @staticmethod
+    async def _drain_stderr(reader: asyncio.StreamReader) -> None:
+        while await reader.read(8192):
+            pass
+
+    @staticmethod
+    def _message_id(message: dict[str, Any], kind: str) -> str:
+        request_id = message.get("id")
+        if not isinstance(request_id, str) or not request_id:
+            raise CyberPiError(f"CyberPi {kind} is missing a valid id")
+        return request_id
+
+    @staticmethod
+    def _require_usage(value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise CyberPiError("CyberPi completed without measurable usage")
+        token_fields = ("input_tokens", "output_tokens", "total_tokens")
+        if any(
+            not isinstance(value.get(key), int) or isinstance(value.get(key), bool)
+            for key in token_fields
+        ):
+            raise CyberPiError("CyberPi completed without measurable usage")
+        cached = value.get("cached_input_tokens", 0)
+        cost = value.get("cost_usd")
+        if not isinstance(cached, int) or isinstance(cached, bool):
+            raise CyberPiError("CyberPi completed without measurable usage")
+        if not isinstance(cost, (int, float)) or isinstance(cost, bool):
+            raise CyberPiError("CyberPi completed without measurable usage")
+        if (
+            not math.isfinite(float(cost))
+            or any(int(value[key]) < 0 for key in token_fields)
+            or cached < 0
+            or float(cost) < 0
+        ):
+            raise CyberPiError("CyberPi returned invalid usage")
+        if cached > int(value["input_tokens"]) or int(value["total_tokens"]) != int(
+            value["input_tokens"]
+        ) + int(value["output_tokens"]):
+            raise CyberPiError("CyberPi returned invalid usage")
+        return value
+
+    @staticmethod
+    def _empty_usage() -> dict[str, Any]:
+        return {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached_input_tokens": 0,
+            "total_tokens": 0,
+            "cost_usd": 0.0,
+        }
+
+    @staticmethod
+    def _accumulate_usage(total: dict[str, Any], usage: dict[str, Any]) -> None:
+        total["input_tokens"] += int(usage["input_tokens"])
+        total["output_tokens"] += int(usage["output_tokens"])
+        total["cached_input_tokens"] += int(usage.get("cached_input_tokens") or 0)
+        total["total_tokens"] += int(usage["total_tokens"])
+
+    @staticmethod
+    def _stop_reason(message: dict[str, Any], max_turns: int) -> str:
+        reason = str(message.get("stop_reason") or "completed")
+        if reason not in {
+            "aborted",
+            "budget_exhausted",
+            "completed",
+            "length",
+            "max_steps",
+            "stop",
+        }:
+            raise CyberPiError(f"CyberPi completed with an invalid stop reason: {reason}")
+        turns = message.get("turns", 0)
+        if not isinstance(turns, int) or isinstance(turns, bool) or turns < 0:
+            raise CyberPiError("CyberPi completed with an invalid turn count")
+        if reason == "aborted" and turns >= max_turns:
+            return "max_steps"
+        return {"stop": "completed", "length": "max_steps"}.get(reason, reason)
+
+    @staticmethod
+    def _process_error(return_code: int) -> str:
+        return f"CyberPi sidecar exited with status {return_code}"
+
+    @staticmethod
+    def _authorize_model_call(
+        client: AsyncLLMClient,
+        message: dict[str, Any],
+    ) -> tuple[dict[str, Any], BudgetReservation | None]:
+        request_id = CyberPiHuntEngine._message_id(message, "model call")
+        input_bytes = message.get("input_bytes")
+        requested_max_tokens = message.get("max_tokens")
+        if (
+            not isinstance(input_bytes, int)
+            or isinstance(input_bytes, bool)
+            or input_bytes < 0
+            or input_bytes > _MAX_MESSAGE_BYTES
+        ):
+            raise CyberPiError("CyberPi model call has an invalid input size")
+        if (
+            not isinstance(requested_max_tokens, int)
+            or isinstance(requested_max_tokens, bool)
+            or requested_max_tokens < 1
+            or requested_max_tokens > 1_000_000
+        ):
+            raise CyberPiError("CyberPi model call has an invalid output limit")
+        ledger = client.spend_ledger
+        if ledger is None:
+            return {
+                "type": "model_authorization",
+                "id": request_id,
+                "max_tokens": requested_max_tokens,
+            }, None
+        reservation = ledger.reserve_call(
+            model=client.model_name,
+            provider=client.provider_name,
+            stage="hunt",
+            input_token_upper_bound=input_bytes + 512,
+            requested_max_output_tokens=requested_max_tokens,
+            supports_output_limit=True,
+            metadata=current_spend_metadata(),
+        )
+        return {
+            "type": "model_authorization",
+            "id": request_id,
+            "max_tokens": reservation.max_output_tokens
+            if ledger.enforcing
+            else requested_max_tokens,
+        }, reservation
+
+    @staticmethod
+    def _settle_model_call(
+        client: AsyncLLMClient,
+        active_reservations: dict[str, BudgetReservation],
+        active_calls: set[str],
+        message: dict[str, Any],
+        usage: dict[str, Any],
+        *,
+        succeeded: bool,
+    ) -> float:
+        request_id = CyberPiHuntEngine._message_id(message, "model result")
+        if request_id not in active_calls:
+            raise CyberPiError(f"CyberPi returned an unknown model call id: {request_id}")
+        ledger = client.spend_ledger
+        reservation = active_reservations.get(request_id)
+        if reservation is not None and ledger is not None:
+            if succeeded:
+                cost = ledger.settle_call(
+                    reservation,
+                    input_tokens=int(usage["input_tokens"]),
+                    output_tokens=int(usage["output_tokens"]),
+                    cached_input_tokens=int(usage.get("cached_input_tokens") or 0),
+                    provider_cost_usd=(None if ledger.enforcing else float(usage["cost_usd"])),
+                )
+            else:
+                ledger.fail_call(reservation, error="CyberPiProviderError")
+                cost = reservation.reserved_usd if ledger.enforcing else float(usage["cost_usd"])
+        elif ledger is not None:
+            raise CyberPiError(f"CyberPi lost the budget reservation for: {request_id}")
+        else:
+            cost = float(usage["cost_usd"])
+        active_calls.remove(request_id)
+        active_reservations.pop(request_id, None)
+        return float(cost)
+
+    @staticmethod
+    def _fail_active_reservations(
+        client: Any,
+        reservations: dict[str, BudgetReservation],
+        exc: BaseException,
+    ) -> None:
+        ledger = client.spend_ledger if isinstance(client, AsyncLLMClient) else None
+        if ledger is None:
+            return
+        for reservation in reservations.values():
+            ledger.fail_call(reservation, error=type(exc).__name__)
+        reservations.clear()
+
+
+__all__ = ["CyberPiError", "CyberPiHuntEngine", "CyberPiModel"]

--- a/clearwing/sourcehunt/cyberpi.py
+++ b/clearwing/sourcehunt/cyberpi.py
@@ -10,14 +10,14 @@ import os
 import tempfile
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from importlib.resources import files
 from pathlib import Path, PurePosixPath
 from typing import Any
 
-from clearwing.llm import AsyncLLMClient, NativeToolSpec
+from clearwing.llm import AsyncLLMClient, ChatMessage, NativeToolSpec
 from clearwing.llm.budget import BudgetReservation, current_spend_metadata
 
 from .hunt_engine import HuntAssignment, HuntOutcome
+from .hunter import HunterTrajectoryLogger
 
 logger = logging.getLogger(__name__)
 
@@ -63,8 +63,9 @@ class CyberPiHuntEngine:
 
     @staticmethod
     def default_command() -> tuple[str, ...]:
-        sidecar = files("clearwing.sourcehunt.cyberpi_sidecar").joinpath("index.mjs")
-        return (os.environ.get("CLEARWING_CYBERPI_NODE", "node"), str(sidecar))
+        from .cyberpi_runtime import CyberPiRuntime
+
+        return CyberPiRuntime().command()
 
     async def hunt(self, assignment: HuntAssignment, sandbox: Any) -> HuntOutcome:
         if sandbox is None:
@@ -75,6 +76,8 @@ class CyberPiHuntEngine:
         active_reservations: dict[str, BudgetReservation] = {}
         active_calls: set[str] = set()
         stderr_task: asyncio.Task[None] | None = None
+        trajectory: HunterTrajectoryLogger | None = None
+        trajectory_finished = False
         runtime_dir = tempfile.TemporaryDirectory(prefix="clearwing-cyberpi-")
         try:
             model = self._model_from_client(native_hunter.llm)
@@ -87,6 +90,15 @@ class CyberPiHuntEngine:
                     "CyberPi requires Clearwing's deep hunt tools; missing "
                     + ", ".join(sorted(missing_tools))
                 )
+            trajectory = HunterTrajectoryLogger.for_hunter(
+                context,
+                prompt=native_hunter.prompt,
+                initial_messages=[
+                    ChatMessage("user", self._initial_user_message(native_hunter, assignment))
+                ],
+                tools=tools,
+                engine="cyberpi",
+            )
             process = await self._start_process(model.api_key, cwd=runtime_dir.name)
             assert process.stdin is not None
             assert process.stdout is not None
@@ -114,7 +126,7 @@ class CyberPiHuntEngine:
                         "temperature": 1.0,
                         "top_p": 0.95,
                         "cost": model.cost,
-                        "max_output_tokens": self._max_output_tokens(native_hunter.llm),
+                        "max_output_tokens": self._max_output_tokens(native_hunter),
                     },
                     "system_prompt": native_hunter.prompt,
                     "user_message": self._initial_user_message(native_hunter, assignment),
@@ -130,7 +142,9 @@ class CyberPiHuntEngine:
                 process=process,
                 active_reservations=active_reservations,
                 active_calls=active_calls,
+                trajectory=trajectory,
             )
+            trajectory_finished = True
 
             try:
                 process.stdin.close()
@@ -145,6 +159,18 @@ class CyberPiHuntEngine:
             return outcome
         except BaseException as exc:
             self._fail_active_reservations(native_hunter.llm, active_reservations, exc)
+            if trajectory is not None and not trajectory_finished:
+                trajectory.log(
+                    "finish",
+                    {
+                        "step": 0,
+                        "status": "error",
+                        "error_type": type(exc).__name__,
+                        "findings": [
+                            self._serialize_finding(finding) for finding in context.findings
+                        ],
+                    },
+                )
             raise
         finally:
             if process is not None and process.returncode is None:
@@ -170,18 +196,52 @@ class CyberPiHuntEngine:
         process: asyncio.subprocess.Process,
         active_reservations: dict[str, BudgetReservation],
         active_calls: set[str],
+        trajectory: HunterTrajectoryLogger,
     ) -> HuntOutcome:
         assert process.stdin is not None
         assert process.stdout is not None
 
         usage = self._empty_usage()
+        step = 0
         while True:
             message = await self._read_message(process.stdout)
             message_type = message.get("type")
             if message_type == "tool_call":
-                await self._write_message(process.stdin, await self._invoke_tool(tools, message))
+                tool_call = self._trajectory_tool_call(message)
+                trajectory.log("tool_call", {"step": step, "tool_call": tool_call})
+                result = await self._invoke_tool(tools, message)
+                tool_output = result.get("result")
+                tool_summary = (
+                    tool_output
+                    if isinstance(tool_output, str)
+                    else json.dumps(tool_output, sort_keys=True, default=str)
+                )
+                trajectory.log(
+                    "tool_result",
+                    {
+                        "step": step,
+                        "tool_call": tool_call,
+                        "tool_output": tool_output,
+                        "tool_summary": tool_summary,
+                        "repeated_skip": False,
+                    },
+                )
+                trajectory.log(
+                    "message",
+                    {
+                        "step": step,
+                        "message": {
+                            "role": "tool",
+                            "content": tool_summary,
+                            "tool_calls": [],
+                            "tool_response_call_id": tool_call["call_id"],
+                        },
+                    },
+                )
+                await self._write_message(process.stdin, result)
                 continue
             if message_type == "model_call":
+                step += 1
                 request_id = self._message_id(message, "model call")
                 if request_id in active_calls:
                     raise CyberPiError(f"Duplicate CyberPi model call id: {request_id}")
@@ -217,6 +277,9 @@ class CyberPiHuntEngine:
                     detail = str(message.get("error") or "provider request failed")
                     raise CyberPiError(f"CyberPi model call failed: {detail[:2000]}")
                 continue
+            if message_type == "trajectory":
+                self._log_assistant_trajectory(trajectory, message, step)
+                continue
             if message_type == "complete":
                 if active_calls:
                     raise CyberPiError("CyberPi completed with an unsettled model call")
@@ -227,12 +290,24 @@ class CyberPiHuntEngine:
                     or model_calls < 1
                 ):
                     raise CyberPiError("CyberPi completed without a model call")
-                return HuntOutcome(
+                outcome = HuntOutcome(
                     findings=tuple(context.findings),
                     cost_usd=float(usage["cost_usd"]),
                     tokens_used=int(usage["total_tokens"]),
                     stop_reason=self._stop_reason(message, native_hunter.max_steps),
                 )
+                trajectory.log(
+                    "finish",
+                    {
+                        "step": step,
+                        "status": outcome.stop_reason,
+                        "findings": [self._serialize_finding(finding) for finding in context.findings],
+                        "total_input_tokens": int(usage["input_tokens"]),
+                        "total_output_tokens": int(usage["output_tokens"]),
+                        "total_cost_usd": float(usage["cost_usd"]),
+                    },
+                )
+                return outcome
             if message_type == "error":
                 detail = str(message.get("message") or "CyberPi sidecar failed")
                 raise CyberPiError(detail[:2000])
@@ -270,8 +345,8 @@ class CyberPiHuntEngine:
             )
         except FileNotFoundError as exc:
             raise CyberPiError(
-                "CyberPi runtime is not installed. Run `npm ci --omit=dev` in "
-                "clearwing/sourcehunt/cyberpi_sidecar."
+                "CyberPi runtime is not available. Run `clearwing cyberpi install`, "
+                "then verify it with `clearwing cyberpi doctor`."
             ) from exc
 
     def _check_runtime_installed(self) -> None:
@@ -280,9 +355,16 @@ class CyberPiHuntEngine:
         package_dir = Path(self._command[1]).parent
         dependency = package_dir / "node_modules" / "@earendil-works" / "pi-coding-agent"
         if dependency.is_dir():
+            from .cyberpi_runtime import CyberPiRuntime, CyberPiRuntimeError
+
+            try:
+                CyberPiRuntime(runtime_dir=package_dir).require_ready(include_docker=False)
+            except CyberPiRuntimeError as exc:
+                raise CyberPiError(str(exc)) from exc
             return
         raise CyberPiError(
-            f"CyberPi runtime is not installed. Run `npm ci --omit=dev` in {package_dir}."
+            "CyberPi runtime is not installed. Run `clearwing cyberpi install`, "
+            "then verify it with `clearwing cyberpi doctor`."
         )
 
     @staticmethod
@@ -362,11 +444,14 @@ class CyberPiHuntEngine:
         )
 
     @staticmethod
-    def _max_output_tokens(client: AsyncLLMClient) -> int | None:
+    def _max_output_tokens(native_hunter: Any) -> int:
+        client = native_hunter.llm
+        requested = getattr(native_hunter, "max_output_tokens", None)
         ledger = client.spend_ledger
         if ledger is not None and ledger.enforcing:
-            return int(ledger.default_max_output_tokens)
-        return None
+            ledger_cap = int(ledger.default_max_output_tokens)
+            return min(ledger_cap, requested) if requested else ledger_cap
+        return int(requested or 8192)
 
     @staticmethod
     def _initial_user_message(native_hunter: Any, assignment: HuntAssignment) -> str:
@@ -486,6 +571,66 @@ class CyberPiHuntEngine:
             and ".." not in path.parts
             and (path == scratch or scratch in path.parents)
         )
+
+    @staticmethod
+    def _trajectory_tool_call(message: dict[str, Any]) -> dict[str, Any]:
+        request_id = CyberPiHuntEngine._message_id(message, "tool call")
+        name = message.get("name")
+        if not isinstance(name, str) or not name:
+            raise CyberPiError("CyberPi tool call is missing a valid name")
+        arguments = message.get("arguments")
+        return {
+            "call_id": request_id,
+            "fn_name": name,
+            "fn_arguments": arguments,
+            "fn_arguments_json": json.dumps(arguments, sort_keys=True, default=str),
+        }
+
+    @staticmethod
+    def _log_assistant_trajectory(
+        trajectory: HunterTrajectoryLogger,
+        message: dict[str, Any],
+        current_step: int,
+    ) -> None:
+        step = message.get("step")
+        assistant = message.get("message")
+        reasoning = message.get("reasoning_content", "")
+        usage = message.get("usage")
+        model = message.get("model")
+        if (
+            not isinstance(step, int)
+            or isinstance(step, bool)
+            or step < 1
+            or step > current_step
+            or not isinstance(assistant, dict)
+            or assistant.get("role") != "assistant"
+            or not isinstance(reasoning, str)
+            or not isinstance(usage, dict)
+            or not isinstance(model, str)
+        ):
+            raise CyberPiError("CyberPi emitted an invalid trajectory event")
+        trajectory.log(
+            "message",
+            {
+                "step": step,
+                "message": assistant,
+                "reasoning_content": reasoning,
+                "usage": usage,
+                "model": model,
+            },
+        )
+
+    @staticmethod
+    def _serialize_finding(finding: Any) -> dict[str, Any]:
+        return {
+            "id": finding.get("id"),
+            "file": finding.get("file"),
+            "line_number": finding.get("line_number"),
+            "severity": finding.get("severity"),
+            "cwe": finding.get("cwe"),
+            "description": finding.get("description"),
+            "evidence_level": finding.get("evidence_level"),
+        }
 
     @staticmethod
     async def _write_message(writer: asyncio.StreamWriter, message: dict[str, Any]) -> None:

--- a/clearwing/sourcehunt/cyberpi_runtime.py
+++ b/clearwing/sourcehunt/cyberpi_runtime.py
@@ -1,0 +1,374 @@
+"""Installation and preflight for Clearwing's pinned CyberPi sidecar."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass
+from importlib.resources import files
+from pathlib import Path
+from typing import Literal
+from uuid import uuid4
+
+from clearwing.core.config import clearwing_home
+
+PI_VERSION = "0.84.1"
+RUNTIME_VERSION = f"pi-{PI_VERSION}"
+MINIMUM_NODE = (22, 19, 0)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeCheck:
+    """One actionable CyberPi environment check."""
+
+    name: str
+    status: Literal["ok", "warn", "error"]
+    detail: str
+    remedy: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeStatus:
+    """CyberPi runtime state, independent of terminal rendering."""
+
+    runtime_dir: Path
+    command: tuple[str, ...]
+    checks: tuple[RuntimeCheck, ...]
+
+    @property
+    def ready(self) -> bool:
+        return all(check.status != "error" for check in self.checks)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ready": self.ready,
+            "runtime_dir": str(self.runtime_dir),
+            "command": list(self.command),
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+
+class CyberPiRuntimeError(RuntimeError):
+    """Raised when the managed CyberPi runtime is unavailable or invalid."""
+
+
+class CyberPiRuntime:
+    """Own the single pinned Pi runtime used by the CyberPi adapter.
+
+    Package resources stay immutable. ``install`` copies the small sidecar and
+    lockfile into Clearwing's user data directory, lets npm materialize the
+    exact locked dependencies there, and atomically promotes the completed
+    directory.
+    """
+
+    def __init__(self, runtime_dir: str | Path | None = None) -> None:
+        configured = os.environ.get("CLEARWING_CYBERPI_HOME")
+        self.runtime_dir = Path(
+            runtime_dir or configured or (clearwing_home() / "cyberpi" / RUNTIME_VERSION)
+        ).expanduser()
+
+    @property
+    def entrypoint(self) -> Path:
+        return self.runtime_dir / "index.mjs"
+
+    @property
+    def package_json(self) -> Path:
+        return self.runtime_dir / "package.json"
+
+    @property
+    def dependency_dir(self) -> Path:
+        return self.runtime_dir / "node_modules" / "@earendil-works" / "pi-coding-agent"
+
+    @property
+    def node(self) -> str:
+        return os.environ.get("CLEARWING_CYBERPI_NODE", "node")
+
+    def command(self) -> tuple[str, ...]:
+        """Resolve a runnable sidecar, preferring the managed installation."""
+
+        if self._runtime_files_ready(self.runtime_dir):
+            return (self.node, str(self.entrypoint))
+        packaged = self._packaged_dir()
+        if self._runtime_files_ready(packaged):
+            return (self.node, str(packaged / "index.mjs"))
+        return (self.node, str(self.entrypoint))
+
+    def inspect(self, *, include_docker: bool = True) -> RuntimeStatus:
+        """Inspect prerequisites without changing the environment."""
+
+        command = self.command()
+        checks = [self._node_check(), self._npm_check()]
+        runtime_path = Path(command[1])
+        package_dir = runtime_path.parent
+        if runtime_path.is_file():
+            checks.append(RuntimeCheck("Sidecar", "ok", str(runtime_path)))
+        else:
+            checks.append(
+                RuntimeCheck(
+                    "Sidecar",
+                    "error",
+                    f"not installed at {runtime_path}",
+                    "Run `clearwing cyberpi install`.",
+                )
+            )
+        dependency = package_dir / "node_modules" / "@earendil-works" / "pi-coding-agent"
+        installed_version = self._installed_pi_version(dependency)
+        if installed_version == PI_VERSION:
+            checks.append(RuntimeCheck("Pi SDK", "ok", f"{installed_version} (pinned)"))
+        elif installed_version:
+            checks.append(
+                RuntimeCheck(
+                    "Pi SDK",
+                    "error",
+                    f"found {installed_version}; expected {PI_VERSION}",
+                    "Run `clearwing cyberpi install --force`.",
+                )
+            )
+        else:
+            checks.append(
+                RuntimeCheck(
+                    "Pi SDK",
+                    "error",
+                    "locked dependencies are not installed",
+                    "Run `clearwing cyberpi install`.",
+                )
+            )
+        if include_docker:
+            checks.append(self._docker_check())
+        return RuntimeStatus(self.runtime_dir, command, tuple(checks))
+
+    def require_ready(self, *, include_docker: bool = False) -> tuple[str, ...]:
+        """Return the resolved command or raise one concise actionable error."""
+
+        status = self.inspect(include_docker=include_docker)
+        errors = [
+            check
+            for check in status.checks
+            if check.status == "error"
+            or (include_docker and check.name == "Docker" and check.status != "ok")
+        ]
+        if errors:
+            detail = "; ".join(f"{check.name}: {check.detail}" for check in errors)
+            remedies = list(dict.fromkeys(check.remedy for check in errors if check.remedy))
+            suffix = f" {' '.join(remedies)}" if remedies else ""
+            raise CyberPiRuntimeError(f"CyberPi preflight failed: {detail}.{suffix}")
+        return status.command
+
+    def install(self, *, force: bool = False) -> Path:
+        """Install the exact lockfile into Clearwing's managed runtime directory."""
+
+        self._validate_install_target()
+        node_check = self._node_check()
+        npm_check = self._npm_check(required=True)
+        prerequisite_errors = [
+            check for check in (node_check, npm_check) if check.status == "error"
+        ]
+        if prerequisite_errors:
+            raise CyberPiRuntimeError(
+                "CyberPi install failed: "
+                + "; ".join(f"{check.name}: {check.detail}" for check in prerequisite_errors)
+            )
+        if not force and self._runtime_files_ready(self.runtime_dir):
+            return self.runtime_dir
+
+        self.runtime_dir.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.TemporaryDirectory(
+            prefix=f".{RUNTIME_VERSION}-", dir=self.runtime_dir.parent
+        ) as temporary:
+            staging = Path(temporary) / RUNTIME_VERSION
+            staging.mkdir()
+            packaged = self._packaged_dir()
+            for name in ("index.mjs", "package.json", "package-lock.json"):
+                shutil.copyfile(packaged / name, staging / name)
+            try:
+                result = subprocess.run(
+                    [
+                        shutil.which("npm") or "npm",
+                        "ci",
+                        "--omit=dev",
+                        "--ignore-scripts",
+                        "--no-audit",
+                        "--no-fund",
+                    ],
+                    cwd=staging,
+                    capture_output=True,
+                    text=True,
+                    timeout=300,
+                    check=False,
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                raise CyberPiRuntimeError(f"CyberPi install failed: {exc}") from exc
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout or "npm ci failed").strip()[-2000:]
+                raise CyberPiRuntimeError(f"CyberPi install failed: {detail}")
+            if self._installed_pi_version(
+                staging / "node_modules" / "@earendil-works" / "pi-coding-agent"
+            ) != PI_VERSION:
+                raise CyberPiRuntimeError(
+                    f"CyberPi install did not produce the pinned Pi SDK {PI_VERSION}"
+                )
+            previous = self.runtime_dir.with_name(
+                f".{self.runtime_dir.name}-previous-{uuid4().hex[:8]}"
+            )
+            if self.runtime_dir.exists():
+                self.runtime_dir.replace(previous)
+            try:
+                staging.replace(self.runtime_dir)
+            except BaseException:
+                if previous.exists() and not self.runtime_dir.exists():
+                    previous.replace(self.runtime_dir)
+                raise
+            if previous.exists():
+                shutil.rmtree(previous)
+        return self.runtime_dir
+
+    def _validate_install_target(self) -> None:
+        resolved = self.runtime_dir.resolve()
+        forbidden = {Path(resolved.anchor), Path.home().resolve(), clearwing_home().resolve()}
+        if resolved in forbidden:
+            raise CyberPiRuntimeError(f"Refusing unsafe CyberPi runtime directory: {resolved}")
+        if resolved.exists() and not resolved.is_dir():
+            raise CyberPiRuntimeError(f"CyberPi runtime path is not a directory: {resolved}")
+        if resolved.exists() and any(resolved.iterdir()) and not self._owns_runtime_dir(resolved):
+            raise CyberPiRuntimeError(
+                f"Refusing to replace unrecognized directory: {resolved}. "
+                "Choose an empty CLEARWING_CYBERPI_HOME."
+            )
+
+    @staticmethod
+    def _owns_runtime_dir(directory: Path) -> bool:
+        try:
+            payload = json.loads((directory / "package.json").read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return False
+        return isinstance(payload, dict) and payload.get("name") == "@clearwing/cyberpi-sidecar"
+
+    @staticmethod
+    def _packaged_dir() -> Path:
+        return Path(str(files("clearwing.sourcehunt.cyberpi_sidecar")))
+
+    @staticmethod
+    def _installed_pi_version(dependency: Path) -> str | None:
+        try:
+            payload = json.loads((dependency / "package.json").read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return None
+        version = payload.get("version") if isinstance(payload, dict) else None
+        return version if isinstance(version, str) else None
+
+    @classmethod
+    def _runtime_files_ready(cls, directory: Path) -> bool:
+        dependency = directory / "node_modules" / "@earendil-works" / "pi-coding-agent"
+        return (directory / "index.mjs").is_file() and cls._installed_pi_version(
+            dependency
+        ) == PI_VERSION
+
+    def _node_check(self) -> RuntimeCheck:
+        executable = shutil.which(self.node)
+        if not executable:
+            return RuntimeCheck(
+                "Node.js",
+                "error",
+                f"{self.node!r} is not on PATH",
+                "Install Node.js 22.19 or newer.",
+            )
+        try:
+            result = subprocess.run(
+                [executable, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return RuntimeCheck("Node.js", "error", str(exc), "Check the Node.js installation.")
+        raw = result.stdout.strip()
+        match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?", raw)
+        if result.returncode != 0 or match is None:
+            return RuntimeCheck(
+                "Node.js", "error", raw or "could not read version", "Reinstall Node.js."
+            )
+        version = tuple(int(part) for part in match.groups())
+        if version < MINIMUM_NODE:
+            return RuntimeCheck(
+                "Node.js",
+                "error",
+                f"{raw}; requires >=22.19.0",
+                "Upgrade Node.js, then rerun `clearwing cyberpi install`.",
+            )
+        return RuntimeCheck("Node.js", "ok", f"{raw} at {executable}")
+
+    @staticmethod
+    def _npm_check(*, required: bool = False) -> RuntimeCheck:
+        executable = shutil.which("npm")
+        if not executable:
+            return RuntimeCheck(
+                "npm",
+                "error" if required else "warn",
+                "not on PATH; only required to install/update CyberPi",
+                "Install npm before running `clearwing cyberpi install`.",
+            )
+        try:
+            result = subprocess.run(
+                [executable, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return RuntimeCheck("npm", "error", str(exc), "Check the npm installation.")
+        if result.returncode != 0:
+            return RuntimeCheck("npm", "error", "could not read version", "Reinstall npm.")
+        return RuntimeCheck("npm", "ok", f"{result.stdout.strip()} at {executable}")
+
+    @staticmethod
+    def _docker_check() -> RuntimeCheck:
+        if not shutil.which("docker"):
+            return RuntimeCheck(
+                "Docker",
+                "warn",
+                "CLI not found; smoke/benchmark still work, Sourcehunt does not",
+                "Install and start Docker before a repository hunt.",
+            )
+        try:
+            result = subprocess.run(
+                ["docker", "info", "--format", "{{.ServerVersion}}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return RuntimeCheck(
+                "Docker",
+                "warn",
+                str(exc),
+                "Start Docker before a repository hunt.",
+            )
+        if result.returncode != 0:
+            return RuntimeCheck(
+                "Docker",
+                "warn",
+                "CLI is installed but the daemon is unavailable",
+                "Start Docker before a repository hunt.",
+            )
+        return RuntimeCheck("Docker", "ok", f"daemon {result.stdout.strip()}")
+
+
+__all__ = [
+    "CyberPiRuntime",
+    "CyberPiRuntimeError",
+    "MINIMUM_NODE",
+    "PI_VERSION",
+    "RUNTIME_VERSION",
+    "RuntimeCheck",
+    "RuntimeStatus",
+]

--- a/clearwing/sourcehunt/cyberpi_sidecar/__init__.py
+++ b/clearwing/sourcehunt/cyberpi_sidecar/__init__.py
@@ -1,0 +1,1 @@
+"""Package resources for the optional CyberPi Node sidecar."""

--- a/clearwing/sourcehunt/cyberpi_sidecar/index.mjs
+++ b/clearwing/sourcehunt/cyberpi_sidecar/index.mjs
@@ -144,6 +144,44 @@ function errorMessage(model, error) {
   };
 }
 
+function trajectoryMessage(message) {
+  const content = Array.isArray(message.content) ? message.content : [];
+  const text = content
+    .filter((part) => part?.type === "text")
+    .map((part) => String(part.text || ""))
+    .join("");
+  const reasoning = content
+    .filter((part) => part?.type === "thinking")
+    .map((part) => String(part.thinking || ""))
+    .join("");
+  const toolCalls = content
+    .filter((part) => part?.type === "toolCall")
+    .map((part) => ({
+      call_id: String(part.id || ""),
+      fn_name: String(part.name || ""),
+      fn_arguments: part.arguments || {},
+      fn_arguments_json: JSON.stringify(part.arguments || {}),
+    }));
+  return {
+    message: {
+      role: "assistant",
+      content: text,
+      tool_calls: toolCalls,
+      tool_response_call_id: null,
+    },
+    reasoning_content: reasoning,
+    usage: {
+      input_tokens:
+        Number(message.usage?.input || 0) +
+        Number(message.usage?.cacheRead || 0) +
+        Number(message.usage?.cacheWrite || 0),
+      output_tokens: Number(message.usage?.output || 0),
+      total_tokens: Number(message.usage?.totalTokens || 0),
+    },
+    model: String(message.model || ""),
+  };
+}
+
 function meteredStream(originalStream, protocol, request, meter) {
   return async (model, context, options = {}) => {
     const id = randomUUID();
@@ -289,6 +327,7 @@ async function run() {
       if (event.type !== "message_end" || event.message?.role !== "assistant") return;
       turns += 1;
       lastStopReason = event.message.stopReason || lastStopReason;
+      send({ type: "trajectory", step: turns, ...trajectoryMessage(event.message) });
     });
 
     const originalStream = session.agent.streamFunction;

--- a/clearwing/sourcehunt/cyberpi_sidecar/index.mjs
+++ b/clearwing/sourcehunt/cyberpi_sidecar/index.mjs
@@ -1,0 +1,328 @@
+import readline from "node:readline";
+import { randomUUID } from "node:crypto";
+import process from "node:process";
+
+import {
+  createAssistantMessageEventStream,
+  InMemoryCredentialStore,
+  Type,
+} from "@earendil-works/pi-ai";
+import {
+  createAgentSession,
+  createExtensionRuntime,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+const PROTOCOL_VERSION = 1;
+const MAX_MESSAGE_BYTES = 10 * 1024 * 1024;
+let protocolSecret = "";
+
+function safeMessage(value) {
+  let message = value instanceof Error ? value.message : String(value);
+  if (protocolSecret) message = message.split(protocolSecret).join("[REDACTED]");
+  return message.slice(0, 2000);
+}
+
+function send(message) {
+  const encoded = JSON.stringify(message);
+  if (Buffer.byteLength(encoded, "utf8") > MAX_MESSAGE_BYTES) {
+    throw new Error("CyberPi protocol message exceeds the size limit");
+  }
+  process.stdout.write(`${encoded}\n`);
+}
+
+function fail(message) {
+  send({ type: "error", message: safeMessage(message) });
+}
+
+function readMessages() {
+  const input = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+  const iterator = input[Symbol.asyncIterator]();
+  return {
+    input,
+    async next() {
+      const item = await iterator.next();
+      if (item.done) throw new Error("Clearwing closed the CyberPi protocol");
+      if (Buffer.byteLength(item.value, "utf8") > MAX_MESSAGE_BYTES) {
+        throw new Error("CyberPi protocol message exceeds the size limit");
+      }
+      const value = JSON.parse(item.value);
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("CyberPi protocol messages must be JSON objects");
+      }
+      return value;
+    },
+  };
+}
+
+function resourceLoader(systemPrompt) {
+  return {
+    getExtensions: () => ({ extensions: [], errors: [], runtime: createExtensionRuntime() }),
+    getSkills: () => ({ skills: [], diagnostics: [] }),
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: [] }),
+    getSystemPrompt: () => systemPrompt,
+    getSystemPromptSource: () => undefined,
+    getAppendSystemPrompt: () => [],
+    getAppendSystemPromptSources: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  };
+}
+
+function customTools(definitions, protocol) {
+  return definitions.map((definition) => ({
+    name: definition.name,
+    label: definition.name,
+    description: definition.description,
+    parameters: Type.Unsafe(definition.schema),
+    executionMode: "sequential",
+    async execute(toolCallId, params) {
+      send({ type: "tool_call", id: toolCallId, name: definition.name, arguments: params });
+      const response = await protocol.next();
+      if (response.type !== "tool_result" || response.id !== toolCallId) {
+        throw new Error(`Unexpected Clearwing tool response for ${toolCallId}`);
+      }
+      const text =
+        typeof response.result === "string" ? response.result : JSON.stringify(response.result ?? null);
+      if (response.ok !== true) throw new Error(text);
+      return {
+        content: [{ type: "text", text }],
+        details: response.result,
+      };
+    },
+  }));
+}
+
+function usageAccumulator() {
+  const totals = {
+    input_tokens: 0,
+    output_tokens: 0,
+    cached_input_tokens: 0,
+    total_tokens: 0,
+    cost_usd: 0,
+  };
+  return {
+    totals,
+    calls: 0,
+    error: undefined,
+    add(message) {
+      if (message?.role !== "assistant" || !message.usage) return;
+      totals.input_tokens +=
+        Number(message.usage.input || 0) +
+        Number(message.usage.cacheRead || 0) +
+        Number(message.usage.cacheWrite || 0);
+      totals.output_tokens += Number(message.usage.output || 0);
+      totals.cached_input_tokens += Number(message.usage.cacheRead || 0);
+      totals.total_tokens += Number(message.usage.totalTokens || 0);
+      totals.cost_usd += Number(message.usage.cost?.total || 0);
+    },
+  };
+}
+
+function errorMessage(model, error) {
+  return {
+    role: "assistant",
+    content: [],
+    api: model.api,
+    provider: model.provider,
+    model: model.id,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "error",
+    errorMessage: safeMessage(error),
+    timestamp: Date.now(),
+  };
+}
+
+function meteredStream(originalStream, protocol, request, meter) {
+  return async (model, context, options = {}) => {
+    const id = randomUUID();
+    const clearwingMaxTokens = Number(request.model.max_output_tokens);
+    const requestedMaxTokens = Math.min(
+      Number(options.maxTokens || model.maxTokens),
+      Number.isInteger(clearwingMaxTokens) && clearwingMaxTokens > 0
+        ? clearwingMaxTokens
+        : Number.POSITIVE_INFINITY,
+    );
+    send({
+      type: "model_call",
+      id,
+      input_bytes: Buffer.byteLength(JSON.stringify(context), "utf8"),
+      max_tokens: requestedMaxTokens,
+    });
+    const authorization = await protocol.next();
+    if (authorization.type !== "model_authorization" || authorization.id !== id) {
+      throw new Error(`Unexpected Clearwing model authorization for ${id}`);
+    }
+    if (!Number.isInteger(authorization.max_tokens) || authorization.max_tokens < 1) {
+      throw new Error(`Invalid Clearwing output limit for ${id}`);
+    }
+    meter.calls += 1;
+    const upstream = await originalStream(model, context, {
+      ...options,
+      temperature: request.model.temperature,
+      samplingParams: { ...options.samplingParams, top_p: request.model.top_p },
+      maxTokens: authorization.max_tokens,
+    });
+    const output = createAssistantMessageEventStream();
+    void (async () => {
+      let finalized = false;
+      for await (const event of upstream) {
+        if (event.type === "done" || event.type === "error") {
+          finalized = true;
+          const message = event.type === "done" ? event.message : event.error;
+          meter.add(message);
+          send({
+            type: "model_result",
+            id,
+            ok: event.type === "done",
+            error:
+              event.type === "error"
+                ? safeMessage(message.errorMessage || message.stopReason)
+                : undefined,
+            usage: {
+              input_tokens:
+                Number(message.usage?.input || 0) +
+                Number(message.usage?.cacheRead || 0) +
+                Number(message.usage?.cacheWrite || 0),
+              output_tokens: Number(message.usage?.output || 0),
+              cached_input_tokens: Number(message.usage?.cacheRead || 0),
+              total_tokens: Number(message.usage?.totalTokens || 0),
+              cost_usd: Number(message.usage?.cost?.total || 0),
+            },
+          });
+          const acknowledgment = await protocol.next();
+          if (acknowledgment.type !== "model_result_ack" || acknowledgment.id !== id) {
+            throw new Error(`Unexpected Clearwing model-result acknowledgment for ${id}`);
+          }
+        }
+        output.push(event);
+      }
+      if (!finalized) throw new Error("Pi provider stream ended without a result");
+    })().catch((error) => {
+      meter.error = error;
+      output.push({ type: "error", reason: "error", error: errorMessage(model, error) });
+    });
+    return output;
+  };
+}
+
+async function run() {
+  const protocol = readMessages();
+  let session;
+  try {
+    const request = await protocol.next();
+    if (request.type !== "start" || request.protocol !== PROTOCOL_VERSION) {
+      throw new Error("Unsupported CyberPi protocol");
+    }
+    const apiKey = process.env.CLEARWING_CYBERPI_API_KEY;
+    delete process.env.CLEARWING_CYBERPI_API_KEY;
+    if (!apiKey) throw new Error("CyberPi API key was not provided");
+    protocolSecret = apiKey;
+
+    const credentials = new InMemoryCredentialStore();
+    await credentials.modify(request.model.provider, async () => ({ type: "api_key", key: apiKey }));
+    const modelRuntime = await ModelRuntime.create({
+      credentials,
+      modelsPath: null,
+      refreshOnCreate: false,
+    });
+    const exactModel = modelRuntime.getModel(request.model.provider, request.model.id);
+    const registered = exactModel || modelRuntime.getModels(request.model.provider)[0];
+    if (!registered) throw new Error(`Unknown Pi model ${request.model.provider}/${request.model.id}`);
+    const model = {
+      ...registered,
+      id: request.model.id,
+      name: request.model.id,
+      api: request.model.api,
+      baseUrl: request.model.base_url,
+      reasoning: exactModel ? registered.reasoning : request.model.reasoning,
+      thinkingLevelMap:
+        exactModel || !request.model.id.toLowerCase().includes("deepseek-v4")
+          ? registered.thinkingLevelMap
+          : {
+              minimal: null,
+              low: request.model.id.toLowerCase().includes("flash") ? "low" : null,
+              medium: null,
+              high: "high",
+              xhigh: null,
+              max: "max",
+            },
+      samplingParams: { ...registered.samplingParams, top_p: request.model.top_p },
+      cost: Object.keys(request.model.cost || {}).length > 0 ? request.model.cost : registered.cost,
+    };
+
+    const settingsManager = SettingsManager.inMemory({
+      compaction: { enabled: false },
+      retry: { enabled: false, maxRetries: 0, provider: { maxRetries: 0 } },
+    });
+    const tools = customTools(request.tools, protocol);
+    const runtimeCwd = process.cwd();
+    ({ session } = await createAgentSession({
+      cwd: runtimeCwd,
+      agentDir: runtimeCwd,
+      model,
+      thinkingLevel: model.reasoning ? request.model.thinking_level : "off",
+      modelRuntime,
+      resourceLoader: resourceLoader(request.system_prompt),
+      noTools: "builtin",
+      tools: tools.map((tool) => tool.name),
+      customTools: tools,
+      sessionManager: SessionManager.inMemory(runtimeCwd),
+      settingsManager,
+    }));
+
+    const meter = usageAccumulator();
+    let turns = 0;
+    let lastStopReason = "stop";
+    session.subscribe((event) => {
+      if (event.type !== "message_end" || event.message?.role !== "assistant") return;
+      turns += 1;
+      lastStopReason = event.message.stopReason || lastStopReason;
+    });
+
+    const originalStream = session.agent.streamFunction;
+    session.agent.streamFunction = meteredStream(originalStream, protocol, request, meter);
+    let enforcedStopReason;
+    session.agent.shouldStopAfterTurn = () => {
+      if (turns >= request.max_turns) enforcedStopReason = "max_steps";
+      else if (
+        request.assignment.budget_usd > 0 &&
+        meter.totals.cost_usd >= request.assignment.budget_usd * 0.9
+      ) {
+        enforcedStopReason = "budget_exhausted";
+      }
+      return enforcedStopReason !== undefined;
+    };
+
+    await session.prompt(request.user_message, { expandPromptTemplates: false });
+    if (meter.error) throw meter.error;
+    if (lastStopReason === "error" || lastStopReason === "aborted") {
+      throw new Error(`CyberPi model stopped with reason: ${lastStopReason}`);
+    }
+    send({
+      type: "complete",
+      stop_reason: enforcedStopReason || lastStopReason,
+      turns,
+      model_calls: meter.calls,
+    });
+  } finally {
+    session?.dispose();
+    protocol.input.close();
+  }
+}
+
+run().catch((error) => {
+  fail(error);
+  process.exitCode = 1;
+});

--- a/clearwing/sourcehunt/cyberpi_sidecar/package-lock.json
+++ b/clearwing/sourcehunt/cyberpi_sidecar/package-lock.json
@@ -1,0 +1,3094 @@
+{
+  "name": "@clearwing/cyberpi-sidecar",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@clearwing/cyberpi-sidecar",
+      "version": "0.1.0",
+      "dependencies": {
+        "@earendil-works/pi-ai": "0.84.1",
+        "@earendil-works/pi-coding-agent": "0.84.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+      "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/xml-builder": "^3.972.38",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+      "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+      "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz",
+      "integrity": "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+      "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-login": "^3.972.75",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+      "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.79",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+      "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-ini": "^3.973.13",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+      "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+      "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/token-providers": "3.1108.0",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+      "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+      "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.32.tgz",
+      "integrity": "sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.27.tgz",
+      "integrity": "sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.50.tgz",
+      "integrity": "sha512-gdcWRbmIf1dWA/prf44Bnnzgqj+AbsXX2yfhZhOQLwSm7NfKIYPmkRlPqP0CTepHzjxMIBdWBDdtQB+Y/dFUeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+      "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz",
+      "integrity": "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+      "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.9.tgz",
+      "integrity": "sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+      "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
+      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-client": "^0.84.1",
+        "@earendil-works/pi-protocol": "^0.84.1",
+        "@earendil-works/pi-tui": "^0.84.1",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.1",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.33.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.0.tgz",
+      "integrity": "sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/clearwing/sourcehunt/cyberpi_sidecar/package.json
+++ b/clearwing/sourcehunt/cyberpi_sidecar/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@clearwing/cyberpi-sidecar",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.19.0"
+  },
+  "dependencies": {
+    "@earendil-works/pi-ai": "0.84.1",
+    "@earendil-works/pi-coding-agent": "0.84.1"
+  }
+}

--- a/clearwing/sourcehunt/hunt_engine.py
+++ b/clearwing/sourcehunt/hunt_engine.py
@@ -1,0 +1,40 @@
+"""Domain contract for running one Sourcehunt discovery assignment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from .state import FileTarget, Finding
+
+
+@dataclass(frozen=True, slots=True)
+class HuntAssignment:
+    """Everything a hunt engine needs to investigate one ranked target."""
+
+    file_target: FileTarget
+    session_id: str
+    work_item_id: str
+    budget_usd: float = 0.0
+    seed_transcript: str | None = None
+    entry_point: Any = None
+    seed_context: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HuntOutcome:
+    """Engine-neutral result consumed by the existing Sourcehunt pipeline."""
+
+    findings: tuple[Finding, ...]
+    cost_usd: float
+    tokens_used: int
+    stop_reason: str
+
+
+class HuntEngine(Protocol):
+    """The single extension seam for Sourcehunt discovery execution."""
+
+    async def hunt(self, assignment: HuntAssignment, sandbox: Any) -> HuntOutcome: ...
+
+
+__all__ = ["HuntAssignment", "HuntEngine", "HuntOutcome"]

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -233,6 +233,7 @@ class HunterTrajectoryLogger:
         prompt: str,
         initial_messages: list[ChatMessage],
         tools: list[NativeToolSpec],
+        engine: str = "native",
     ) -> HunterTrajectoryLogger:
         path = _trajectory_path(ctx)
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -249,6 +250,7 @@ class HunterTrajectoryLogger:
                 "session_id": ctx.session_id,
                 "file_path": ctx.file_path,
                 "specialist": ctx.specialist,
+                "engine": engine,
                 "prompt": prompt,
                 "tools": [tool.name for tool in tools],
                 "seeded_crash": ctx.seeded_crash,
@@ -1381,6 +1383,7 @@ class NativeHunter:
     initial_user_message: str = ""  # spec 006: override default first message
     max_repeated_skips: int = 15  # hard cap on total skipped degenerate-loop calls before giving up
     summarizer: ContextSummarizer | None = field(default=None)
+    max_output_tokens: int | None = None  # None preserves the provider/native default
 
     def _should_stop(self, step: int, cost_usd: float) -> str | None:
         """Return a stop reason string, or None to continue."""
@@ -1456,11 +1459,19 @@ class NativeHunter:
                     messages = await self.summarizer.summarize(messages, self.llm)
                     logger.info("Hunter context summarized: %d → %d messages", pre, len(messages))
 
-                response = await self.llm.achat(
-                    messages=messages,
-                    system=self.prompt,
-                    tools=self.tools,
-                )
+                if self.max_output_tokens is None:
+                    response = await self.llm.achat(
+                        messages=messages,
+                        system=self.prompt,
+                        tools=self.tools,
+                    )
+                else:
+                    response = await self.llm.achat(
+                        messages=messages,
+                        system=self.prompt,
+                        tools=self.tools,
+                        max_tokens=self.max_output_tokens,
+                    )
             # Preserve the provider's reasoning_content alongside the
             # visible text. `response.first_text` only returns the
             # first Text part — reasoning/thinking blocks are separate

--- a/clearwing/sourcehunt/native_hunt_engine.py
+++ b/clearwing/sourcehunt/native_hunt_engine.py
@@ -1,0 +1,37 @@
+"""Adapter from the hunt-engine contract to Clearwing's native agent loop."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from .hunt_engine import HuntAssignment, HuntOutcome
+
+logger = logging.getLogger(__name__)
+
+
+class NativeHuntEngine:
+    """Run an assignment with the existing ``NativeHunter`` implementation."""
+
+    def __init__(self, build_hunter: Callable[[HuntAssignment, Any], Any]) -> None:
+        self._build_hunter = build_hunter
+
+    async def hunt(self, assignment: HuntAssignment, sandbox: Any) -> HuntOutcome:
+        hunter, context = self._build_hunter(assignment, sandbox)
+        try:
+            result = await hunter.arun()
+            return HuntOutcome(
+                findings=tuple(result.findings),
+                cost_usd=result.cost_usd,
+                tokens_used=result.tokens_used,
+                stop_reason=result.stop_reason,
+            )
+        finally:
+            try:
+                context.cleanup_variants()
+            except Exception:
+                logger.debug("Variant sandbox cleanup failed", exc_info=True)
+
+
+__all__ = ["NativeHuntEngine"]

--- a/clearwing/sourcehunt/pool.py
+++ b/clearwing/sourcehunt/pool.py
@@ -35,7 +35,9 @@ from clearwing.runners.parallel.executor import (
     TierBudget as _ExecutorTierBudget,
 )
 
+from .hunt_engine import HuntAssignment, HuntEngine
 from .instrumentation import stable_run_id
+from .native_hunt_engine import NativeHuntEngine
 from .state import FileTarget, Finding
 
 logger = logging.getLogger(__name__)
@@ -184,6 +186,8 @@ class HuntPoolConfig:
     # If None, the pool will import build_hunter_agent
     # at run time and require an llm in the config.
     llm: object | None = None  # Required if hunter_factory is None
+    hunt_engine: HuntEngine | None = None
+    hunt_engine_name: str = "native"  # "native" | "cyberpi"
     max_parallel: int = 8
     budget_usd: float = 0.0
     tier_budget: TierBudget = field(default_factory=TierBudget)
@@ -271,6 +275,9 @@ class HunterPool:
 
     def __init__(self, config: HuntPoolConfig):
         self.config = config
+        if config.hunt_engine is not None and config.hunter_factory is not None:
+            raise ValueError("hunt_engine and hunter_factory cannot both be supplied")
+        self._hunt_engine = config.hunt_engine or self._build_hunt_engine(config.hunt_engine_name)
         for ft in self.config.files:
             ft["tier"] = assign_tier(ft)
         self._results: dict[str, TargetResult] = {}
@@ -280,6 +287,15 @@ class HunterPool:
         self._promotion_counts: dict[str, int] = {"fast→standard": 0, "standard→deep": 0}
         self._state_lock = asyncio.Lock()
         self._cancelled = False
+
+    def _build_hunt_engine(self, name: str) -> HuntEngine:
+        if name == "native":
+            return NativeHuntEngine(self._build_hunter_for_assignment)
+        if name == "cyberpi":
+            from .cyberpi import CyberPiHuntEngine
+
+            return CyberPiHuntEngine(self._build_hunter_for_assignment)
+        raise ValueError(f"Unknown hunt engine: {name!r}")
 
     def run(self) -> list[Finding]:
         return asyncio.run(self.arun())
@@ -745,41 +761,50 @@ class HunterPool:
                 logger.warning("sandbox_factory failed for %s: %s", file_target.get("path"), e)
 
         try:
-            hunter, ctx = self._build_hunter_for_file(
-                file_target,
-                sandbox,
+            assignment = HuntAssignment(
+                file_target=file_target,
+                session_id=f"{self.config.session_id_prefix}-{uuid.uuid4().hex[:8]}",
+                work_item_id=work_item_id,
                 budget_usd=cost_limit,
                 seed_transcript=seed_transcript,
                 entry_point=entry_point,
                 seed_context=seed_context,
-                work_item_id=work_item_id,
             )
-            run_result = await hunter.arun()
+            outcome = await self._hunt_engine.hunt(assignment, sandbox)
 
             logger.info(
                 "Hunter completed for %s findings=%d cost=%.4f stop=%s",
                 file_target.get("path"),
-                len(run_result.findings),
-                run_result.cost_usd,
-                run_result.stop_reason,
+                len(outcome.findings),
+                outcome.cost_usd,
+                outcome.stop_reason,
             )
             return (
-                list(run_result.findings),
-                run_result.cost_usd,
-                run_result.tokens_used,
-                run_result.stop_reason,
+                list(outcome.findings),
+                outcome.cost_usd,
+                outcome.tokens_used,
+                outcome.stop_reason,
             )
         finally:
-            try:
-                if "ctx" in locals():
-                    ctx.cleanup_variants()
-            except Exception:
-                logger.debug("Variant sandbox cleanup failed", exc_info=True)
             if sandbox is not None:
                 try:
                     await asyncio.to_thread(sandbox.stop)
                 except Exception:
                     pass
+
+    def _build_hunter_for_assignment(
+        self, assignment: HuntAssignment, sandbox: Any
+    ) -> Any:
+        return self._build_hunter_for_file(
+            assignment.file_target,
+            sandbox,
+            budget_usd=assignment.budget_usd,
+            seed_transcript=assignment.seed_transcript,
+            entry_point=assignment.entry_point,
+            seed_context=assignment.seed_context,
+            work_item_id=assignment.work_item_id,
+            session_id=assignment.session_id,
+        )
 
     def _build_hunter_for_file(
         self,
@@ -790,6 +815,7 @@ class HunterPool:
         entry_point: Any = None,
         seed_context: str | None = None,
         work_item_id: str = "",
+        session_id: str = "",
     ) -> Any:
         """Either invoke the user-supplied hunter_factory or import build_hunter_agent."""
         if not work_item_id:
@@ -803,7 +829,7 @@ class HunterPool:
                     ),
                 },
             )
-        session_id = f"{self.config.session_id_prefix}-{uuid.uuid4().hex[:8]}"
+        session_id = session_id or f"{self.config.session_id_prefix}-{uuid.uuid4().hex[:8]}"
 
         if self.config.hunter_factory is not None:
             result = self.config.hunter_factory(file_target, sandbox, session_id)

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -1027,6 +1027,10 @@ class SourceHuntRunner:
             metadata={"flow": self._flow, "repository": self.repo_url},
         )
         try:
+            if self._hunt_engine == "cyberpi":
+                from .cyberpi_runtime import CyberPiRuntime
+
+                CyberPiRuntime().require_ready(include_docker=self.sandbox_factory is None)
             self._preflight_budget_clients()
             # 1. Preprocess
             self._emit_stage("preprocess", "started")

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -259,6 +259,7 @@ class SourceHuntRunner:
         sandbox_cpus: float | None = None,
         *,
         config: SourceHuntConfig | None = None,
+        hunt_engine: str = "native",  # "native" | "cyberpi"
         flow: str = "legacy",
         proof_compile_commands: str | None = None,
         proof_validation_manifest: str | None = None,
@@ -361,6 +362,7 @@ class SourceHuntRunner:
             exploit_mode = exploit_mode or f.exploit_mode
             agent_mode = agent_mode if agent_mode != "auto" else f.agent_mode
             prompt_mode = prompt_mode if prompt_mode != "unconstrained" else f.prompt_mode
+            hunt_engine = hunt_engine if hunt_engine != "native" else f.hunt_engine
             # Hunt tuning
             starting_band = starting_band if starting_band is not None else h.starting_band
             redundancy_override = (
@@ -442,6 +444,10 @@ class SourceHuntRunner:
             raise ValueError("sandbox_cpus must be a finite number greater than or equal to 0")
         if flow not in {"legacy", "proof"}:
             raise ValueError("flow must be 'legacy' or 'proof'")
+        if hunt_engine not in {"native", "cyberpi"}:
+            raise ValueError("hunt_engine must be 'native' or 'cyberpi'")
+        if hunt_engine == "cyberpi" and flow != "legacy":
+            raise ValueError("CyberPi is only available with the legacy Sourcehunt flow")
         if proof_max_actions < 1:
             raise ValueError("proof_max_actions must be positive")
         if proof_max_model_calls < 0 or proof_max_dynamic_actions < 0:
@@ -514,6 +520,7 @@ class SourceHuntRunner:
         self._session_id = parent_session_id or f"sh-{uuid.uuid4().hex[:8]}"
         self._agent_mode_override = agent_mode
         self._prompt_mode = prompt_mode
+        self._hunt_engine = hunt_engine
         self._campaign_hint = campaign_hint
         self._exploit_mode = exploit_mode
         self._starting_band_override = starting_band
@@ -1036,6 +1043,13 @@ class SourceHuntRunner:
                 files=stage_files,
             )
             self._ensure_sandbox_factory(repo_path, files)
+            if self._hunt_engine == "cyberpi" and (
+                self.sandbox_factory is None or self._effective_agent_mode != "deep"
+            ):
+                raise RuntimeError(
+                    "CyberPi requires --depth standard/deep (or --agent-mode deep) "
+                    "and an available isolated HunterSandbox"
+                )
 
             # 2. Rank — unless depth=quick AND no LLM available, or --no-rank
             ranker_llm = (
@@ -1339,6 +1353,7 @@ class SourceHuntRunner:
                         sandbox_manager=self._sandbox_manager,
                         hunter_factory=None,
                         llm=hunter_llm,
+                        hunt_engine_name=self._hunt_engine,
                         max_parallel=self.max_parallel,
                         budget_usd=self.budget_usd,
                         tier_budget=self.tier_budget,

--- a/clearwing/ui/commands/__init__.py
+++ b/clearwing/ui/commands/__init__.py
@@ -5,6 +5,7 @@ from . import (
     campaign,
     ci,
     config,
+    cyberpi,
     disclose,
     doctor,
     eval,
@@ -26,6 +27,7 @@ from . import (
 ALL_COMMANDS = [
     setup,
     doctor,
+    cyberpi,
     scan,
     report,
     history,

--- a/clearwing/ui/commands/cyberpi.py
+++ b/clearwing/ui/commands/cyberpi.py
@@ -1,0 +1,232 @@
+"""Operator workflow for installing and evaluating the CyberPi harness."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from rich.table import Table
+
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser(
+        "cyberpi",
+        help="Install, diagnose, smoke-test, and benchmark the CyberPi harness",
+    )
+    actions = parser.add_subparsers(dest="cyberpi_action")
+
+    install = actions.add_parser("install", help="Install the pinned Pi runtime")
+    install.add_argument("--force", action="store_true", help="Reinstall an existing runtime")
+
+    doctor = actions.add_parser("doctor", help="Check Node, Pi, and Docker prerequisites")
+    doctor.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+
+    smoke = actions.add_parser(
+        "smoke", help="Run one bounded CyberPi/provider integration check (uses inference)"
+    )
+    _provider_arguments(smoke)
+    smoke.add_argument(
+        "--output-dir", default=None, help="Directory for the result and JSONL trajectory"
+    )
+    smoke.add_argument(
+        "--max-turns", type=_positive_int, default=3, help="Maximum model turns (default: 3)"
+    )
+    smoke.add_argument(
+        "--max-output-tokens",
+        type=_positive_int,
+        default=4096,
+        help="Maximum output tokens per turn (default: 4096)",
+    )
+
+    benchmark = actions.add_parser(
+        "benchmark", help="Compare native and CyberPi on paired positive/negative fixtures"
+    )
+    _provider_arguments(benchmark)
+    benchmark.add_argument(
+        "--output-dir", default=None, help="Directory for JSON, Markdown, and trajectories"
+    )
+    benchmark.add_argument(
+        "--runs", type=_positive_int, default=1, help="Replicates per fixture (default: 1)"
+    )
+    benchmark.add_argument(
+        "--max-turns", type=_positive_int, default=4, help="Maximum model turns (default: 4)"
+    )
+    benchmark.add_argument(
+        "--max-output-tokens",
+        type=_positive_int,
+        default=4096,
+        help="Maximum output tokens per turn (default: 4096)",
+    )
+    return parser
+
+
+def handle(cli, args) -> None:
+    action = getattr(args, "cyberpi_action", None)
+    handlers = {
+        "install": _handle_install,
+        "doctor": _handle_doctor,
+        "smoke": _handle_smoke,
+        "benchmark": _handle_benchmark,
+    }
+    if action not in handlers:
+        cli.console.print("[yellow]Usage: clearwing cyberpi <install|doctor|smoke|benchmark>[/yellow]")
+        return
+    handlers[action](cli, args)
+
+
+def _handle_install(cli, args) -> None:
+    from clearwing.sourcehunt.cyberpi_runtime import CyberPiRuntime, CyberPiRuntimeError
+
+    runtime = CyberPiRuntime()
+    cli.console.print(f"Installing pinned CyberPi runtime in [cyan]{runtime.runtime_dir}[/cyan]")
+    try:
+        destination = runtime.install(force=args.force)
+    except CyberPiRuntimeError as exc:
+        cli.console.print(f"[red]Error: {exc}[/red]")
+        sys.exit(1)
+    cli.console.print(f"[green]CyberPi is installed:[/green] {destination}")
+    cli.console.print("Next: [bold]clearwing cyberpi doctor[/bold]")
+
+
+def _handle_doctor(cli, args) -> None:
+    from clearwing.sourcehunt.cyberpi_runtime import CyberPiRuntime
+
+    status = CyberPiRuntime().inspect(include_docker=True)
+    if args.json:
+        sys.stdout.write(json.dumps(status.to_dict(), indent=2, sort_keys=True) + "\n")
+    else:
+        table = Table(title="CyberPi preflight", show_header=True, header_style="bold")
+        table.add_column("Status", width=6)
+        table.add_column("Check")
+        table.add_column("Detail")
+        glyphs = {"ok": "[green]OK[/green]", "warn": "[yellow]WARN[/yellow]", "error": "[red]ERR[/red]"}
+        for check in status.checks:
+            detail = check.detail + (f"\n[dim]{check.remedy}[/dim]" if check.remedy else "")
+            table.add_row(glyphs[check.status], check.name, detail)
+        cli.console.print(table)
+        if status.ready:
+            cli.console.print("[green]CyberPi is ready.[/green]")
+        else:
+            cli.console.print("[red]CyberPi needs attention; use the remedies above.[/red]")
+    sys.exit(0 if status.ready else 1)
+
+
+def _handle_smoke(cli, args) -> None:
+    from clearwing.bench.cyberpi import BUILTIN_FIXTURES, CyberPiBenchmark
+
+    llm, endpoint, output_dir = _evaluation_context(cli, args)
+    cli.console.print(f"CyberPi smoke test: [cyan]{endpoint.describe()}[/cyan]")
+    report = asyncio.run(
+        CyberPiBenchmark(
+            llm,
+            output_dir=output_dir,
+            max_turns=args.max_turns,
+            max_output_tokens=args.max_output_tokens,
+        ).arun(
+            engines=("cyberpi",), fixtures=(BUILTIN_FIXTURES[0],)
+        )
+    )
+    json_path, markdown_path = report.write(output_dir)
+    observation = report.observations[0]
+    if observation.error:
+        cli.console.print(f"[red]CyberPi/provider integration failed:[/red] {observation.error}")
+        cli.console.print(f"Result: {json_path}")
+        sys.exit(1)
+    cli.console.print("[green]CyberPi/provider integration succeeded.[/green]")
+    behavior = "found the known fixture vulnerability" if observation.passed else "completed but missed the fixture vulnerability"
+    cli.console.print(f"Behavior check: {behavior}")
+    cli.console.print(f"Tokens: {observation.tokens_used}; trajectory: {observation.trajectory}")
+    cli.console.print(f"Reports: {json_path}, {markdown_path}")
+
+
+def _handle_benchmark(cli, args) -> None:
+    from clearwing.bench.cyberpi import CyberPiBenchmark
+
+    llm, endpoint, output_dir = _evaluation_context(cli, args)
+    cli.console.print(
+        f"CyberPi paired benchmark: [cyan]{endpoint.describe()}[/cyan], runs={args.runs}"
+    )
+    report = asyncio.run(
+        CyberPiBenchmark(
+            llm,
+            output_dir=output_dir,
+            max_turns=args.max_turns,
+            max_output_tokens=args.max_output_tokens,
+        ).arun(
+            replicates=args.runs
+        )
+    )
+    json_path, markdown_path = report.write(output_dir)
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Engine")
+    table.add_column("Passed", justify="right")
+    table.add_column("Tokens", justify="right")
+    table.add_column("Reported cost*", justify="right")
+    table.add_column("Errors", justify="right")
+    for engine, values in report.metrics().items():
+        table.add_row(
+            engine,
+            f"{values['passed']}/{values['cases']}",
+            str(values["tokens"]),
+            f"${float(values['cost_usd']):.4f}",
+            str(values["errors"]),
+        )
+    cli.console.print(table)
+    cli.console.print(
+        "[dim]* Native uses Clearwing's estimate; CyberPi uses the provider/model report. "
+        "Compare tokens unless endpoint pricing is configured.[/dim]"
+    )
+    cli.console.print(f"Reports: {json_path}, {markdown_path}")
+    if not report.successful:
+        sys.exit(1)
+
+
+def _evaluation_context(cli, args):
+    from clearwing.core.config import default_results_dir
+    from clearwing.providers import ProviderManager, resolve_llm_endpoint
+    from clearwing.sourcehunt.cyberpi_runtime import CyberPiRuntime, CyberPiRuntimeError
+
+    try:
+        runtime = CyberPiRuntime()
+        runtime.require_ready(include_docker=False)
+    except CyberPiRuntimeError as exc:
+        cli.console.print(f"[red]Error: {exc}[/red]")
+        sys.exit(1)
+    endpoint = resolve_llm_endpoint(
+        cli_model=args.model,
+        cli_base_url=args.base_url,
+        cli_api_key=args.api_key,
+        config_provider=cli.config.get_provider_section() or None,
+    )
+    if not endpoint.api_key:
+        cli.console.print(
+            "[red]Error: no API credential is configured. Run `clearwing setup` or set "
+            "CLEARWING_API_KEY.[/red]"
+        )
+        sys.exit(1)
+    llm = ProviderManager.for_endpoint(endpoint).get_native_client("hunter")
+    output_dir = (
+        Path(args.output_dir).expanduser()
+        if args.output_dir
+        else Path(default_results_dir("bench")).expanduser() / "cyberpi"
+    )
+    return llm, endpoint, output_dir
+
+
+def _provider_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--model", default=None, help="Exact provider model identifier")
+    parser.add_argument("--base-url", default=None, help="Provider API base URL")
+    parser.add_argument("--api-key", default=None, help="Provider API key (prefer configuration/env)")
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+__all__ = ["add_parser", "handle"]

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -192,6 +192,13 @@ def add_parser(subparsers):
         "9-tool hunter, 'deep' forces full-shell agent (default: auto)",
     )
     parser.add_argument(
+        "--hunt-engine",
+        choices=["native", "cyberpi"],
+        default="native",
+        dest="hunt_engine",
+        help="Per-file hunt harness (default: native)",
+    )
+    parser.add_argument(
         "--prompt-mode",
         choices=["unconstrained", "specialist"],
         default="unconstrained",
@@ -1164,6 +1171,7 @@ def handle(cli, args):
         model_override=args.model,
         provider_manager=provider_manager,
         agent_mode=args.agent_mode,
+        hunt_engine=args.hunt_engine,
         prompt_mode=args.prompt_mode,
         campaign_hint=args.campaign_hint,
         exploit_mode=args.exploit_mode,
@@ -1304,6 +1312,7 @@ def _handle_machine(descriptor: int) -> int:
                 no_exploit=not parsed["exploit"],
                 flow=parsed["flow"],
                 agent_mode=parsed["agent_mode"],
+                hunt_engine=parsed["hunt_engine"],
                 no_rank=parsed["no_rank"],
                 no_per_file_hunt=parsed["no_per_file_hunt"],
                 enable_subsystem_hunt=parsed["subsystem_hunt"]
@@ -1336,6 +1345,7 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "exploit",
         "flow",
         "agent_mode",
+        "hunt_engine",
         "no_rank",
         "format",
         "subsystem_hunt",
@@ -1353,6 +1363,9 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
     agent_mode = _choice(
         value.get("agent_mode", "auto"), "agent_mode", {"auto", "constrained", "deep"}
     )
+    hunt_engine = _choice(
+        value.get("hunt_engine", "native"), "hunt_engine", {"native", "cyberpi"}
+    )
     parsed = {
         "repo_url": repo_url,
         "branch": _bounded_text(value.get("branch", "main"), "branch", 256),
@@ -1365,6 +1378,7 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "exploit": _boolean(value.get("exploit", True), "exploit"),
         "flow": flow,
         "agent_mode": agent_mode,
+        "hunt_engine": hunt_engine,
         "no_rank": _boolean(value.get("no_rank", False), "no_rank"),
         "no_per_file_hunt": _boolean(value.get("no_per_file_hunt", False), "no_per_file_hunt"),
         "subsystem_hunt": _boolean(value.get("subsystem_hunt", False), "subsystem_hunt"),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,7 +3,7 @@
 ```
 clearwing [-h] {scan,report,history,config,interactive,graph,sessions,
                 ci,parallel,mcp,operate,webui,sourcehunt,disclose,
-                campaign,bench,eval} ...
+                campaign,bench,eval,cyberpi} ...
 ```
 
 Every subcommand supports `-h` / `--help` for flag-level details.
@@ -458,6 +458,22 @@ glyphs plus a totals panel at the bottom.
 
 Exit code is 0 when every check is ok/warn and 1 when any check is
 in error state — useful in CI pipelines (`clearwing doctor || exit 1`).
+
+## `cyberpi` — minimal harness workflow
+
+```bash
+clearwing cyberpi install                  # install pinned Pi 0.84.1
+clearwing cyberpi doctor [--json]          # Node/Pi/Docker preflight
+clearwing cyberpi smoke [provider flags]   # one bounded live integration test
+clearwing cyberpi benchmark --runs 3       # paired native/CyberPi fixtures
+```
+
+`smoke` and `benchmark` accept `--model`, `--base-url`, `--api-key`,
+`--max-turns`, `--max-output-tokens`, and `--output-dir`; normal Clearwing
+config/environment resolution also applies. Prefer config or environment credentials so secrets
+do not enter shell history. The benchmark writes JSON, Markdown, and complete
+JSONL trajectories. See the [CyberPi guide](cyberpi.md) for the full workflow
+and the repository-hunt command.
 
 ## `config` — show/edit config
 

--- a/docs/cyberpi.md
+++ b/docs/cyberpi.md
@@ -1,0 +1,107 @@
+# CyberPi
+
+CyberPi is Clearwing's opt-in Sourcehunt engine built on the small Pi agent
+harness. It changes only per-file discovery: ranking, isolation, validation,
+budget accounting, reporting, and every native default remain Clearwing-owned.
+
+## Install and verify
+
+CyberPi requires Node.js 22.19 or newer. A full repository hunt also requires
+a running Docker daemon; the smoke test and paired benchmark do not.
+
+```bash
+clearwing cyberpi install
+clearwing cyberpi doctor
+```
+
+The installer uses the packaged lockfile and installs Pi 0.84.1 under
+`~/.clearwing/cyberpi/pi-0.84.1`. It never writes npm dependencies into the
+Python package or the current repository. `clearwing cyberpi doctor --json`
+provides an unstyled, machine-readable preflight for CI and support scripts.
+
+## Configure a model
+
+CyberPi uses the normal Clearwing provider resolution. Configuration and
+environment variables are preferable to putting a credential in shell history:
+
+```bash
+export CLEARWING_BASE_URL=https://provider.example/v1
+export CLEARWING_API_KEY="$PROVIDER_API_KEY"
+export CLEARWING_MODEL=provider-model-id
+
+clearwing cyberpi smoke
+```
+
+Model identifiers are sent to the provider exactly as configured and may be
+case-sensitive. If the provider returns “model not found,” copy the identifier
+from that provider's model listing instead of changing its case.
+
+The smoke command performs one bounded inference against an in-memory vulnerable
+C fixture. It validates Node → Pi → provider → Clearwing tool routing without
+Docker. A successful integration can still report a behavioral miss; that means
+the harness ran correctly but the model did not identify the known issue.
+
+## Compare the harnesses
+
+```bash
+clearwing cyberpi benchmark --runs 3 --max-turns 4
+```
+
+The paired micro-benchmark runs the native and CyberPi engines with the same
+model, system prompt, tool definitions, positive/negative source fixtures,
+turn cap, and 4,096-token per-turn output cap. Replicate order alternates to
+reduce ordering bias. It writes:
+
+- a JSON result with per-arm accuracy, tokens, reported cost and its basis, duration,
+  stop reason, and errors;
+- a compact Markdown summary; and
+- complete JSONL trajectories containing the prompt, assistant reasoning/text,
+  tool calls, tool results, usage, and final findings.
+
+By default these live under `results/bench/cyberpi/` in a development checkout
+or `~/.clearwing/results/bench/cyberpi/` from an installed package. Use
+`--output-dir` to choose an exact destination.
+
+This is a harness integration and regression benchmark, not a CVE recall claim.
+Use several runs, inspect trajectories, and evaluate on a held-out vulnerability
+corpus before promoting a prompt or CyberPi change. The JSONL records are also
+the input artifact to retain for GEPA-style prompt optimization.
+
+The native arm's dollar value uses Clearwing's built-in price estimate, while
+CyberPi reports Pi's provider/model cost. Compare token counts unless both arms
+have the same explicit endpoint pricing; the report records each cost basis.
+
+## Run Sourcehunt with CyberPi
+
+```bash
+clearwing sourcehunt /path/to/repository \
+  --depth deep \
+  --hunt-engine cyberpi \
+  --budget 25
+```
+
+CyberPi requires the deep tool set (`--depth standard` or `deep`, or an explicit
+`--agent-mode deep`) and an isolated Docker-backed HunterSandbox. Clearwing runs
+the CyberPi/Node/Docker preflight before preprocessing, so missing prerequisites
+fail quickly with the command needed to fix them.
+
+CyberPi is intentionally locked down: Pi receives only Clearwing's
+`execute`, `read_file`, scratch-only `write_file`, `record_trace_step`, and
+`record_finding` tools. Pi extensions, skills, prompts, sessions, retries,
+compaction, and built-in tools are disabled. Only structured findings recorded
+through the Clearwing tool boundary enter Sourcehunt results.
+
+## Troubleshooting
+
+```bash
+clearwing cyberpi doctor
+clearwing cyberpi install --force
+clearwing cyberpi smoke --max-turns 2
+```
+
+- **Node is too old:** install Node 22.19+ and rerun the installer.
+- **Pi SDK is missing or mismatched:** run `clearwing cyberpi install --force`.
+- **Docker is a warning:** smoke and benchmark work; start Docker before
+  `sourcehunt --hunt-engine cyberpi`.
+- **Provider/model failure:** verify the configured endpoint and the exact,
+  case-sensitive model identifier. Clearwing never persists the CLI API key.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -100,9 +100,26 @@ clearwing sourcehunt https://github.com/example/project \
 # and auto-patch validation (recompile + rerun PoC). The most
 # rigorous mode; expects real build deps in the sandbox.
 clearwing sourcehunt /path/to/repo \
-    --depth deep --max-parallel 8 \
-    --auto-patch
+  --depth deep --max-parallel 8 \
+  --auto-patch
 ```
+
+To use the optional minimal Pi harness for per-file discovery:
+
+```bash
+clearwing cyberpi install       # one-time pinned runtime install
+clearwing cyberpi doctor        # Node/Pi/Docker preflight
+clearwing cyberpi smoke         # bounded provider test; Docker not required
+
+clearwing sourcehunt /path/to/repo \
+  --depth deep \
+  --hunt-engine cyberpi
+```
+
+Run `clearwing cyberpi benchmark --runs 3` for a paired native-vs-CyberPi
+micro-benchmark with JSON, Markdown, and complete JSONL trajectories. See the
+[CyberPi guide](cyberpi.md) for provider configuration, interpretation, and
+limitations.
 
 Output lives in `./results/sourcehunt/<session_id>/` (dev checkout) or
 `~/.clearwing/results/sourcehunt/<session_id>/` (PyPI install) — SARIF for

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Home: index.md
   - Quickstart: quickstart.md
   - LLM providers: providers.md
+  - CyberPi harness: cyberpi.md
   - FFmpeg case study: FFmpeg.md
   - Sourcehunt evaluation and rollout: eval_rollout.md
   - Architecture: architecture.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,8 @@ clearwing = [
     "core/config_data/*.yaml",
     "core/skills/vulnerabilities/*.md",
     "ui/web/static/**/*",
+    "sourcehunt/cyberpi_sidecar/*.mjs",
+    "sourcehunt/cyberpi_sidecar/package*.json",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_cyberpi_ux.py
+++ b/tests/test_cyberpi_ux.py
@@ -1,0 +1,125 @@
+"""CyberPi managed-runtime, command-surface, and report regressions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from clearwing.bench.cyberpi import BenchmarkObservation, CyberPiBenchmarkReport
+from clearwing.sourcehunt.cyberpi_runtime import (
+    PI_VERSION,
+    CyberPiRuntime,
+    RuntimeCheck,
+)
+from clearwing.ui.commands import ALL_COMMANDS
+from clearwing.ui.commands import cyberpi as cyberpi_command
+
+
+def test_cyberpi_command_is_registered_with_cohesive_actions():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    cyberpi_command.add_parser(subparsers)
+
+    assert cyberpi_command in ALL_COMMANDS
+    assert parser.parse_args(["cyberpi", "install"]).cyberpi_action == "install"
+    assert parser.parse_args(["cyberpi", "doctor", "--json"]).json is True
+    benchmark = parser.parse_args(
+        ["cyberpi", "benchmark", "--runs", "3", "--model", "Exact-Model-Alias"]
+    )
+    assert benchmark.runs == 3
+    assert benchmark.model == "Exact-Model-Alias"
+
+
+def test_managed_install_uses_packaged_lockfile_and_atomic_destination(tmp_path, monkeypatch):
+    packaged = tmp_path / "packaged"
+    packaged.mkdir()
+    (packaged / "index.mjs").write_text("// sidecar\n")
+    (packaged / "package.json").write_text(json.dumps({"dependencies": {}}))
+    (packaged / "package-lock.json").write_text(json.dumps({"lockfileVersion": 3}))
+    runtime = CyberPiRuntime(tmp_path / "managed" / "runtime")
+
+    monkeypatch.setattr(CyberPiRuntime, "_packaged_dir", staticmethod(lambda: packaged))
+    monkeypatch.setattr(
+        CyberPiRuntime,
+        "_node_check",
+        lambda self: RuntimeCheck("Node.js", "ok", "v22.19.0"),
+    )
+    monkeypatch.setattr(
+        CyberPiRuntime,
+        "_npm_check",
+        staticmethod(lambda **_kwargs: RuntimeCheck("npm", "ok", "10.0.0")),
+    )
+
+    def fake_run(_command, *, cwd, **_kwargs):
+        dependency = Path(cwd) / "node_modules" / "@earendil-works" / "pi-coding-agent"
+        dependency.mkdir(parents=True)
+        (dependency / "package.json").write_text(json.dumps({"version": PI_VERSION}))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("clearwing.sourcehunt.cyberpi_runtime.subprocess.run", fake_run)
+
+    installed = runtime.install()
+
+    assert installed == runtime.runtime_dir
+    assert (installed / "index.mjs").is_file()
+    assert runtime.command() == (runtime.node, str(installed / "index.mjs"))
+    assert not list(runtime.runtime_dir.parent.glob(f".{runtime.runtime_dir.name}-previous-*"))
+
+
+def test_benchmark_report_has_machine_and_human_outputs(tmp_path):
+    observations = (
+        BenchmarkObservation(
+            engine="native",
+            fixture="heap-overflow",
+            replicate=1,
+            passed=False,
+            findings=(),
+            tokens_used=120,
+            cost_usd=0.01,
+            cost_basis="clearwing_estimate",
+            duration_seconds=1.0,
+            stop_reason="completed",
+            trajectory="native.jsonl",
+        ),
+        BenchmarkObservation(
+            engine="cyberpi",
+            fixture="heap-overflow",
+            replicate=1,
+            passed=True,
+            findings=({"cwe": "CWE-122", "line_number": 7},),
+            tokens_used=80,
+            cost_usd=0.005,
+            cost_basis="provider_reported",
+            duration_seconds=0.8,
+            stop_reason="completed",
+            trajectory="cyberpi.jsonl",
+        ),
+    )
+    report = CyberPiBenchmarkReport(
+        benchmark_id="cyberpi-test",
+        created_at="2026-08-13T00:00:00+00:00",
+        model="DeepSeek-v4-Flash-0731",
+        base_url="https://example.test/v1",
+        max_turns=4,
+        max_output_tokens=4096,
+        observations=observations,
+    )
+
+    json_path, markdown_path = report.write(tmp_path)
+
+    payload = json.loads(json_path.read_text())
+    assert payload["metrics"]["native"]["pass_rate"] == 0
+    assert payload["metrics"]["cyberpi"]["pass_rate"] == 1
+    assert payload["metrics"]["cyberpi"]["cost_basis"] == "provider_reported"
+    assert "| cyberpi | 1 | 1 | 100% |" in markdown_path.read_text()
+    assert "API" not in json_path.read_text()
+
+
+def test_benchmark_scoring_normalizes_provider_cwe_spelling():
+    from clearwing.bench.cyberpi import BUILTIN_FIXTURES, CyberPiBenchmark
+
+    finding = ({"cwe": "122", "line_number": 7},)
+
+    assert CyberPiBenchmark._passed(BUILTIN_FIXTURES[0], finding) is True

--- a/tests/test_sourcehunt_cyberpi.py
+++ b/tests/test_sourcehunt_cyberpi.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import sys
 from pathlib import Path
@@ -11,6 +12,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from clearwing.agent.tools.hunt.sandbox import HunterContext
 from clearwing.findings.types import Finding
 from clearwing.llm import AsyncLLMClient, NativeToolSpec
 from clearwing.llm.budget import BudgetExceeded, SpendLedger
@@ -95,6 +97,19 @@ send({"type": "model_result", "id": "model-1", "ok": mode != "model_error", "err
 ack = read()
 assert ack == {"type": "model_result_ack", "id": "model-1"}
 send({
+    "type": "trajectory",
+    "step": 1,
+    "message": {
+        "role": "assistant",
+        "content": "I inspected the bounded fixture.",
+        "tool_calls": [],
+        "tool_response_call_id": None,
+    },
+    "reasoning_content": "The length reaches memcpy without a bound.",
+    "usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+    "model": start["model"]["id"],
+})
+send({
     "type": "complete",
     "stop_reason": "stop",
     "turns": 1,
@@ -128,7 +143,14 @@ def _runtime(tmp_path: Path, *, mode: str = "happy", ledger: SpendLedger | None 
 
     script = tmp_path / "fake_sidecar.py"
     script.write_text(_FAKE_SIDECAR, encoding="utf-8")
-    context = SimpleNamespace(findings=[], cleanup_variants=MagicMock())
+    context = HunterContext(
+        repo_path="/repo",
+        file_path="src/app.c",
+        session_id="cyberpi-test",
+        trajectory_dir=tmp_path / "trajectory",
+        work_item_id="work-1",
+    )
+    context.cleanup_variants = MagicMock()
 
     async def text_result(**_kwargs):
         return "source"
@@ -226,6 +248,25 @@ async def test_sidecar_routes_tools_and_accepts_findings_only_from_context(tmp_p
     assert outcome.cost_usd == pytest.approx(0.01)
     assert outcome.tokens_used == 2
     context.cleanup_variants.assert_called_once_with()
+    records = [
+        json.loads(line)
+        for line in (Path(context.trajectory_dir) / "transcript.jsonl").read_text().splitlines()
+    ]
+    assert [record["event"] for record in records] == [
+        "start",
+        "message",
+        "tool_call",
+        "tool_result",
+        "message",
+        "tool_call",
+        "tool_result",
+        "message",
+        "message",
+        "finish",
+    ]
+    assistant = records[-2]
+    assert assistant["reasoning_content"] == "The length reaches memcpy without a bound."
+    assert assistant["usage"]["total_tokens"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_sourcehunt_cyberpi.py
+++ b/tests/test_sourcehunt_cyberpi.py
@@ -1,0 +1,453 @@
+"""CyberPi hunt-engine and sidecar boundary regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from clearwing.findings.types import Finding
+from clearwing.llm import AsyncLLMClient, NativeToolSpec
+from clearwing.llm.budget import BudgetExceeded, SpendLedger
+from clearwing.sourcehunt.config import FeatureFlags
+from clearwing.sourcehunt.hunt_engine import HuntAssignment, HuntOutcome
+from clearwing.sourcehunt.native_hunt_engine import NativeHuntEngine
+from clearwing.sourcehunt.pool import HunterPool, HuntPoolConfig
+from clearwing.ui.commands import sourcehunt as sourcehunt_command
+
+_FAKE_SIDECAR = r"""
+import json
+import os
+import sys
+import time
+
+def read():
+    line = sys.stdin.readline()
+    if not line:
+        raise RuntimeError("protocol closed")
+    return json.loads(line)
+
+def send(message):
+    sys.stdout.write(json.dumps(message, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+mode = os.environ.get("FAKE_MODE", "happy")
+secret = os.environ.pop("CLEARWING_CYBERPI_API_KEY")
+start = read()
+assert secret not in repr(sys.argv)
+assert secret not in json.dumps(start)
+
+if mode == "malformed_json":
+    sys.stdout.write("{not-json\n")
+    sys.stdout.flush()
+    raise SystemExit(0)
+if mode == "unexpected":
+    send({"type": "unexpected"})
+    time.sleep(60)
+if mode == "exit":
+    raise SystemExit(7)
+
+if mode != "prose_only":
+    send({"type": "tool_call", "id": "read-1", "name": "read_file", "arguments": {"path": "/repo/src/app.c"}})
+    assert read() == {"type": "tool_result", "id": "read-1", "ok": True, "result": "source"}
+    send({
+        "type": "tool_call",
+        "id": "finding-1",
+        "name": "record_finding",
+        "arguments": {
+            "file": "src/app.c",
+            "line_number": 7,
+            "finding_type": "buffer_overflow",
+            "severity": "high",
+            "description": "attacker-controlled length reaches memcpy",
+        },
+    })
+    result = read()
+    assert result["type"] == "tool_result" and result["ok"] is True
+
+send({"type": "model_call", "id": "model-1", "input_bytes": 1, "max_tokens": start["model"]["max_output_tokens"] or 4096})
+authorization = read()
+if os.environ.get("AUTH_MARKER"):
+    Path = __import__("pathlib").Path
+    Path(os.environ["AUTH_MARKER"]).write_text(str(authorization["max_tokens"]))
+
+if mode == "cancel":
+    Path = __import__("pathlib").Path
+    Path(os.environ["PID_FILE"]).write_text(str(os.getpid()))
+    time.sleep(60)
+
+if mode == "malformed_usage":
+    usage = {"input_tokens": 1}
+else:
+    usage = {
+        "input_tokens": 1,
+        "output_tokens": 1,
+        "cached_input_tokens": 0,
+        "total_tokens": 2,
+        "cost_usd": 0.01,
+    }
+send({"type": "model_result", "id": "model-1", "ok": mode != "model_error", "error": "provider failed" if mode == "model_error" else None, "usage": usage})
+ack = read()
+assert ack == {"type": "model_result_ack", "id": "model-1"}
+send({
+    "type": "complete",
+    "stop_reason": "stop",
+    "turns": 1,
+    "model_calls": 1,
+    "final_text": "Invented prose-only CVE that Clearwing must ignore",
+})
+"""
+
+
+def _schema(properties: dict, required: list[str]) -> dict:
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+def _client(ledger: SpendLedger | None = None) -> AsyncLLMClient:
+    client = AsyncLLMClient(
+        model_name="deepseek-v4-flash-0731",
+        provider_name="openai",
+        api_key="secret-value",
+        base_url=("https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1"),
+    )
+    return client.with_spend_ledger(ledger, stage="hunt") if ledger else client
+
+
+def _runtime(tmp_path: Path, *, mode: str = "happy", ledger: SpendLedger | None = None):
+    from clearwing.sourcehunt.cyberpi import CyberPiHuntEngine
+
+    script = tmp_path / "fake_sidecar.py"
+    script.write_text(_FAKE_SIDECAR, encoding="utf-8")
+    context = SimpleNamespace(findings=[], cleanup_variants=MagicMock())
+
+    async def text_result(**_kwargs):
+        return "source"
+
+    async def record_finding(**arguments):
+        context.findings.append(Finding(**arguments))
+        return "recorded"
+
+    tools = [
+        NativeToolSpec(
+            name="execute",
+            description="execute",
+            schema=_schema({"command": {"type": "string"}}, ["command"]),
+            handler=text_result,
+        ),
+        NativeToolSpec(
+            name="read_file",
+            description="read",
+            schema=_schema({"path": {"type": "string"}}, ["path"]),
+            handler=text_result,
+        ),
+        NativeToolSpec(
+            name="write_file",
+            description="write",
+            schema=_schema(
+                {"path": {"type": "string"}, "contents": {"type": "string"}},
+                ["path", "contents"],
+            ),
+            handler=text_result,
+        ),
+        NativeToolSpec(
+            name="record_trace_step",
+            description="trace",
+            schema=_schema(
+                {"file": {"type": "string"}, "line": {"type": "integer"}},
+                ["file", "line"],
+            ),
+            handler=text_result,
+        ),
+        NativeToolSpec(
+            name="record_finding",
+            description="finding",
+            schema=_schema(
+                {
+                    "file": {"type": "string"},
+                    "line_number": {"type": "integer"},
+                    "finding_type": {"type": "string"},
+                    "severity": {"type": "string"},
+                    "description": {"type": "string"},
+                },
+                ["file", "line_number", "finding_type", "severity", "description"],
+            ),
+            handler=record_finding,
+        ),
+    ]
+    hunter = SimpleNamespace(
+        llm=_client(ledger),
+        tools=tools,
+        prompt="Find real vulnerabilities. Record findings through the tool.",
+        initial_user_message="Audit src/app.c",
+        max_steps=4,
+    )
+    engine = CyberPiHuntEngine(
+        lambda _assignment, _sandbox: (hunter, context),
+        command=(sys.executable, os.fspath(script)),
+        environ={"FAKE_MODE": mode},
+    )
+    assignment = HuntAssignment(
+        file_target={"path": "src/app.c"},
+        session_id="cyberpi-test",
+        work_item_id="work-1",
+        budget_usd=2.0,
+    )
+    return engine, assignment, context
+
+
+def _ledger(tmp_path: Path, limit: float = 2.0) -> SpendLedger:
+    return SpendLedger(
+        limit_usd=limit,
+        session_id="cyberpi-ledger",
+        repo_url="/repo",
+        output_dir=tmp_path,
+        input_price_per_million=0.0,
+        output_price_per_million=1_000_000.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sidecar_routes_tools_and_accepts_findings_only_from_context(tmp_path):
+    engine, assignment, context = _runtime(tmp_path)
+
+    outcome = await engine.hunt(assignment, object())
+
+    assert [finding.finding_type for finding in outcome.findings] == ["buffer_overflow"]
+    assert outcome.cost_usd == pytest.approx(0.01)
+    assert outcome.tokens_used == 2
+    context.cleanup_variants.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_final_prose_cannot_create_a_finding(tmp_path):
+    engine, assignment, _context = _runtime(tmp_path, mode="prose_only")
+
+    outcome = await engine.hunt(assignment, object())
+
+    assert outcome.findings == ()
+
+
+@pytest.mark.asyncio
+async def test_model_calls_reserve_and_settle_the_clearwing_ledger(tmp_path):
+    ledger = _ledger(tmp_path)
+    engine, assignment, _context = _runtime(tmp_path, ledger=ledger)
+
+    outcome = await engine.hunt(assignment, object())
+
+    assert ledger.spent_usd == pytest.approx(1.0)
+    assert ledger.remaining_usd == pytest.approx(1.0)
+    assert outcome.cost_usd == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_budget_refusal_happens_before_provider_dispatch(tmp_path):
+    ledger = _ledger(tmp_path, limit=0.5)
+    engine, assignment, context = _runtime(tmp_path, ledger=ledger)
+    marker = tmp_path / "authorized"
+    engine._environ["AUTH_MARKER"] = os.fspath(marker)
+
+    with pytest.raises(BudgetExceeded):
+        await engine.hunt(assignment, object())
+
+    assert not marker.exists()
+    assert ledger.spent_usd == 0.0
+    context.cleanup_variants.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_packaged_pi_sdk_reaches_the_budget_gate_without_dispatch(tmp_path):
+    from clearwing.sourcehunt.cyberpi import CyberPiHuntEngine
+
+    command = CyberPiHuntEngine.default_command()
+    dependency = Path(command[1]).parent / "node_modules" / "@earendil-works" / "pi-coding-agent"
+    if not dependency.is_dir():
+        pytest.skip("CyberPi npm dependencies are not installed")
+    ledger = _ledger(tmp_path, limit=0.5)
+    engine, assignment, context = _runtime(tmp_path, ledger=ledger)
+    engine._command = command
+    engine._environ = None
+
+    with pytest.raises(BudgetExceeded):
+        await engine.hunt(assignment, object())
+
+    assert ledger.spent_usd == 0.0
+    context.cleanup_variants.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["malformed_usage", "model_error"])
+async def test_ambiguous_model_failures_charge_the_reservation(tmp_path, mode):
+    from clearwing.sourcehunt.cyberpi import CyberPiError
+
+    ledger = _ledger(tmp_path)
+    engine, assignment, _context = _runtime(tmp_path, mode=mode, ledger=ledger)
+
+    with pytest.raises(CyberPiError):
+        await engine.hunt(assignment, object())
+
+    assert ledger.spent_usd == pytest.approx(2.0)
+    assert ledger.remaining_usd == pytest.approx(0.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["malformed_json", "unexpected", "exit"])
+async def test_protocol_violations_fail_closed(tmp_path, mode):
+    from clearwing.sourcehunt.cyberpi import CyberPiError
+
+    engine, assignment, context = _runtime(tmp_path, mode=mode)
+
+    with pytest.raises(CyberPiError):
+        await engine.hunt(assignment, object())
+
+    context.cleanup_variants.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_kills_child_and_conservatively_settles(tmp_path):
+    ledger = _ledger(tmp_path)
+    engine, assignment, context = _runtime(tmp_path, mode="cancel", ledger=ledger)
+    pid_file = tmp_path / "pid"
+    engine._environ["PID_FILE"] = os.fspath(pid_file)
+    task = asyncio.create_task(engine.hunt(assignment, object()))
+    for _ in range(100):
+        if pid_file.exists():
+            break
+        await asyncio.sleep(0.01)
+    assert pid_file.exists()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    with pytest.raises(ProcessLookupError):
+        os.kill(int(pid_file.read_text()), 0)
+    assert ledger.spent_usd == pytest.approx(2.0)
+    context.cleanup_variants.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_tool_boundary_rejects_unknown_malformed_and_unsafe_calls():
+    from clearwing.sourcehunt.cyberpi import CyberPiHuntEngine
+
+    async def handler(**_kwargs):
+        return "ok"
+
+    tool = NativeToolSpec(
+        name="write_file",
+        description="write",
+        schema=_schema(
+            {"path": {"type": "string"}, "contents": {"type": "string"}},
+            ["path", "contents"],
+        ),
+        handler=handler,
+    )
+    cases = [
+        {"id": "1", "name": "unknown", "arguments": {}},
+        {"id": "2", "name": "write_file", "arguments": []},
+        {"id": "3", "name": "write_file", "arguments": {"path": "/scratch/a"}},
+        {
+            "id": "4",
+            "name": "write_file",
+            "arguments": {"path": 7, "contents": "x"},
+        },
+        {
+            "id": "5",
+            "name": "write_file",
+            "arguments": {"path": "/scratch/a", "contents": "x", "extra": True},
+        },
+        {
+            "id": "6",
+            "name": "write_file",
+            "arguments": {"path": "/etc/passwd", "contents": "x"},
+        },
+    ]
+
+    results = [await CyberPiHuntEngine._invoke_tool([tool], case) for case in cases]
+
+    assert all(result["ok"] is False for result in results)
+    allowed = await CyberPiHuntEngine._invoke_tool(
+        [tool],
+        {
+            "id": "7",
+            "name": "write_file",
+            "arguments": {"path": "/scratch/poc.py", "contents": "x"},
+        },
+    )
+    assert allowed["ok"] is True
+    assert CyberPiHuntEngine._is_scratch_path("/scratch/../etc/passwd") is False
+
+
+def test_deepseek_v4_flash_uses_the_pi_token_plan_adapter():
+    from clearwing.sourcehunt.cyberpi import CyberPiHuntEngine
+
+    model = CyberPiHuntEngine._model_from_client(_client())
+
+    assert model.provider == "qwen-token-plan-individual"
+    assert model.model == "deepseek-v4-flash-0731"
+    assert model.api == "openai-completions"
+
+
+def test_native_is_default_and_does_not_import_cyberpi():
+    sys.modules.pop("clearwing.sourcehunt.cyberpi", None)
+    pool = HunterPool(
+        HuntPoolConfig(
+            files=[],
+            repo_path="/repo",
+            hunter_factory=lambda *_args: None,
+        )
+    )
+
+    assert isinstance(pool._hunt_engine, NativeHuntEngine)
+    assert "clearwing.sourcehunt.cyberpi" not in sys.modules
+    assert FeatureFlags().hunt_engine == "native"
+
+
+def test_engine_injection_uses_the_domain_contract():
+    finding = Finding(file="src/app.c", finding_type="test", description="test")
+
+    class Engine:
+        async def hunt(self, assignment, sandbox):
+            assert assignment.file_target["path"] == "src/app.c"
+            assert sandbox is None
+            return HuntOutcome((finding,), 0.25, 11, "completed")
+
+    pool = HunterPool(
+        HuntPoolConfig(
+            files=[{"path": "src/app.c", "priority": 4.0}],
+            repo_path="/repo",
+            hunt_engine=Engine(),
+            starting_band="deep",
+            max_band="deep",
+            redundancy_override=1,
+        )
+    )
+
+    assert pool.run() == [finding]
+
+
+def test_cli_and_machine_mode_expose_engine_selection():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    sourcehunt_command.add_parser(subparsers)
+
+    assert parser.parse_args(["sourcehunt", "repo"]).hunt_engine == "native"
+    assert (
+        parser.parse_args(["sourcehunt", "repo", "--hunt-engine", "cyberpi"]).hunt_engine
+        == "cyberpi"
+    )
+    parsed = sourcehunt_command._machine_request(
+        {"repo_url": "https://example.test/repo", "hunt_engine": "cyberpi"}
+    )
+    assert parsed["hunt_engine"] == "cyberpi"


### PR DESCRIPTION
## Summary

- add one Sourcehunt domain seam: `HuntAssignment -> HuntEngine.hunt() -> HuntOutcome`
- keep the native engine behavior-compatible and default; make CyberPi explicitly opt-in
- run Pi as a pinned, locked-down sidecar with only Clearwing-owned tools and budget authorization before provider dispatch
- add a cohesive operator workflow: `clearwing cyberpi install|doctor|smoke|benchmark`
- add complete native/CyberPi JSONL trajectories for prompt evaluation and GEPA

## Operator UX

- atomically install Pi 0.84.1 from the packaged lockfile into `~/.clearwing/cyberpi/pi-0.84.1`
- diagnose Node, npm, pinned sidecar resources, and Docker with rich or plain JSON output
- fail CyberPi repository hunts before preprocessing when the runtime or Docker sandbox is unavailable
- smoke-test Pi/provider/tool routing on a bounded in-memory fixture without Docker
- compare native and CyberPi with identical model, prompt, tools, fixtures, turn cap, and output-token cap; emit JSON, Markdown, and full trajectories
- document setup, provider aliases, outputs, interpretation, troubleshooting, and benchmark limitations

## Safety

- require an isolated HunterSandbox for repository hunts
- disable Pi built-in tools, extensions, prompts, skills, sessions, retries, compaction, and context discovery
- validate the size-bounded JSONL protocol, trajectory records, usage, and tool arguments
- restrict writes to `/scratch` and accept findings only through Clearwing `HunterContext`
- fail closed, redact provider errors, avoid persisting credentials, and conservatively settle budget reservations
- preserve all native defaults

## Verification

- 2,808 environment-independent tests passed; 26 skipped
- unfiltered suite exposed only the known Docker/socket/model-download failures plus one test-double compatibility issue, which was corrected and rerun green
- focused CyberPi/hunter/instrumentation suite: 37 passed
- Ruff, focused mypy, Node syntax, and diff checks pass
- wheel and sdist contain the runtime, command, benchmark, and pinned sidecar resources
- managed install, idempotent reinstall, and JSON doctor output verified locally
- live smoke against `DeepSeek-v4-Flash-0731`: passed, found the known line-7 CWE-122 fixture, 4,242 tokens
- one-replicate paired baseline: CyberPi 2/2; native 1/2. Both found the overflow; only CyberPi declined the bounded-safe case. This is a micro-benchmark, not a CVE recall claim.
- all four live trajectories contain start metadata, assistant usage/reasoning, tool activity, and finish records; no credential fields were emitted

## Remaining draft validation

- run the full Docker-backed Sourcehunt E2E in an environment with Docker
- expand to a held-out CVE corpus and multiple replicates before changing the CyberPi security prompt
- use the emitted trajectories as the evaluation input for GEPA experiments
