### PR TITLE
feat(sourcehunt): checkpoint hunt, verification, and exploitation

### DIFF
--- a/clearwing/sourcehunt/checkpoints.py
+++ b/clearwing/sourcehunt/checkpoints.py
@@ -11,12 +11,16 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
+from clearwing.findings.types import Finding
+
 from .preprocessor import PreprocessResult
 
 PREPROCESS_CHECKPOINT_SCHEMA_VERSION = 1
 PREPROCESSOR_VERSION = 1
 RANK_CHECKPOINT_SCHEMA_VERSION = 1
 RANKER_VERSION = 1
+HUNT_CHECKPOINT_SCHEMA_VERSION = 1
+HUNTER_VERSION = 1
 
 
 class PreprocessFingerprint(BaseModel):
@@ -227,6 +231,118 @@ class RankCheckpointStore:
             metrics={"files": len(files)},
         )
         PreprocessCheckpointStore._atomic_write(self.result_path, payload)
+        PreprocessCheckpointStore._atomic_write(
+            self.envelope_path,
+            envelope.model_dump_json(indent=2).encode("utf-8"),
+        )
+
+
+def ranked_targets_digest(files: list[dict]) -> str:
+    payload = json.dumps(files, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class HuntResult(BaseModel):
+    """Complete hand-off from the hunt stage to verification."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    findings: list[Finding]
+    files_hunted: int = 0
+    spent_per_tier: dict[str, float]
+    band_stats: dict[str, Any] | None = None
+    subsystems_hunted: int = 0
+    subsystem_spent_usd: float = 0.0
+
+
+class HuntFingerprint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ranked_targets_digest: str
+    options: dict[str, Any]
+    hunter_version: Literal[1] = HUNTER_VERSION
+
+
+class HuntCheckpoint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = HUNT_CHECKPOINT_SCHEMA_VERSION
+    stage: Literal["hunt"] = "hunt"
+    status: Literal["completed", "budget_exhausted"]
+    session_id: str
+    fingerprint: HuntFingerprint
+    result_path: Literal["result.json"] = "result.json"
+    result_sha256: str
+    metrics: dict[str, int | float]
+
+
+class HuntCheckpointStore:
+    """Persist and restore a terminal hunt result.
+
+    Both a normally completed hunt and a hunt stopped by the run budget are
+    terminal, restorable states. Mid-hunt state is deliberately not modeled.
+    """
+
+    def __init__(self, session_dir: Path, session_id: str):
+        self.directory = session_dir / "checkpoints" / "hunt"
+        self.session_id = session_id
+        self.envelope_path = self.directory / "checkpoint.json"
+        self.result_path = self.directory / "result.json"
+        self.last_status: Literal["completed", "budget_exhausted"] | None = None
+
+    def load(
+        self,
+        *,
+        ranked_targets_digest: str,
+        options: dict[str, Any],
+    ) -> HuntResult | None:
+        self.last_status = None
+        try:
+            envelope = HuntCheckpoint.model_validate_json(
+                self.envelope_path.read_text(encoding="utf-8")
+            )
+            if envelope.session_id != self.session_id:
+                return None
+            if envelope.fingerprint.ranked_targets_digest != ranked_targets_digest:
+                return None
+            if envelope.fingerprint.options != options:
+                return None
+            payload = (self.directory / envelope.result_path).read_bytes()
+            if hashlib.sha256(payload).hexdigest() != envelope.result_sha256:
+                return None
+            result = HuntResult.model_validate_json(payload)
+            self.last_status = envelope.status
+            return result
+        except (OSError, ValueError, TypeError):
+            return None
+
+    def save(
+        self,
+        result: HuntResult,
+        *,
+        status: Literal["completed", "budget_exhausted"],
+        ranked_targets_digest: str,
+        options: dict[str, Any],
+    ) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        payload = result.model_dump_json(indent=2).encode("utf-8")
+        envelope = HuntCheckpoint(
+            status=status,
+            session_id=self.session_id,
+            fingerprint=HuntFingerprint(
+                ranked_targets_digest=ranked_targets_digest,
+                options=options,
+            ),
+            result_sha256=hashlib.sha256(payload).hexdigest(),
+            metrics={
+                "findings": len(result.findings),
+                "files_hunted": result.files_hunted,
+                "subsystems_hunted": result.subsystems_hunted,
+                "subsystem_spent_usd": result.subsystem_spent_usd,
+            },
+        )
+        PreprocessCheckpointStore._atomic_write(self.result_path, payload)
+        # The envelope is written last and acts as the completed-stage marker.
         PreprocessCheckpointStore._atomic_write(
             self.envelope_path,
             envelope.model_dump_json(indent=2).encode("utf-8"),

--- a/clearwing/sourcehunt/checkpoints.py
+++ b/clearwing/sourcehunt/checkpoints.py
@@ -9,7 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
 
 from clearwing.findings.types import Finding
 
@@ -27,13 +27,145 @@ EXPLOIT_CHECKPOINT_SCHEMA_VERSION = 1
 EXPLOITER_VERSION = 1
 
 
+class CheckpointOptions(BaseModel):
+    """Strict, immutable compatibility inputs for a stage checkpoint."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class PreprocessCheckpointOptions(CheckpointOptions):
+    tag_files: bool = True
+    build_callgraph: bool = False
+    propagate_reachability: bool = False
+    run_semgrep: bool = False
+    run_taint: bool = False
+    respect_gitignore: bool = True
+    subsystem_paths: list[str] = Field(default_factory=list)
+
+
+class RankCheckpointOptions(CheckpointOptions):
+    no_rank: bool = False
+    preprocessing: bool = True
+    model: str = ""
+    max_parallel: int = 4
+
+
+class HuntCheckpointOptions(CheckpointOptions):
+    depth: str = "standard"
+    agent_mode: str = "auto"
+    prompt_mode: str = "unconstrained"
+    model: str = ""
+    max_parallel: int = 4
+    tier_budget: dict[str, Any] = Field(default_factory=dict)
+    starting_band: str | None = None
+    max_band: str | None = None
+    redundancy_override: int | None = None
+    no_per_file_hunt: bool = False
+    enable_subsystem_hunt: bool = False
+    subsystem_paths: list[str] = Field(default_factory=list)
+    subsystem_max_files: int | None = None
+    subsystem_max_parallel: int = 4
+    shard_entry_points: bool = False
+    min_shard_rank: int = 4
+    min_project_loc: int = 0
+    seed_corpus_sources: list[str] = Field(default_factory=list)
+    seed_harness_crashes: bool = False
+    campaign_hint: str = ""
+    exploit_mode: str | bool = False
+
+
+class VerificationCheckpointOptions(CheckpointOptions):
+    no_verify: bool = False
+    validator_mode: str = "v1"
+    model: str = ""
+    adversarial_verifier: bool = False
+    adversarial_threshold: str | None = "static_corroboration"
+    enable_patch_oracle: bool = False
+    enable_calibration: bool = False
+    enable_mechanism_memory: bool = False
+    enable_variant_loop: bool = False
+    enable_stability_verification: bool = False
+
+
+class ExploitationCheckpointOptions(CheckpointOptions):
+    no_exploit: bool = False
+    model: str = ""
+    exploit_mode: str | bool = False
+    exploit_budget_band: str = "standard"
+    enable_elaboration: bool = False
+    elaboration_cap: int | str = 0
+    enable_auto_patch: bool = False
+    auto_pr: bool = False
+    enable_knowledge_graph: bool = False
+    export_disclosures: bool = False
+    disclosure_reporter_name: str = ""
+    disclosure_reporter_affiliation: str = ""
+    disclosure_reporter_email: str = ""
+    enable_artifact_store: bool = False
+
+
+def preprocess_checkpoint_options(
+    *,
+    depth: str,
+    preprocessing: bool,
+    no_rank: bool,
+    respect_gitignore: bool,
+    subsystem_paths: list[str] | None,
+) -> PreprocessCheckpointOptions:
+    enabled = depth != "quick" and preprocessing
+    return PreprocessCheckpointOptions(
+        build_callgraph=enabled,
+        propagate_reachability=enabled,
+        run_semgrep=enabled,
+        run_taint=enabled and not no_rank,
+        respect_gitignore=respect_gitignore,
+        subsystem_paths=sorted(subsystem_paths or []),
+    )
+
+
+def rank_checkpoint_options(
+    *, no_rank: bool, preprocessing: bool, model: str | None, max_parallel: int
+) -> RankCheckpointOptions:
+    return RankCheckpointOptions(
+        no_rank=no_rank,
+        preprocessing=preprocessing,
+        model=model or "",
+        max_parallel=max_parallel,
+    )
+
+
+def hunt_checkpoint_options(**values: Any) -> HuntCheckpointOptions:
+    values["model"] = values.get("model") or ""
+    values["campaign_hint"] = values.get("campaign_hint") or ""
+    values["subsystem_paths"] = sorted(values.get("subsystem_paths") or [])
+    values["seed_corpus_sources"] = sorted(values.get("seed_corpus_sources") or [])
+    return HuntCheckpointOptions.model_validate(values)
+
+
+def verification_checkpoint_options(**values: Any) -> VerificationCheckpointOptions:
+    values["model"] = values.get("model") or ""
+    return VerificationCheckpointOptions.model_validate(values)
+
+
+def exploitation_checkpoint_options(**values: Any) -> ExploitationCheckpointOptions:
+    values["model"] = values.get("model") or ""
+    return ExploitationCheckpointOptions.model_validate(values)
+
+
+def _options_match(saved: CheckpointOptions, supplied: CheckpointOptions | dict[str, Any]) -> bool:
+    try:
+        return saved == type(saved).model_validate(supplied)
+    except (ValueError, TypeError):
+        return False
+
+
 class PreprocessFingerprint(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     repo_url: str
     branch: str
     source_digest: str
-    options: dict[str, Any]
+    options: PreprocessCheckpointOptions
     preprocessor_version: Literal[1] = PREPROCESSOR_VERSION
 
 
@@ -95,7 +227,7 @@ class PreprocessCheckpointStore:
         *,
         repo_url: str,
         branch: str,
-        options: dict[str, Any],
+        options: PreprocessCheckpointOptions | dict[str, Any],
     ) -> PreprocessResult | None:
         try:
             envelope = PreprocessCheckpoint.model_validate_json(
@@ -105,7 +237,9 @@ class PreprocessCheckpointStore:
                 return None
             if envelope.fingerprint.repo_url != repo_url:
                 return None
-            if envelope.fingerprint.branch != branch or envelope.fingerprint.options != options:
+            if envelope.fingerprint.branch != branch or not _options_match(
+                envelope.fingerprint.options, options
+            ):
                 return None
             payload = (self.directory / envelope.result_path).read_bytes()
             if hashlib.sha256(payload).hexdigest() != envelope.result_sha256:
@@ -127,7 +261,7 @@ class PreprocessCheckpointStore:
         *,
         repo_url: str,
         branch: str,
-        options: dict[str, Any],
+        options: PreprocessCheckpointOptions | dict[str, Any],
     ) -> None:
         self.directory.mkdir(parents=True, exist_ok=True)
         payload = result.model_dump_json(indent=2).encode("utf-8")
@@ -178,7 +312,7 @@ def preprocess_result_digest(result: PreprocessResult) -> str:
 class RankFingerprint(BaseModel):
     model_config = ConfigDict(extra="forbid")
     preprocess_digest: str
-    options: dict[str, Any]
+    options: RankCheckpointOptions
     ranker_version: Literal[1] = RANKER_VERSION
 
 
@@ -201,7 +335,12 @@ class RankCheckpointStore:
         self.envelope_path = self.directory / "checkpoint.json"
         self.result_path = self.directory / "result.json"
 
-    def load(self, *, preprocess_digest: str, options: dict[str, Any]) -> list[dict] | None:
+    def load(
+        self,
+        *,
+        preprocess_digest: str,
+        options: RankCheckpointOptions | dict[str, Any],
+    ) -> list[dict] | None:
         try:
             envelope = RankCheckpoint.model_validate_json(
                 self.envelope_path.read_text(encoding="utf-8")
@@ -210,7 +349,7 @@ class RankCheckpointStore:
                 return None
             if envelope.fingerprint.preprocess_digest != preprocess_digest:
                 return None
-            if envelope.fingerprint.options != options:
+            if not _options_match(envelope.fingerprint.options, options):
                 return None
             payload = (self.directory / envelope.result_path).read_bytes()
             if hashlib.sha256(payload).hexdigest() != envelope.result_sha256:
@@ -222,7 +361,13 @@ class RankCheckpointStore:
         except (OSError, ValueError, TypeError):
             return None
 
-    def save(self, files: list[dict], *, preprocess_digest: str, options: dict[str, Any]) -> None:
+    def save(
+        self,
+        files: list[dict],
+        *,
+        preprocess_digest: str,
+        options: RankCheckpointOptions | dict[str, Any],
+    ) -> None:
         self.directory.mkdir(parents=True, exist_ok=True)
         payload = json.dumps(files, indent=2, sort_keys=True).encode("utf-8")
         envelope = RankCheckpoint(
@@ -263,7 +408,7 @@ class HuntFingerprint(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     ranked_targets_digest: str
-    options: dict[str, Any]
+    options: HuntCheckpointOptions
     hunter_version: Literal[1] = HUNTER_VERSION
 
 
@@ -298,7 +443,7 @@ class HuntCheckpointStore:
         self,
         *,
         ranked_targets_digest: str,
-        options: dict[str, Any],
+        options: HuntCheckpointOptions | dict[str, Any],
     ) -> HuntResult | None:
         self.last_status = None
         try:
@@ -309,7 +454,7 @@ class HuntCheckpointStore:
                 return None
             if envelope.fingerprint.ranked_targets_digest != ranked_targets_digest:
                 return None
-            if envelope.fingerprint.options != options:
+            if not _options_match(envelope.fingerprint.options, options):
                 return None
             payload = (self.directory / envelope.result_path).read_bytes()
             if hashlib.sha256(payload).hexdigest() != envelope.result_sha256:
@@ -326,7 +471,7 @@ class HuntCheckpointStore:
         *,
         status: Literal["completed", "budget_exhausted"],
         ranked_targets_digest: str,
-        options: dict[str, Any],
+        options: HuntCheckpointOptions | dict[str, Any],
     ) -> None:
         self.directory.mkdir(parents=True, exist_ok=True)
         payload = result.model_dump_json(indent=2).encode("utf-8")
@@ -377,7 +522,7 @@ class VerificationFingerprint(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     hunt_findings_digest: str
-    options: dict[str, Any]
+    options: VerificationCheckpointOptions
     verifier_version: Literal[1] = VERIFIER_VERSION
 
 
@@ -403,7 +548,10 @@ class VerificationCheckpointStore:
         self.last_status: str | None = None
 
     def load(
-        self, *, hunt_findings_digest: str, options: dict[str, Any]
+        self,
+        *,
+        hunt_findings_digest: str,
+        options: VerificationCheckpointOptions | dict[str, Any],
     ) -> VerificationResult | None:
         self.last_status = None
         try:
@@ -414,7 +562,7 @@ class VerificationCheckpointStore:
                 return None
             if envelope.fingerprint.hunt_findings_digest != hunt_findings_digest:
                 return None
-            if envelope.fingerprint.options != options:
+            if not _options_match(envelope.fingerprint.options, options):
                 return None
             payload = (self.directory / envelope.result_path).read_bytes()
             if hashlib.sha256(payload).hexdigest() != envelope.result_sha256:
@@ -431,7 +579,7 @@ class VerificationCheckpointStore:
         *,
         status: Literal["completed", "degraded", "skipped", "budget_exhausted"],
         hunt_findings_digest: str,
-        options: dict[str, Any],
+        options: VerificationCheckpointOptions | dict[str, Any],
     ) -> None:
         self.directory.mkdir(parents=True, exist_ok=True)
         payload = result.model_dump_json(indent=2).encode("utf-8")
@@ -477,7 +625,7 @@ class ExploitationFingerprint(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     verification_result_digest: str
-    options: dict[str, Any]
+    options: ExploitationCheckpointOptions
     exploiter_version: Literal[1] = EXPLOITER_VERSION
 
 
@@ -503,7 +651,10 @@ class ExploitationCheckpointStore:
         self.last_status: str | None = None
 
     def load(
-        self, *, verification_result_digest: str, options: dict[str, Any]
+        self,
+        *,
+        verification_result_digest: str,
+        options: ExploitationCheckpointOptions | dict[str, Any],
     ) -> ExploitationResult | None:
         self.last_status = None
         try:
@@ -514,7 +665,7 @@ class ExploitationCheckpointStore:
                 return None
             if envelope.fingerprint.verification_result_digest != verification_result_digest:
                 return None
-            if envelope.fingerprint.options != options:
+            if not _options_match(envelope.fingerprint.options, options):
                 return None
             payload = (self.directory / envelope.result_path).read_bytes()
             if hashlib.sha256(payload).hexdigest() != envelope.result_sha256:
@@ -531,7 +682,7 @@ class ExploitationCheckpointStore:
         *,
         status: Literal["completed", "skipped", "budget_exhausted"],
         verification_result_digest: str,
-        options: dict[str, Any],
+        options: ExploitationCheckpointOptions | dict[str, Any],
     ) -> None:
         self.directory.mkdir(parents=True, exist_ok=True)
         payload = result.model_dump_json(indent=2).encode("utf-8")

--- a/clearwing/sourcehunt/checkpoints.py
+++ b/clearwing/sourcehunt/checkpoints.py
@@ -9,7 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, TypeAdapter
 
 from clearwing.findings.types import Finding
 
@@ -21,6 +21,10 @@ RANK_CHECKPOINT_SCHEMA_VERSION = 1
 RANKER_VERSION = 1
 HUNT_CHECKPOINT_SCHEMA_VERSION = 1
 HUNTER_VERSION = 1
+VERIFY_CHECKPOINT_SCHEMA_VERSION = 1
+VERIFIER_VERSION = 1
+EXPLOIT_CHECKPOINT_SCHEMA_VERSION = 1
+EXPLOITER_VERSION = 1
 
 
 class PreprocessFingerprint(BaseModel):
@@ -343,6 +347,209 @@ class HuntCheckpointStore:
         )
         PreprocessCheckpointStore._atomic_write(self.result_path, payload)
         # The envelope is written last and acts as the completed-stage marker.
+        PreprocessCheckpointStore._atomic_write(
+            self.envelope_path,
+            envelope.model_dump_json(indent=2).encode("utf-8"),
+        )
+
+
+def findings_digest(findings: list[Finding]) -> str:
+    payload = json.dumps(
+        TypeAdapter(list[Finding]).dump_python(findings, mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class VerificationResult(BaseModel):
+    """Complete hand-off from verification to exploitation."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    findings: list[Finding]
+    verified_findings: list[Finding]
+    rejected_findings: list[Finding]
+
+
+class VerificationFingerprint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    hunt_findings_digest: str
+    options: dict[str, Any]
+    verifier_version: Literal[1] = VERIFIER_VERSION
+
+
+class VerificationCheckpoint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = VERIFY_CHECKPOINT_SCHEMA_VERSION
+    stage: Literal["verify"] = "verify"
+    status: Literal["completed", "degraded", "skipped", "budget_exhausted"]
+    session_id: str
+    fingerprint: VerificationFingerprint
+    result_path: Literal["result.json"] = "result.json"
+    result_sha256: str
+    metrics: dict[str, int]
+
+
+class VerificationCheckpointStore:
+    def __init__(self, session_dir: Path, session_id: str):
+        self.directory = session_dir / "checkpoints" / "verify"
+        self.session_id = session_id
+        self.envelope_path = self.directory / "checkpoint.json"
+        self.result_path = self.directory / "result.json"
+        self.last_status: str | None = None
+
+    def load(
+        self, *, hunt_findings_digest: str, options: dict[str, Any]
+    ) -> VerificationResult | None:
+        self.last_status = None
+        try:
+            envelope = VerificationCheckpoint.model_validate_json(
+                self.envelope_path.read_text(encoding="utf-8")
+            )
+            if envelope.session_id != self.session_id:
+                return None
+            if envelope.fingerprint.hunt_findings_digest != hunt_findings_digest:
+                return None
+            if envelope.fingerprint.options != options:
+                return None
+            payload = (self.directory / envelope.result_path).read_bytes()
+            if hashlib.sha256(payload).hexdigest() != envelope.result_sha256:
+                return None
+            result = VerificationResult.model_validate_json(payload)
+            self.last_status = envelope.status
+            return result
+        except (OSError, ValueError, TypeError):
+            return None
+
+    def save(
+        self,
+        result: VerificationResult,
+        *,
+        status: Literal["completed", "degraded", "skipped", "budget_exhausted"],
+        hunt_findings_digest: str,
+        options: dict[str, Any],
+    ) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        payload = result.model_dump_json(indent=2).encode("utf-8")
+        envelope = VerificationCheckpoint(
+            status=status,
+            session_id=self.session_id,
+            fingerprint=VerificationFingerprint(
+                hunt_findings_digest=hunt_findings_digest,
+                options=options,
+            ),
+            result_sha256=hashlib.sha256(payload).hexdigest(),
+            metrics={
+                "findings": len(result.findings),
+                "verified": len(result.verified_findings),
+                "rejected": len(result.rejected_findings),
+            },
+        )
+        PreprocessCheckpointStore._atomic_write(self.result_path, payload)
+        PreprocessCheckpointStore._atomic_write(
+            self.envelope_path,
+            envelope.model_dump_json(indent=2).encode("utf-8"),
+        )
+
+
+def verification_result_digest(result: VerificationResult) -> str:
+    payload = json.dumps(
+        result.model_dump(mode="json"), sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+class ExploitationResult(BaseModel):
+    """Complete hand-off from exploitation to reporting."""
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    findings: list[Finding]
+    verified_findings: list[Finding]
+    exploited_findings: list[Finding]
+
+
+class ExploitationFingerprint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    verification_result_digest: str
+    options: dict[str, Any]
+    exploiter_version: Literal[1] = EXPLOITER_VERSION
+
+
+class ExploitationCheckpoint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = EXPLOIT_CHECKPOINT_SCHEMA_VERSION
+    stage: Literal["exploit"] = "exploit"
+    status: Literal["completed", "skipped", "budget_exhausted"]
+    session_id: str
+    fingerprint: ExploitationFingerprint
+    result_path: Literal["result.json"] = "result.json"
+    result_sha256: str
+    metrics: dict[str, int]
+
+
+class ExploitationCheckpointStore:
+    def __init__(self, session_dir: Path, session_id: str):
+        self.directory = session_dir / "checkpoints" / "exploit"
+        self.session_id = session_id
+        self.envelope_path = self.directory / "checkpoint.json"
+        self.result_path = self.directory / "result.json"
+        self.last_status: str | None = None
+
+    def load(
+        self, *, verification_result_digest: str, options: dict[str, Any]
+    ) -> ExploitationResult | None:
+        self.last_status = None
+        try:
+            envelope = ExploitationCheckpoint.model_validate_json(
+                self.envelope_path.read_text(encoding="utf-8")
+            )
+            if envelope.session_id != self.session_id:
+                return None
+            if envelope.fingerprint.verification_result_digest != verification_result_digest:
+                return None
+            if envelope.fingerprint.options != options:
+                return None
+            payload = (self.directory / envelope.result_path).read_bytes()
+            if hashlib.sha256(payload).hexdigest() != envelope.result_sha256:
+                return None
+            result = ExploitationResult.model_validate_json(payload)
+            self.last_status = envelope.status
+            return result
+        except (OSError, ValueError, TypeError):
+            return None
+
+    def save(
+        self,
+        result: ExploitationResult,
+        *,
+        status: Literal["completed", "skipped", "budget_exhausted"],
+        verification_result_digest: str,
+        options: dict[str, Any],
+    ) -> None:
+        self.directory.mkdir(parents=True, exist_ok=True)
+        payload = result.model_dump_json(indent=2).encode("utf-8")
+        envelope = ExploitationCheckpoint(
+            status=status,
+            session_id=self.session_id,
+            fingerprint=ExploitationFingerprint(
+                verification_result_digest=verification_result_digest,
+                options=options,
+            ),
+            result_sha256=hashlib.sha256(payload).hexdigest(),
+            metrics={
+                "findings": len(result.findings),
+                "verified": len(result.verified_findings),
+                "exploited": len(result.exploited_findings),
+            },
+        )
+        PreprocessCheckpointStore._atomic_write(self.result_path, payload)
         PreprocessCheckpointStore._atomic_write(
             self.envelope_path,
             envelope.model_dump_json(indent=2).encode("utf-8"),

--- a/clearwing/sourcehunt/findings_pool.py
+++ b/clearwing/sourcehunt/findings_pool.py
@@ -227,6 +227,32 @@ class FindingsPool:
     def all_findings(self) -> list[Finding]:
         return list(self._findings.values())
 
+    def restore_completed(self, findings: list[Finding]) -> None:
+        """Hydrate a completed hunt without replaying live add side effects.
+
+        The end-of-hunt checkpoint is already deduplicated and classified, so
+        restoring it must not append duplicate JSONL entries or invoke the LLM.
+        """
+
+        self._findings = {finding.id: finding for finding in findings}
+        self._clusters = {}
+        for finding in findings:
+            cluster_id = finding.cluster_id
+            if not cluster_id:
+                continue
+            cluster = self._clusters.get(cluster_id)
+            if cluster is None:
+                cluster = FindingCluster(
+                    cluster_id=cluster_id,
+                    root_cause_summary=finding.description,
+                    primitive_type=finding.primitive_type,
+                    cwe=finding.cwe,
+                )
+                self._clusters[cluster_id] = cluster
+            cluster.finding_ids.append(finding.id)
+            if finding.file:
+                cluster.file_paths.add(finding.file)
+
     def clusters(self) -> list[FindingCluster]:
         return list(self._clusters.values())
 

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -35,7 +35,13 @@ from clearwing.providers import (
 )
 
 from ..sandbox.hunter_sandbox import HunterSandbox
-from .checkpoints import PreprocessCheckpointStore, RankCheckpointStore
+from .checkpoints import (
+    HuntCheckpointStore,
+    HuntResult,
+    PreprocessCheckpointStore,
+    RankCheckpointStore,
+    ranked_targets_digest,
+)
 from .config import SourceHuntConfig
 from .disclosure import (
     DisclosureGenerator,
@@ -1068,10 +1074,6 @@ class SourceHuntRunner:
                 ),
                 files=stage_files,
             )
-            _t = time.monotonic()
-            self._ensure_sandbox_factory(repo_path, files)
-            logger.info("Sandbox factory ready in %.2fs", time.monotonic() - _t)
-
             # 2. Rank — unless depth=quick AND no LLM available, or --no-rank
             ranker_llm = (
                 None
@@ -1236,6 +1238,32 @@ class SourceHuntRunner:
                     ft["surface"] * 0.5 + ft["influence"] * 0.2 + ft["reachability"] * 0.3
                 )
 
+            hunt_options = self._hunt_checkpoint_options()
+            ranked_digest = ranked_targets_digest(files)
+            hunt_store = HuntCheckpointStore(
+                Path(self.output_dir) / self._session_id,
+                self._session_id,
+            )
+            restored_hunt = None
+            if self._resume_session_id and self.depth != "quick":
+                restored_hunt = hunt_store.load(
+                    ranked_targets_digest=ranked_digest,
+                    options=hunt_options,
+                )
+                if restored_hunt is not None:
+                    logger.info(
+                        "Restored %s hunt result from session %s",
+                        hunt_store.last_status,
+                        self._session_id,
+                    )
+
+            # Hunt needs a sandbox; a restored hunt only needs one when a
+            # downstream verification or exploitation phase will use it.
+            if restored_hunt is None or not self.no_verify or not self.no_exploit:
+                _t = time.monotonic()
+                self._ensure_sandbox_factory(repo_path, files)
+                logger.info("Sandbox factory ready in %.2fs", time.monotonic() - _t)
+
             # depth=quick exits here with the static_findings as-is
             if self.depth == "quick":
                 return self._build_quick_result(
@@ -1251,7 +1279,7 @@ class SourceHuntRunner:
             seeded_crashes: list[SeededCrash] = []
             if (
                 self.depth == "deep" or self._seed_harness_crashes
-            ) and not self._budget_exhausted():
+            ) and restored_hunt is None and not self._budget_exhausted():
                 harness_llm = self._get_native_client(
                     "hunter",
                     self.hunter_llm,
@@ -1304,7 +1332,7 @@ class SourceHuntRunner:
             # v0.3: Recall cross-run mechanisms and inject them into every hunter's
             # hint list as a synthetic entry. The hunter's prompt wraps these in
             # "static analysis hints — NOT ground truth" framing.
-            if self._mechanism_store is not None:
+            if restored_hunt is None and self._mechanism_store is not None:
                 mechanism_hints = self._recalled_mechanism_hints(files)
                 if mechanism_hints:
                     for ft in files:
@@ -1313,7 +1341,11 @@ class SourceHuntRunner:
 
             # 2.7. Entry-point extraction (spec 004)
             entry_points_by_file: dict = {}
-            if self._shard_entry_points and preprocess_result.callgraph is not None:
+            if (
+                restored_hunt is None
+                and self._shard_entry_points
+                and preprocess_result.callgraph is not None
+            ):
                 total_loc = sum(ft.get("loc", 0) for ft in files)
                 if total_loc >= self._min_project_loc:
                     try:
@@ -1334,7 +1366,7 @@ class SourceHuntRunner:
 
             # 2.8. Seed corpus ingestion (spec 004)
             seed_corpus_by_file: dict = {}
-            if self._seed_corpus_sources:
+            if restored_hunt is None and self._seed_corpus_sources:
                 try:
                     from .seed_corpus import ingest_seed_corpus
 
@@ -1368,25 +1400,39 @@ class SourceHuntRunner:
 
                 checkpoint_path = Path(self.output_dir) / self._session_id / "findings_pool.jsonl"
                 findings_pool = FindingsPool(checkpoint_path=checkpoint_path)
-                try:
-                    historical_db = HistoricalFindingsDB(path=self._historical_db_path)
-                    prior = historical_db.query_prior(repo_url=self.repo_url)
-                    if prior:
-                        logger.info("Loaded %d historical findings for dedup", len(prior))
-                except Exception:
-                    logger.warning("Historical findings DB load failed", exc_info=True)
-                    historical_db = None
+                if restored_hunt is None:
+                    try:
+                        historical_db = HistoricalFindingsDB(path=self._historical_db_path)
+                        prior = historical_db.query_prior(repo_url=self.repo_url)
+                        if prior:
+                            logger.info("Loaded %d historical findings for dedup", len(prior))
+                    except Exception:
+                        logger.warning("Historical findings DB load failed", exc_info=True)
+                        historical_db = None
 
             # 3. Tiered hunt
-            hunter_llm = self._get_native_client(
-                "hunter",
-                self.hunter_llm,
-                budget_stage="hunt",
+            hunter_llm = (
+                None
+                if restored_hunt is not None
+                else self._get_native_client(
+                    "hunter",
+                    self.hunter_llm,
+                    budget_stage="hunt",
+                )
             )
             all_findings: list[Finding] = []
             files_hunted = 0
             spent_per_tier: dict[str, float] = {"A": 0.0, "B": 0.0, "C": 0.0}
             band_stats: dict | None = None
+            hunt_failed = False
+            hunt_budget_exhausted = False
+            if restored_hunt is not None:
+                all_findings = list(restored_hunt.findings)
+                files_hunted = restored_hunt.files_hunted
+                spent_per_tier = dict(restored_hunt.spent_per_tier)
+                band_stats = restored_hunt.band_stats
+                if findings_pool is not None:
+                    findings_pool.restore_completed(all_findings)
             hunt_symbols = sorted(
                 {
                     str(getattr(entry_point, "function_name", "") or "")
@@ -1396,7 +1442,28 @@ class SourceHuntRunner:
                 }
             )
 
-            if self._no_per_file_hunt:
+            if restored_hunt is not None:
+                restored_status = hunt_store.last_status or "completed"
+                if restored_status == "budget_exhausted":
+                    pipeline_status.record(
+                        "hunter_pool",
+                        StageOutcome.SKIPPED,
+                        fallback_description=(
+                            "Restored partial hunter results saved at budget exhaustion"
+                        ),
+                    )
+                else:
+                    pipeline_status.record_succeeded("hunter_pool")
+                self._emit_stage(
+                    "hunt",
+                    restored_status,
+                    findings_so_far=len(all_findings),
+                    detail=f"Restored {len(all_findings)} findings from checkpoint",
+                    files=[str(finding.file or "") for finding in all_findings],
+                    symbols=self._finding_symbols(all_findings),
+                    finding_ids=[finding.id for finding in all_findings],
+                )
+            elif self._no_per_file_hunt:
                 logger.info("Per-file hunt skipped (--no-per-file-hunt)")
                 self._emit_stage(
                     "hunt",
@@ -1447,6 +1514,7 @@ class SourceHuntRunner:
                     all_findings = await pool.arun()
                     logger.info("HunterPool completed with %d findings", len(all_findings))
                     if pool.budget_exhausted or self._budget_exhausted():
+                        hunt_budget_exhausted = True
                         pipeline_status.record(
                             "hunter_pool",
                             StageOutcome.SKIPPED,
@@ -1475,6 +1543,7 @@ class SourceHuntRunner:
                             finding_ids=[finding.id for finding in all_findings],
                         )
                 except BudgetExceeded:
+                    hunt_budget_exhausted = True
                     logger.info("HunterPool stopped because the run budget is exhausted")
                     pipeline_status.record(
                         "hunter_pool",
@@ -1490,6 +1559,7 @@ class SourceHuntRunner:
                         finding_ids=[finding.id for finding in all_findings],
                     )
                 except Exception as exc:
+                    hunt_failed = True
                     logger.warning("HunterPool run failed", exc_info=True)
                     pipeline_status.record_degraded(
                         "hunter_pool",
@@ -1521,11 +1591,13 @@ class SourceHuntRunner:
                     hunt_status = "skipped"
                     hunt_detail = "No source files were available"
                 elif self._budget_exhausted():
+                    hunt_budget_exhausted = True
                     hunt_status = "budget_exhausted"
                     hunt_detail = "Run budget was exhausted before hunting"
                 else:
                     hunt_status = "degraded"
                     hunt_detail = "No hunter model was available"
+                    hunt_failed = True
                 self._emit_stage(
                     "hunt",
                     hunt_status,
@@ -1535,7 +1607,7 @@ class SourceHuntRunner:
                 )
 
             # 3.5. v0.6: Behavioral monitoring of findings text (spec 013).
-            if self._enable_behavior_monitor and all_findings:
+            if restored_hunt is None and self._enable_behavior_monitor and all_findings:
                 try:
                     from .behavior_monitor import BehaviorMonitor
 
@@ -1557,11 +1629,17 @@ class SourceHuntRunner:
 
             # Promote static findings into the all_findings list so depth=quick
             # output is still useful when no hunter llm is available
-            all_findings = self._merge_static_findings(all_findings, preprocess_result)
+            if restored_hunt is None:
+                all_findings = self._merge_static_findings(all_findings, preprocess_result)
 
             # 3.5. Persist findings to historical DB (spec 005)
             # Skip when running under campaign — campaign handles bulk ingestion.
-            if historical_db is not None and all_findings and self._injected_findings_pool is None:
+            if (
+                restored_hunt is None
+                and historical_db is not None
+                and all_findings
+                and self._injected_findings_pool is None
+            ):
                 try:
                     count = historical_db.ingest_campaign(
                         all_findings,
@@ -1575,9 +1653,15 @@ class SourceHuntRunner:
                     historical_db.close()
 
             # 3.7. Subsystem hunt (spec 006)
-            subsystems_hunted = 0
-            subsystem_spent = 0.0
-            if self._enable_subsystem_hunt and hunter_llm is not None and self._budget_exhausted():
+            subsystems_hunted = (
+                restored_hunt.subsystems_hunted if restored_hunt is not None else 0
+            )
+            subsystem_spent = (
+                restored_hunt.subsystem_spent_usd if restored_hunt is not None else 0.0
+            )
+            if restored_hunt is not None:
+                pass
+            elif self._enable_subsystem_hunt and hunter_llm is not None and self._budget_exhausted():
                 logger.info(
                     "Subsystem hunt skipped: budget $%.2f exhausted ($%.2f spent)",
                     self.budget_usd,
@@ -1719,6 +1803,7 @@ class SourceHuntRunner:
                             finding_ids=[finding.id for finding in subsys_findings],
                         )
                     except Exception as exc:
+                        hunt_failed = True
                         logger.warning("Subsystem hunt failed", exc_info=True)
                         pipeline_status.record_degraded(
                             "subsystem_hunt",
@@ -1731,6 +1816,30 @@ class SourceHuntRunner:
                             symbols=subsystem_symbols,
                             error={"type": type(exc).__name__, "message": str(exc)},
                         )
+
+            if restored_hunt is None and not hunt_failed:
+                hunt_status = (
+                    "budget_exhausted"
+                    if hunt_budget_exhausted or self._budget_exhausted()
+                    else "completed"
+                )
+                hunt_result = HuntResult(
+                    findings=all_findings,
+                    files_hunted=files_hunted,
+                    spent_per_tier=spent_per_tier,
+                    band_stats=band_stats,
+                    subsystems_hunted=subsystems_hunted,
+                    subsystem_spent_usd=subsystem_spent,
+                )
+                try:
+                    hunt_store.save(
+                        hunt_result,
+                        status=hunt_status,
+                        ranked_targets_digest=ranked_digest,
+                        options=hunt_options,
+                    )
+                except Exception:
+                    logger.warning("Could not persist hunt checkpoint", exc_info=True)
 
             # 4. Verify (unless --no-verify)
             verified: list[Finding] = []
@@ -2751,6 +2860,33 @@ class SourceHuntRunner:
         except Exception:
             logger.warning("Could not persist preprocess checkpoint", exc_info=True)
         return result
+
+    def _hunt_checkpoint_options(self) -> dict[str, Any]:
+        """Return every configured input that can change hunt output."""
+
+        return {
+            "depth": self.depth,
+            "agent_mode": self._effective_agent_mode,
+            "prompt_mode": self._prompt_mode,
+            "model": self.model_override or "",
+            "max_parallel": self.max_parallel,
+            "tier_budget": vars(self.tier_budget),
+            "starting_band": self._starting_band,
+            "max_band": self._max_band,
+            "redundancy_override": self._redundancy_override,
+            "no_per_file_hunt": self._no_per_file_hunt,
+            "enable_subsystem_hunt": self._enable_subsystem_hunt,
+            "subsystem_paths": sorted(self._subsystem_paths or []),
+            "subsystem_max_files": self._subsystem_max_files,
+            "subsystem_max_parallel": self._subsystem_max_parallel,
+            "shard_entry_points": self._shard_entry_points,
+            "min_shard_rank": self._min_shard_rank,
+            "min_project_loc": self._min_project_loc,
+            "seed_corpus_sources": sorted(self._seed_corpus_sources or []),
+            "seed_harness_crashes": self._seed_harness_crashes,
+            "campaign_hint": self._campaign_hint or "",
+            "exploit_mode": self._exploit_mode,
+        }
 
     def _ensure_sandbox_factory(self, repo_path: str, files: list[FileTarget]) -> None:
         if self.depth == "quick":

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -44,8 +44,13 @@ from .checkpoints import (
     RankCheckpointStore,
     VerificationCheckpointStore,
     VerificationResult,
+    exploitation_checkpoint_options,
     findings_digest,
+    hunt_checkpoint_options,
+    preprocess_checkpoint_options,
+    rank_checkpoint_options,
     ranked_targets_digest,
+    verification_checkpoint_options,
     verification_result_digest,
 )
 from .config import SourceHuntConfig
@@ -1090,12 +1095,12 @@ class SourceHuntRunner:
                     budget_stage="rank",
                 )
             )
-            rank_options = {
-                "no_rank": self._no_rank,
-                "preprocessing": self._preprocessing,
-                "model": self.model_override or "",
-                "max_parallel": self.max_parallel,
-            }
+            rank_options = rank_checkpoint_options(
+                no_rank=self._no_rank,
+                preprocessing=self._preprocessing,
+                model=self.model_override,
+                max_parallel=self.max_parallel,
+            )
             preprocess_checkpoint_payload = (
                 Path(self.output_dir)
                 / self._session_id
@@ -1244,7 +1249,29 @@ class SourceHuntRunner:
                     ft["surface"] * 0.5 + ft["influence"] * 0.2 + ft["reachability"] * 0.3
                 )
 
-            hunt_options = self._hunt_checkpoint_options()
+            hunt_options = hunt_checkpoint_options(
+                depth=self.depth,
+                agent_mode=self._effective_agent_mode,
+                prompt_mode=self._prompt_mode,
+                model=self.model_override,
+                max_parallel=self.max_parallel,
+                tier_budget=vars(self.tier_budget),
+                starting_band=self._starting_band,
+                max_band=self._max_band,
+                redundancy_override=self._redundancy_override,
+                no_per_file_hunt=self._no_per_file_hunt,
+                enable_subsystem_hunt=self._enable_subsystem_hunt,
+                subsystem_paths=self._subsystem_paths,
+                subsystem_max_files=self._subsystem_max_files,
+                subsystem_max_parallel=self._subsystem_max_parallel,
+                shard_entry_points=self._shard_entry_points,
+                min_shard_rank=self._min_shard_rank,
+                min_project_loc=self._min_project_loc,
+                seed_corpus_sources=self._seed_corpus_sources,
+                seed_harness_crashes=self._seed_harness_crashes,
+                campaign_hint=self._campaign_hint,
+                exploit_mode=self._exploit_mode,
+            )
             ranked_digest = ranked_targets_digest(files)
             hunt_store = HuntCheckpointStore(
                 Path(self.output_dir) / self._session_id,
@@ -1263,9 +1290,10 @@ class SourceHuntRunner:
                         self._session_id,
                     )
 
-            # Hunt needs a sandbox; a restored hunt only needs one when a
-            # downstream verification or exploitation phase will use it.
-            if restored_hunt is None or not self.no_verify or not self.no_exploit:
+            # Do not initialize Docker merely because a downstream stage is
+            # enabled: its checkpoint may also restore. A downstream miss
+            # initializes the sandbox immediately before that stage runs.
+            if restored_hunt is None:
                 _t = time.monotonic()
                 self._ensure_sandbox_factory(repo_path, files)
                 logger.info("Sandbox factory ready in %.2fs", time.monotonic() - _t)
@@ -1849,7 +1877,18 @@ class SourceHuntRunner:
 
             # 4. Verify (unless --no-verify)
             verify_input_digest = findings_digest(all_findings)
-            verify_options = self._verification_checkpoint_options()
+            verify_options = verification_checkpoint_options(
+                no_verify=self.no_verify,
+                validator_mode=self.validator_mode,
+                model=self.model_override,
+                adversarial_verifier=self.adversarial_verifier,
+                adversarial_threshold=self.adversarial_threshold,
+                enable_patch_oracle=self.enable_patch_oracle,
+                enable_calibration=self._calibration_store is not None,
+                enable_mechanism_memory=self._mechanism_store is not None,
+                enable_variant_loop=self.enable_variant_loop,
+                enable_stability_verification=self.enable_stability_verification,
+            )
             verify_store = VerificationCheckpointStore(
                 Path(self.output_dir) / self._session_id,
                 self._session_id,
@@ -1860,6 +1899,8 @@ class SourceHuntRunner:
                     hunt_findings_digest=verify_input_digest,
                     options=verify_options,
                 )
+            if restored_verification is None and not self.no_verify:
+                self._ensure_sandbox_factory(repo_path, files)
             verified: list[Finding] = []
             rejected: list[Finding] = []
             verify_status = "completed"
@@ -2154,7 +2195,22 @@ class SourceHuntRunner:
 
             # 5. Exploit-triage (unless --no-exploit) — gated on evidence_level
             exploit_input_digest = verification_result_digest(verification_result)
-            exploit_options = self._exploitation_checkpoint_options()
+            exploit_options = exploitation_checkpoint_options(
+                no_exploit=self.no_exploit,
+                model=self.model_override,
+                exploit_mode=self._exploit_mode,
+                exploit_budget_band=self._exploit_budget_band,
+                enable_elaboration=self.enable_elaboration,
+                elaboration_cap=self._elaboration_cap,
+                enable_auto_patch=self.enable_auto_patch,
+                auto_pr=self.auto_pr,
+                enable_knowledge_graph=self.enable_knowledge_graph,
+                export_disclosures=self.export_disclosures,
+                disclosure_reporter_name=self.disclosure_reporter_name,
+                disclosure_reporter_affiliation=self.disclosure_reporter_affiliation,
+                disclosure_reporter_email=self.disclosure_reporter_email,
+                enable_artifact_store=self._enable_artifact_store,
+            )
             exploit_store = ExploitationCheckpointStore(
                 Path(self.output_dir) / self._session_id,
                 self._session_id,
@@ -2165,6 +2221,8 @@ class SourceHuntRunner:
                     verification_result_digest=exploit_input_digest,
                     options=exploit_options,
                 )
+            if restored_exploitation is None and not self.no_exploit:
+                self._ensure_sandbox_factory(repo_path, files)
             exploited: list[Finding] = []
             # 5.5 v0.3: Auto-patch (opt-in) — runs after exploiter on verified
             #          critical/high findings with root_cause_explained evidence.
@@ -2955,17 +3013,13 @@ class SourceHuntRunner:
         # v0.2: enable callgraph + reachability + Semgrep by default at
         # standard/deep depths. Quick depth stays cheap — just enumerate
         # and tag files.
-        options = {
-            "tag_files": True,
-            "build_callgraph": self.depth != "quick" and self._preprocessing,
-            "propagate_reachability": self.depth != "quick" and self._preprocessing,
-            "run_semgrep": self.depth != "quick" and self._preprocessing,
-            "run_taint": (
-                self.depth != "quick" and self._preprocessing and not self._no_rank
-            ),
-            "respect_gitignore": self._respect_gitignore,
-            "subsystem_paths": sorted(self._subsystem_paths or []),
-        }
+        options = preprocess_checkpoint_options(
+            depth=self.depth,
+            preprocessing=self._preprocessing,
+            no_rank=self._no_rank,
+            respect_gitignore=self._respect_gitignore,
+            subsystem_paths=self._subsystem_paths,
+        )
         checkpoint_store = PreprocessCheckpointStore(
             Path(self.output_dir) / self._session_id,
             self._session_id,
@@ -2986,11 +3040,11 @@ class SourceHuntRunner:
             repo_url=self.repo_url,
             branch=self.branch,
             local_path=self.local_path,
-            tag_files=options["tag_files"],
-            build_callgraph=options["build_callgraph"],
-            propagate_reachability=options["propagate_reachability"],
-            run_semgrep=options["run_semgrep"],
-            run_taint=options["run_taint"],
+            tag_files=options.tag_files,
+            build_callgraph=options.build_callgraph,
+            propagate_reachability=options.propagate_reachability,
+            run_semgrep=options.run_semgrep,
+            run_taint=options.run_taint,
             respect_gitignore=self._respect_gitignore,
             subsystem_paths=self._subsystem_paths,
         )
@@ -3006,49 +3060,6 @@ class SourceHuntRunner:
             logger.warning("Could not persist preprocess checkpoint", exc_info=True)
         return result
 
-    def _hunt_checkpoint_options(self) -> dict[str, Any]:
-        """Return every configured input that can change hunt output."""
-
-        return {
-            "depth": self.depth,
-            "agent_mode": self._effective_agent_mode,
-            "prompt_mode": self._prompt_mode,
-            "model": self.model_override or "",
-            "max_parallel": self.max_parallel,
-            "tier_budget": vars(self.tier_budget),
-            "starting_band": self._starting_band,
-            "max_band": self._max_band,
-            "redundancy_override": self._redundancy_override,
-            "no_per_file_hunt": self._no_per_file_hunt,
-            "enable_subsystem_hunt": self._enable_subsystem_hunt,
-            "subsystem_paths": sorted(self._subsystem_paths or []),
-            "subsystem_max_files": self._subsystem_max_files,
-            "subsystem_max_parallel": self._subsystem_max_parallel,
-            "shard_entry_points": self._shard_entry_points,
-            "min_shard_rank": self._min_shard_rank,
-            "min_project_loc": self._min_project_loc,
-            "seed_corpus_sources": sorted(self._seed_corpus_sources or []),
-            "seed_harness_crashes": self._seed_harness_crashes,
-            "campaign_hint": self._campaign_hint or "",
-            "exploit_mode": self._exploit_mode,
-        }
-
-    def _verification_checkpoint_options(self) -> dict[str, Any]:
-        """Return configured inputs that can change verification output."""
-
-        return {
-            "no_verify": self.no_verify,
-            "validator_mode": self.validator_mode,
-            "model": self.model_override or "",
-            "adversarial_verifier": self.adversarial_verifier,
-            "adversarial_threshold": self.adversarial_threshold,
-            "enable_patch_oracle": self.enable_patch_oracle,
-            "enable_calibration": self._calibration_store is not None,
-            "enable_mechanism_memory": self._mechanism_store is not None,
-            "enable_variant_loop": self.enable_variant_loop,
-            "enable_stability_verification": self.enable_stability_verification,
-        }
-
     @staticmethod
     def _canonical_finding_subset(
         findings: list[Finding], subset: list[Finding]
@@ -3057,26 +3068,6 @@ class SourceHuntRunner:
 
         by_id = {finding.id: finding for finding in findings}
         return [by_id.get(finding.id, finding) for finding in subset]
-
-    def _exploitation_checkpoint_options(self) -> dict[str, Any]:
-        """Return configured inputs that can change exploitation output."""
-
-        return {
-            "no_exploit": self.no_exploit,
-            "model": self.model_override or "",
-            "exploit_mode": self._exploit_mode,
-            "exploit_budget_band": self._exploit_budget_band,
-            "enable_elaboration": self.enable_elaboration,
-            "elaboration_cap": self._elaboration_cap,
-            "enable_auto_patch": self.enable_auto_patch,
-            "auto_pr": self.auto_pr,
-            "enable_knowledge_graph": self.enable_knowledge_graph,
-            "export_disclosures": self.export_disclosures,
-            "disclosure_reporter_name": self.disclosure_reporter_name,
-            "disclosure_reporter_affiliation": self.disclosure_reporter_affiliation,
-            "disclosure_reporter_email": self.disclosure_reporter_email,
-            "enable_artifact_store": self._enable_artifact_store,
-        }
 
     def _ensure_sandbox_factory(self, repo_path: str, files: list[FileTarget]) -> None:
         if self.depth == "quick":

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -36,11 +36,17 @@ from clearwing.providers import (
 
 from ..sandbox.hunter_sandbox import HunterSandbox
 from .checkpoints import (
+    ExploitationCheckpointStore,
+    ExploitationResult,
     HuntCheckpointStore,
     HuntResult,
     PreprocessCheckpointStore,
     RankCheckpointStore,
+    VerificationCheckpointStore,
+    VerificationResult,
+    findings_digest,
     ranked_targets_digest,
+    verification_result_digest,
 )
 from .config import SourceHuntConfig
 from .disclosure import (
@@ -1842,19 +1848,59 @@ class SourceHuntRunner:
                     logger.warning("Could not persist hunt checkpoint", exc_info=True)
 
             # 4. Verify (unless --no-verify)
+            verify_input_digest = findings_digest(all_findings)
+            verify_options = self._verification_checkpoint_options()
+            verify_store = VerificationCheckpointStore(
+                Path(self.output_dir) / self._session_id,
+                self._session_id,
+            )
+            restored_verification = None
+            if self._resume_session_id:
+                restored_verification = verify_store.load(
+                    hunt_findings_digest=verify_input_digest,
+                    options=verify_options,
+                )
             verified: list[Finding] = []
             rejected: list[Finding] = []
             verify_status = "completed"
-            self._emit_stage(
-                "verify",
-                "started",
-                findings_so_far=len(all_findings),
-                detail=f"{len(all_findings)} findings to verify",
-                files=[str(finding.file or "") for finding in all_findings],
-                symbols=self._finding_symbols(all_findings),
-                finding_ids=[finding.id for finding in all_findings],
-            )
-            if not self.no_verify:
+            if restored_verification is not None:
+                all_findings = list(restored_verification.findings)
+                verified = self._canonical_finding_subset(
+                    all_findings, restored_verification.verified_findings
+                )
+                rejected = self._canonical_finding_subset(
+                    all_findings, restored_verification.rejected_findings
+                )
+                verify_status = verify_store.last_status or "completed"
+                logger.info(
+                    "Restored %s verification result from session %s",
+                    verify_status,
+                    self._session_id,
+                )
+            else:
+                self._emit_stage(
+                    "verify",
+                    "started",
+                    findings_so_far=len(all_findings),
+                    detail=f"{len(all_findings)} findings to verify",
+                    files=[str(finding.file or "") for finding in all_findings],
+                    symbols=self._finding_symbols(all_findings),
+                    finding_ids=[finding.id for finding in all_findings],
+                )
+            if restored_verification is not None:
+                if verify_status == "degraded":
+                    pipeline_status.record_degraded(
+                        "verifier", "Restored degraded verification result"
+                    )
+                elif verify_status in {"skipped", "budget_exhausted"}:
+                    pipeline_status.record(
+                        "verifier",
+                        StageOutcome.SKIPPED,
+                        fallback_description=f"Restored {verify_status} verification result",
+                    )
+                else:
+                    pipeline_status.record_succeeded("verifier")
+            elif not self.no_verify:
                 if self._budget_exhausted():
                     verify_status = "budget_exhausted"
                     pipeline_status.record(
@@ -1901,7 +1947,9 @@ class SourceHuntRunner:
                 )
 
             verify_detail = (
-                "Verification skipped (--no-verify)"
+                f"Restored {len(verified)} verified and {len(rejected)} rejected from checkpoint"
+                if restored_verification is not None
+                else "Verification skipped (--no-verify)"
                 if self.no_verify
                 else f"{len(verified)} verified, {len(rejected)} rejected"
             )
@@ -1914,12 +1962,17 @@ class SourceHuntRunner:
                 symbols=self._finding_symbols(all_findings),
                 finding_ids=[finding.id for finding in all_findings],
             )
-            if rejected:
+            if rejected and restored_verification is None:
                 self._write_rejected_findings(rejected)
 
             # 4.5. v0.3: Extract mechanisms from verified findings and persist them
             #      to the cross-run store. Cheap LLM pass; failures are non-fatal.
-            if self._mechanism_store is not None and verified and not self._budget_exhausted():
+            if (
+                restored_verification is None
+                and self._mechanism_store is not None
+                and verified
+                and not self._budget_exhausted()
+            ):
                 verifier_llm_for_extract = self._get_native_client(
                     "verifier",
                     self.verifier_llm,
@@ -1947,7 +2000,12 @@ class SourceHuntRunner:
             #       match as a new suspicion-level finding linked back to the
             #       original. v0.3 scope: we surface the matches in the report;
             #       we don't re-spawn hunters on each match (that's a v1.0 pass).
-            if self.enable_variant_loop and verified and not self._budget_exhausted():
+            if (
+                restored_verification is None
+                and self.enable_variant_loop
+                and verified
+                and not self._budget_exhausted()
+            ):
                 variant_llm = self._get_native_client(
                     "verifier",
                     self.verifier_llm,
@@ -2022,7 +2080,8 @@ class SourceHuntRunner:
             # 4.9. Stage 2.5: PoC stability verification (spec 010).
             # Rerun PoCs in fresh containers to measure reliability.
             if (
-                self.enable_stability_verification
+                restored_verification is None
+                and self.enable_stability_verification
                 and verified
                 and self._sandbox_manager is not None
                 and not self._budget_exhausted()
@@ -2074,20 +2133,69 @@ class SourceHuntRunner:
                 non_poc = [f for f in verified if f not in stability_eligible]
                 verified = stable_verified + non_poc
 
-            # 5. Exploit-triage (unless --no-exploit) — gated on evidence_level
-            self._emit_stage(
-                "exploit",
-                "started",
-                findings_so_far=len(all_findings),
-                files=[str(finding.file or "") for finding in verified],
-                symbols=self._finding_symbols(verified),
-                finding_ids=[finding.id for finding in verified],
+            verification_result = VerificationResult(
+                findings=all_findings,
+                verified_findings=verified,
+                rejected_findings=rejected,
             )
+            if restored_verification is None:
+                verify_checkpoint_status = (
+                    "skipped" if self.no_verify else verify_status
+                )
+                try:
+                    verify_store.save(
+                        verification_result,
+                        status=verify_checkpoint_status,
+                        hunt_findings_digest=verify_input_digest,
+                        options=verify_options,
+                    )
+                except Exception:
+                    logger.warning("Could not persist verification checkpoint", exc_info=True)
+
+            # 5. Exploit-triage (unless --no-exploit) — gated on evidence_level
+            exploit_input_digest = verification_result_digest(verification_result)
+            exploit_options = self._exploitation_checkpoint_options()
+            exploit_store = ExploitationCheckpointStore(
+                Path(self.output_dir) / self._session_id,
+                self._session_id,
+            )
+            restored_exploitation = None
+            if self._resume_session_id:
+                restored_exploitation = exploit_store.load(
+                    verification_result_digest=exploit_input_digest,
+                    options=exploit_options,
+                )
             exploited: list[Finding] = []
             # 5.5 v0.3: Auto-patch (opt-in) — runs after exploiter on verified
             #          critical/high findings with root_cause_explained evidence.
             patched: list[Finding] = []
-            if not self.no_exploit and not self._budget_exhausted():
+            if restored_exploitation is not None:
+                all_findings = list(restored_exploitation.findings)
+                verified = self._canonical_finding_subset(
+                    all_findings, restored_exploitation.verified_findings
+                )
+                exploited = self._canonical_finding_subset(
+                    all_findings, restored_exploitation.exploited_findings
+                )
+                logger.info(
+                    "Restored %s exploitation result from session %s",
+                    exploit_store.last_status or "completed",
+                    self._session_id,
+                )
+            else:
+                self._emit_stage(
+                    "exploit",
+                    "started",
+                    findings_so_far=len(all_findings),
+                    files=[str(finding.file or "") for finding in verified],
+                    symbols=self._finding_symbols(verified),
+                    finding_ids=[finding.id for finding in verified],
+                )
+            if (
+                restored_exploitation is None
+                and not self.no_exploit
+                and not self._budget_exhausted()
+            ):
                 exploiter_llm = self._get_native_client(
                     "sourcehunt_exploit",
                     self.exploiter_llm,
@@ -2154,7 +2262,12 @@ class SourceHuntRunner:
 
             # 5.25. Stage 1.5: Exploit elaboration (autonomous, opt-in).
             elaborated: list[Finding] = []
-            if self.enable_elaboration and exploited and not self._budget_exhausted():
+            if (
+                restored_exploitation is None
+                and self.enable_elaboration
+                and exploited
+                and not self._budget_exhausted()
+            ):
                 from .elaboration import (
                     ElaborationAgent,
                     prioritize_for_elaboration,
@@ -2212,7 +2325,12 @@ class SourceHuntRunner:
             # 5.5. v0.3: Auto-patch mode (opt-in).
             # The verify-by-recompile gate is MANDATORY — a patch is only marked
             # `validated` if we actually applied it, rebuilt, and re-ran the PoC.
-            if self.enable_auto_patch and verified and not self._budget_exhausted():
+            if (
+                restored_exploitation is None
+                and self.enable_auto_patch
+                and verified
+                and not self._budget_exhausted()
+            ):
                 patcher_llm = self._get_native_client(
                     "sourcehunt_exploit",
                     self.exploiter_llm,
@@ -2263,13 +2381,17 @@ class SourceHuntRunner:
             # 5.75. v0.3: Populate the cross-run knowledge graph with source
             #       findings. Best-effort — never blocks the run.
             try:
-                if self.enable_knowledge_graph and all_findings:
+                if (
+                    restored_exploitation is None
+                    and self.enable_knowledge_graph
+                    and all_findings
+                ):
                     self._populate_knowledge_graph_source(repo_path, all_findings)
             except Exception:
                 logger.warning("Knowledge graph population failed", exc_info=True)
 
             # 5.85. v0.4: Coordinated-disclosure templates (opt-in).
-            if self.export_disclosures and verified:
+            if restored_exploitation is None and self.export_disclosures and verified:
                 try:
                     self._export_disclosure_bundle(verified)
                 except Exception:
@@ -2292,7 +2414,7 @@ class SourceHuntRunner:
                     logger.warning("Disclosure DB queue failed", exc_info=True)
 
             # 5.87. v0.6: Store exploits in encrypted artifact store (spec 013).
-            if self._enable_artifact_store and exploited:
+            if restored_exploitation is None and self._enable_artifact_store and exploited:
                 try:
                     from .artifact_store import ArtifactStore
 
@@ -2311,32 +2433,55 @@ class SourceHuntRunner:
                     logger.warning("Artifact store failed", exc_info=True)
 
             # 5.88. v0.6: Auto-commit findings with root_cause_explained (spec 014).
-            try:
-                from .commitment import CommitmentLog
+            if restored_exploitation is None:
+                try:
+                    from .commitment import CommitmentLog
 
-                committable = filter_by_evidence(verified, "root_cause_explained")
-                if committable:
-                    commitment_log = CommitmentLog()
-                    for f in committable:
-                        commitment_log.commit_finding(f, project=self.repo_url)
-                    logger.info(
-                        "Committed %d findings to commitment log",
-                        len(committable),
+                    committable = filter_by_evidence(verified, "root_cause_explained")
+                    if committable:
+                        commitment_log = CommitmentLog()
+                        for f in committable:
+                            commitment_log.commit_finding(f, project=self.repo_url)
+                        logger.info(
+                            "Committed %d findings to commitment log",
+                            len(committable),
+                        )
+                except Exception:
+                    logger.warning("Auto-commitment failed", exc_info=True)
+
+            exploit_status = (
+                exploit_store.last_status or "completed"
+                if restored_exploitation is not None
+                else "skipped"
+                if self.no_exploit
+                else "budget_exhausted"
+                if self._budget_exhausted()
+                else "completed"
+            )
+            if restored_exploitation is None:
+                try:
+                    exploit_store.save(
+                        ExploitationResult(
+                            findings=all_findings,
+                            verified_findings=verified,
+                            exploited_findings=exploited,
+                        ),
+                        status=exploit_status,
+                        verification_result_digest=exploit_input_digest,
+                        options=exploit_options,
                     )
-            except Exception:
-                logger.warning("Auto-commitment failed", exc_info=True)
+                except Exception:
+                    logger.warning("Could not persist exploitation checkpoint", exc_info=True)
 
             self._emit_stage(
                 "exploit",
-                (
-                    "skipped"
-                    if self.no_exploit
-                    else "budget_exhausted"
-                    if self._budget_exhausted()
-                    else "completed"
-                ),
+                exploit_status,
                 findings_so_far=len(all_findings),
-                detail=f"{len(exploited)} exploited",
+                detail=(
+                    f"Restored {len(exploited)} exploited findings from checkpoint"
+                    if restored_exploitation is not None
+                    else f"{len(exploited)} exploited"
+                ),
                 files=[str(finding.file or "") for finding in all_findings],
                 symbols=self._finding_symbols(all_findings),
                 finding_ids=[finding.id for finding in all_findings],
@@ -2886,6 +3031,51 @@ class SourceHuntRunner:
             "seed_harness_crashes": self._seed_harness_crashes,
             "campaign_hint": self._campaign_hint or "",
             "exploit_mode": self._exploit_mode,
+        }
+
+    def _verification_checkpoint_options(self) -> dict[str, Any]:
+        """Return configured inputs that can change verification output."""
+
+        return {
+            "no_verify": self.no_verify,
+            "validator_mode": self.validator_mode,
+            "model": self.model_override or "",
+            "adversarial_verifier": self.adversarial_verifier,
+            "adversarial_threshold": self.adversarial_threshold,
+            "enable_patch_oracle": self.enable_patch_oracle,
+            "enable_calibration": self._calibration_store is not None,
+            "enable_mechanism_memory": self._mechanism_store is not None,
+            "enable_variant_loop": self.enable_variant_loop,
+            "enable_stability_verification": self.enable_stability_verification,
+        }
+
+    @staticmethod
+    def _canonical_finding_subset(
+        findings: list[Finding], subset: list[Finding]
+    ) -> list[Finding]:
+        """Re-link a deserialized subset to the canonical full finding objects."""
+
+        by_id = {finding.id: finding for finding in findings}
+        return [by_id.get(finding.id, finding) for finding in subset]
+
+    def _exploitation_checkpoint_options(self) -> dict[str, Any]:
+        """Return configured inputs that can change exploitation output."""
+
+        return {
+            "no_exploit": self.no_exploit,
+            "model": self.model_override or "",
+            "exploit_mode": self._exploit_mode,
+            "exploit_budget_band": self._exploit_budget_band,
+            "enable_elaboration": self.enable_elaboration,
+            "elaboration_cap": self._elaboration_cap,
+            "enable_auto_patch": self.enable_auto_patch,
+            "auto_pr": self.auto_pr,
+            "enable_knowledge_graph": self.enable_knowledge_graph,
+            "export_disclosures": self.export_disclosures,
+            "disclosure_reporter_name": self.disclosure_reporter_name,
+            "disclosure_reporter_affiliation": self.disclosure_reporter_affiliation,
+            "disclosure_reporter_email": self.disclosure_reporter_email,
+            "enable_artifact_store": self._enable_artifact_store,
         }
 
     def _ensure_sandbox_factory(self, repo_path: str, files: list[FileTarget]) -> None:

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -6,11 +6,17 @@ from clearwing.analysis.source_analyzer import AnalyzerFinding
 from clearwing.findings.types import Finding
 from clearwing.sourcehunt.callgraph import CallGraph, FunctionInfo
 from clearwing.sourcehunt.checkpoints import (
+    ExploitationCheckpointStore,
+    ExploitationResult,
     HuntCheckpointStore,
     HuntResult,
     PreprocessCheckpointStore,
     RankCheckpointStore,
+    VerificationCheckpointStore,
+    VerificationResult,
+    findings_digest,
     ranked_targets_digest,
+    verification_result_digest,
 )
 from clearwing.sourcehunt.findings_pool import FindingsPool
 from clearwing.sourcehunt.preprocessor import PreprocessResult
@@ -205,6 +211,94 @@ def test_hunt_checkpoint_rejects_changed_rank_or_options(tmp_path: Path):
     )
 
 
+def test_verification_checkpoint_round_trips_complete_handoff(tmp_path: Path):
+    store = VerificationCheckpointStore(tmp_path / "sh-test", "sh-test")
+    accepted = Finding(id="f-accepted", file="accepted.c", verified=True)
+    rejected = Finding(id="f-rejected", file="rejected.c", verified=False)
+    result = VerificationResult(
+        findings=[accepted, rejected],
+        verified_findings=[accepted],
+        rejected_findings=[rejected],
+    )
+    options = {"validator_mode": "v2", "enable_patch_oracle": True}
+
+    store.save(
+        result,
+        status="completed",
+        hunt_findings_digest="hunt-sha",
+        options=options,
+    )
+    restored = store.load(hunt_findings_digest="hunt-sha", options=options)
+
+    assert restored is not None
+    assert [finding.id for finding in restored.verified_findings] == ["f-accepted"]
+    assert [finding.id for finding in restored.rejected_findings] == ["f-rejected"]
+    assert store.last_status == "completed"
+    assert store.load(hunt_findings_digest="changed", options=options) is None
+
+
+def test_exploitation_checkpoint_round_trips_complete_handoff(tmp_path: Path):
+    store = ExploitationCheckpointStore(tmp_path / "sh-test", "sh-test")
+    exploited = Finding(
+        id="f-exploited",
+        file="sample.c",
+        verified=True,
+        exploit="proof-of-concept",
+        exploit_success=True,
+    )
+    result = ExploitationResult(
+        findings=[exploited],
+        verified_findings=[exploited],
+        exploited_findings=[exploited],
+    )
+    options = {"exploit_mode": "standard", "enable_auto_patch": False}
+
+    store.save(
+        result,
+        status="completed",
+        verification_result_digest="verify-sha",
+        options=options,
+    )
+    restored = store.load(
+        verification_result_digest="verify-sha",
+        options=options,
+    )
+
+    assert restored is not None
+    assert restored.exploited_findings[0].exploit == "proof-of-concept"
+    assert store.last_status == "completed"
+    assert (
+        store.load(
+            verification_result_digest="verify-sha",
+            options={**options, "enable_auto_patch": True},
+        )
+        is None
+    )
+
+
+def test_findings_and_verification_digests_change_with_handoff():
+    finding = Finding(id="f-test", severity="medium")
+    original_findings_digest = findings_digest([finding])
+    original_verification_digest = verification_result_digest(
+        VerificationResult(
+            findings=[finding],
+            verified_findings=[],
+            rejected_findings=[],
+        )
+    )
+
+    finding.severity = "high"
+
+    assert findings_digest([finding]) != original_findings_digest
+    assert verification_result_digest(
+        VerificationResult(
+            findings=[finding],
+            verified_findings=[finding],
+            rejected_findings=[],
+        )
+    ) != original_verification_digest
+
+
 def test_findings_pool_restore_completed_does_not_append_checkpoint(tmp_path: Path):
     checkpoint = tmp_path / "findings.jsonl"
     pool = FindingsPool(checkpoint_path=checkpoint)
@@ -347,3 +441,98 @@ def test_runner_resumes_at_end_of_hunt_without_starting_hunters(
 
     assert [finding.id for finding in result.findings] == ["f-restored"]
     assert result.files_hunted == 1
+
+
+def test_runner_restores_verification_and_exploitation_handoffs(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    output = tmp_path / "results"
+    common = {
+        "repo_url": str(repo),
+        "local_path": str(repo),
+        "output_dir": str(output),
+        "depth": "standard",
+        "no_rank": True,
+        "no_verify": True,
+        "no_exploit": True,
+        "enable_findings_pool": False,
+        "enable_mechanism_memory": False,
+        "enable_calibration": False,
+        "enable_behavior_monitor": False,
+        "enable_variant_loop": False,
+        "enable_knowledge_graph": False,
+    }
+    first = SourceHuntRunner(parent_session_id="sh-resume-late", **common)
+    preprocessed = first._preprocess()
+    for target in preprocessed.file_targets:
+        target["surface"] = 3
+        target["influence"] = 2
+        target["reachability"] = 3
+        target["priority"] = 2.8
+
+    hunted = Finding(id="f-restored", file="sample.c")
+    HuntCheckpointStore(output / "sh-resume-late", "sh-resume-late").save(
+        HuntResult(
+            findings=[hunted],
+            files_hunted=1,
+            spent_per_tier={"A": 1.0, "B": 0.0, "C": 0.0},
+        ),
+        status="completed",
+        ranked_targets_digest=ranked_targets_digest(preprocessed.file_targets),
+        options=first._hunt_checkpoint_options(),
+    )
+
+    verified_finding = Finding(
+        id="f-restored", file="sample.c", verified=True, evidence_level="crash_reproduced"
+    )
+    verification = VerificationResult(
+        findings=[verified_finding],
+        verified_findings=[verified_finding],
+        rejected_findings=[],
+    )
+    VerificationCheckpointStore(
+        output / "sh-resume-late", "sh-resume-late"
+    ).save(
+        verification,
+        status="completed",
+        hunt_findings_digest=findings_digest([hunted]),
+        options=first._verification_checkpoint_options(),
+    )
+
+    exploited_finding = Finding(
+        id="f-restored",
+        file="sample.c",
+        verified=True,
+        evidence_level="exploit_demonstrated",
+        exploit="proof-of-concept",
+        exploit_success=True,
+    )
+    ExploitationCheckpointStore(
+        output / "sh-resume-late", "sh-resume-late"
+    ).save(
+        ExploitationResult(
+            findings=[exploited_finding],
+            verified_findings=[exploited_finding],
+            exploited_findings=[exploited_finding],
+        ),
+        status="completed",
+        verification_result_digest=verification_result_digest(verification),
+        options=first._exploitation_checkpoint_options(),
+    )
+
+    resumed = SourceHuntRunner(resume_session_id="sh-resume-late", **common)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("sandbox setup ran despite terminal stage checkpoints")
+
+    monkeypatch.setattr(resumed, "_ensure_sandbox_factory", fail_if_called)
+    result = resumed.run()
+
+    assert [finding.id for finding in result.verified_findings] == ["f-restored"]
+    assert [finding.id for finding in result.exploited_findings] == ["f-restored"]
+    assert result.findings[0] is result.verified_findings[0]
+    assert result.findings[0] is result.exploited_findings[0]
+    assert result.exploited_findings[0].exploit == "proof-of-concept"

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -14,8 +14,11 @@ from clearwing.sourcehunt.checkpoints import (
     RankCheckpointStore,
     VerificationCheckpointStore,
     VerificationResult,
+    exploitation_checkpoint_options,
     findings_digest,
+    hunt_checkpoint_options,
     ranked_targets_digest,
+    verification_checkpoint_options,
     verification_result_digest,
 )
 from clearwing.sourcehunt.findings_pool import FindingsPool
@@ -54,6 +57,66 @@ def _result(repo: Path) -> PreprocessResult:
                 variable="input",
             )
         ],
+    )
+
+
+def _hunt_options(runner: SourceHuntRunner):
+    return hunt_checkpoint_options(
+        depth=runner.depth,
+        agent_mode=runner._effective_agent_mode,
+        prompt_mode=runner._prompt_mode,
+        model=runner.model_override,
+        max_parallel=runner.max_parallel,
+        tier_budget=vars(runner.tier_budget),
+        starting_band=runner._starting_band,
+        max_band=runner._max_band,
+        redundancy_override=runner._redundancy_override,
+        no_per_file_hunt=runner._no_per_file_hunt,
+        enable_subsystem_hunt=runner._enable_subsystem_hunt,
+        subsystem_paths=runner._subsystem_paths,
+        subsystem_max_files=runner._subsystem_max_files,
+        subsystem_max_parallel=runner._subsystem_max_parallel,
+        shard_entry_points=runner._shard_entry_points,
+        min_shard_rank=runner._min_shard_rank,
+        min_project_loc=runner._min_project_loc,
+        seed_corpus_sources=runner._seed_corpus_sources,
+        seed_harness_crashes=runner._seed_harness_crashes,
+        campaign_hint=runner._campaign_hint,
+        exploit_mode=runner._exploit_mode,
+    )
+
+
+def _verification_options(runner: SourceHuntRunner):
+    return verification_checkpoint_options(
+        no_verify=runner.no_verify,
+        validator_mode=runner.validator_mode,
+        model=runner.model_override,
+        adversarial_verifier=runner.adversarial_verifier,
+        adversarial_threshold=runner.adversarial_threshold,
+        enable_patch_oracle=runner.enable_patch_oracle,
+        enable_calibration=runner._calibration_store is not None,
+        enable_mechanism_memory=runner._mechanism_store is not None,
+        enable_variant_loop=runner.enable_variant_loop,
+        enable_stability_verification=runner.enable_stability_verification,
+    )
+
+
+def _exploitation_options(runner: SourceHuntRunner):
+    return exploitation_checkpoint_options(
+        no_exploit=runner.no_exploit,
+        model=runner.model_override,
+        exploit_mode=runner._exploit_mode,
+        exploit_budget_band=runner._exploit_budget_band,
+        enable_elaboration=runner.enable_elaboration,
+        elaboration_cap=runner._elaboration_cap,
+        enable_auto_patch=runner.enable_auto_patch,
+        auto_pr=runner.auto_pr,
+        enable_knowledge_graph=runner.enable_knowledge_graph,
+        export_disclosures=runner.export_disclosures,
+        disclosure_reporter_name=runner.disclosure_reporter_name,
+        disclosure_reporter_affiliation=runner.disclosure_reporter_affiliation,
+        disclosure_reporter_email=runner.disclosure_reporter_email,
+        enable_artifact_store=runner._enable_artifact_store,
     )
 
 
@@ -428,7 +491,7 @@ def test_runner_resumes_at_end_of_hunt_without_starting_hunters(
         ),
         status="budget_exhausted",
         ranked_targets_digest=ranked_targets_digest(preprocessed.file_targets),
-        options=first._hunt_checkpoint_options(),
+        options=_hunt_options(first),
     )
 
     resumed = SourceHuntRunner(resume_session_id="sh-resume-hunt", **common)
@@ -456,7 +519,7 @@ def test_runner_restores_verification_and_exploitation_handoffs(
         "output_dir": str(output),
         "depth": "standard",
         "no_rank": True,
-        "no_verify": True,
+        "no_verify": False,
         "no_exploit": True,
         "enable_findings_pool": False,
         "enable_mechanism_memory": False,
@@ -482,7 +545,7 @@ def test_runner_restores_verification_and_exploitation_handoffs(
         ),
         status="completed",
         ranked_targets_digest=ranked_targets_digest(preprocessed.file_targets),
-        options=first._hunt_checkpoint_options(),
+        options=_hunt_options(first),
     )
 
     verified_finding = Finding(
@@ -499,7 +562,7 @@ def test_runner_restores_verification_and_exploitation_handoffs(
         verification,
         status="completed",
         hunt_findings_digest=findings_digest([hunted]),
-        options=first._verification_checkpoint_options(),
+        options=_verification_options(first),
     )
 
     exploited_finding = Finding(
@@ -520,7 +583,7 @@ def test_runner_restores_verification_and_exploitation_handoffs(
         ),
         status="completed",
         verification_result_digest=verification_result_digest(verification),
-        options=first._exploitation_checkpoint_options(),
+        options=_exploitation_options(first),
     )
 
     resumed = SourceHuntRunner(resume_session_id="sh-resume-late", **common)

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 from pathlib import Path
 
 from clearwing.analysis.source_analyzer import AnalyzerFinding
+from clearwing.findings.types import Finding
 from clearwing.sourcehunt.callgraph import CallGraph, FunctionInfo
-from clearwing.sourcehunt.checkpoints import PreprocessCheckpointStore, RankCheckpointStore
+from clearwing.sourcehunt.checkpoints import (
+    HuntCheckpointStore,
+    HuntResult,
+    PreprocessCheckpointStore,
+    RankCheckpointStore,
+    ranked_targets_digest,
+)
+from clearwing.sourcehunt.findings_pool import FindingsPool
 from clearwing.sourcehunt.preprocessor import PreprocessResult
 from clearwing.sourcehunt.runner import SourceHuntRunner
 from clearwing.sourcehunt.taint import TaintPath
@@ -109,6 +117,112 @@ def test_rank_checkpoint_round_trips_exact_ranked_targets(tmp_path: Path):
     ) is None
 
 
+def test_hunt_checkpoint_round_trips_completed_result(tmp_path: Path):
+    store = HuntCheckpointStore(tmp_path / "sh-test", "sh-test")
+    finding = Finding(
+        id="f-test",
+        file="sample.c",
+        line_number=2,
+        finding_type="command_injection",
+        severity="high",
+        evidence_level="static_corroboration",
+        primitive_type="command_execution",
+        cluster_id="cluster-1",
+    )
+    result = HuntResult(
+        findings=[finding],
+        files_hunted=3,
+        spent_per_tier={"A": 1.25, "B": 0.0, "C": 0.0},
+        band_stats={"fast_runs": 3},
+        subsystems_hunted=1,
+        subsystem_spent_usd=0.5,
+    )
+    options = {"depth": "standard", "model": "test-model"}
+
+    store.save(
+        result,
+        status="completed",
+        ranked_targets_digest="ranked-sha",
+        options=options,
+    )
+    restored = store.load(
+        ranked_targets_digest="ranked-sha",
+        options=options,
+    )
+
+    assert restored is not None
+    assert isinstance(restored.findings[0], Finding)
+    assert restored.findings[0].id == "f-test"
+    assert restored.files_hunted == 3
+    assert store.last_status == "completed"
+
+
+def test_hunt_checkpoint_restores_budget_exhausted_terminal_state(tmp_path: Path):
+    store = HuntCheckpointStore(tmp_path / "sh-test", "sh-test")
+    result = HuntResult(
+        findings=[Finding(id="f-partial", file="sample.c")],
+        files_hunted=1,
+        spent_per_tier={"A": 2.0, "B": 0.0, "C": 0.0},
+    )
+
+    store.save(
+        result,
+        status="budget_exhausted",
+        ranked_targets_digest="ranked-sha",
+        options={},
+    )
+
+    assert store.load(ranked_targets_digest="ranked-sha", options={}) is not None
+    assert store.last_status == "budget_exhausted"
+
+
+def test_hunt_checkpoint_rejects_changed_rank_or_options(tmp_path: Path):
+    store = HuntCheckpointStore(tmp_path / "sh-test", "sh-test")
+    result = HuntResult(
+        findings=[],
+        spent_per_tier={"A": 0.0, "B": 0.0, "C": 0.0},
+    )
+    store.save(
+        result,
+        status="completed",
+        ranked_targets_digest="ranked-sha",
+        options={"depth": "standard"},
+    )
+
+    assert (
+        store.load(
+            ranked_targets_digest="changed",
+            options={"depth": "standard"},
+        )
+        is None
+    )
+    assert (
+        store.load(
+            ranked_targets_digest="ranked-sha",
+            options={"depth": "deep"},
+        )
+        is None
+    )
+
+
+def test_findings_pool_restore_completed_does_not_append_checkpoint(tmp_path: Path):
+    checkpoint = tmp_path / "findings.jsonl"
+    pool = FindingsPool(checkpoint_path=checkpoint)
+    finding = Finding(
+        id="f-test",
+        file="sample.c",
+        description="restored",
+        primitive_type="memory_corruption",
+        cluster_id="cluster-1",
+    )
+
+    pool.restore_completed([finding])
+
+    assert pool.all_findings() == [finding]
+    assert pool.clusters()[0].finding_ids == ["f-test"]
+    assert not checkpoint.exists()
+
+
 def test_runner_uses_resume_session_id(tmp_path: Path):
     (tmp_path / "sh-existing").mkdir()
     runner = SourceHuntRunner(
@@ -179,3 +293,57 @@ def test_runner_rejects_missing_resume_session(tmp_path: Path):
         assert "does not exist" in str(exc)
     else:
         raise AssertionError("missing resume session was accepted")
+
+
+def test_runner_resumes_at_end_of_hunt_without_starting_hunters(
+    tmp_path: Path, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    output = tmp_path / "results"
+    common = {
+        "repo_url": str(repo),
+        "local_path": str(repo),
+        "output_dir": str(output),
+        "depth": "standard",
+        "no_rank": True,
+        "no_verify": True,
+        "no_exploit": True,
+        "enable_findings_pool": False,
+        "enable_mechanism_memory": False,
+        "enable_calibration": False,
+        "enable_behavior_monitor": False,
+        "enable_variant_loop": False,
+        "enable_knowledge_graph": False,
+    }
+    first = SourceHuntRunner(parent_session_id="sh-resume-hunt", **common)
+    preprocessed = first._preprocess()
+    for target in preprocessed.file_targets:
+        target["surface"] = 3
+        target["influence"] = 2
+        target["reachability"] = 3
+        target["priority"] = 2.8
+    HuntCheckpointStore(
+        output / "sh-resume-hunt", "sh-resume-hunt"
+    ).save(
+        HuntResult(
+            findings=[Finding(id="f-restored", file="sample.c")],
+            files_hunted=1,
+            spent_per_tier={"A": 1.0, "B": 0.0, "C": 0.0},
+        ),
+        status="budget_exhausted",
+        ranked_targets_digest=ranked_targets_digest(preprocessed.file_targets),
+        options=first._hunt_checkpoint_options(),
+    )
+
+    resumed = SourceHuntRunner(resume_session_id="sh-resume-hunt", **common)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("hunt setup ran instead of restoring its checkpoint")
+
+    monkeypatch.setattr(resumed, "_ensure_sandbox_factory", fail_if_called)
+    result = resumed.run()
+
+    assert [finding.id for finding in result.findings] == ["f-restored"]
+    assert result.files_hunted == 1


### PR DESCRIPTION
## Summary

Extends legacy SourceHunt checkpoint/resume beyond preprocessing to the remaining expensive analysis stages:

```text
hunt → verify → exploit
```

This is a stacked PR on top of `feat/stage-checkpointing`, which provides preprocessing and rank checkpoint infrastructure plus `--resume SESSION_ID`.

## What changed

- persist and restore completed or budget-exhausted hunt handoffs
- persist and restore verification results, including verified and rejected subsets
- persist and restore exploitation results and canonical finding relationships
- chain stage fingerprints from ranked targets through findings and verification output
- hydrate the findings pool without replaying JSONL writes or LLM side effects
- centralize strict, typed compatibility options for all checkpoint stores
- rerun normally when a checkpoint is missing, corrupt, stale, or option-incompatible

## Usage

Checkpoint creation is automatic for legacy runs. Resume by using the same repository, output directory, and stage-affecting options:

```bash
clearwing sourcehunt /path/to/repo \
  --flow legacy \
  --output-dir ./results/sourcehunt \
  --resume sh-abc12345
```

## Testing

```bash
uv run pytest tests/test_sourcehunt_checkpoints.py tests/test_sourcehunt_runner.py tests/test_sourcehunt_verifier.py tests/test_sourcehunt_exploiter.py tests/test_findings_pool.py -q
```