### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,4 +350,4 @@ There are two lanes, and they go to different places:
 
 MIT. See [`LICENSE`](LICENSE).
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Lazarus-AI/clearwing&type=Date)](https://star-history.com/#Lazarus-AI/clearwing&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Lazarus-AI/clearwing&type=Date)](https://star-history.dera.page/#Lazarus-AI/clearwing&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders because of GitHub stargazer API restrictions, which is a necessary fix for the project documentation. Move the chart to the new star-history.dera.page domain, which serves the chart from an alternative data source that requires no API token.