### PR TITLE
feat(sourcehunt): checkpoint preprocessing stage

### DIFF
--- a/clearwing/sourcehunt/checkpoints.py
+++ b/clearwing/sourcehunt/checkpoints.py
@@ -1,0 +1,94 @@
+"""Portable checkpoint bundles for the legacy sourcehunt pipeline."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from .preprocessor import PreprocessResult
+
+CHECKPOINT_SCHEMA_VERSION = 1
+
+logger = logging.getLogger(__name__)
+
+
+class PreprocessCheckpoint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = CHECKPOINT_SCHEMA_VERSION
+    commit_sha: str | None
+    options: dict[str, Any]
+    result: dict[str, Any]
+
+    @classmethod
+    def from_result(
+        cls,
+        result: PreprocessResult,
+        *,
+        options: dict[str, Any],
+    ) -> PreprocessCheckpoint:
+        return cls(
+            commit_sha=repository_commit_sha(result.repo_path),
+            options=options,
+            result=result.to_checkpoint(),
+        )
+
+    def restore(
+        self,
+        *,
+        repo_path: str,
+        options: dict[str, Any],
+    ) -> PreprocessResult | None:
+        current_commit = repository_commit_sha(repo_path)
+        if current_commit is None or current_commit != self.commit_sha:
+            logger.error(
+                "Preprocess checkpoint commit mismatch (checkpoint=%s, checkout=%s)",
+                self.commit_sha,
+                current_commit,
+            )
+            return None
+        if self.options != options:
+            logger.error("Preprocess checkpoint options do not match this run")
+            return None
+        try:
+            return PreprocessResult.from_checkpoint(self.result, repo_path)
+        except (OSError, ValueError):
+            logger.error("Preprocess checkpoint result is invalid", exc_info=True)
+            return None
+
+
+def parse_checkpoint(
+    value: PreprocessCheckpoint | dict[str, Any] | str | None,
+) -> PreprocessCheckpoint | None:
+    """Validate a bridge-provided checkpoint object or serialized JSON blob."""
+
+    if value is None:
+        return None
+    if isinstance(value, PreprocessCheckpoint):
+        return value.model_copy(deep=True)
+    if isinstance(value, str):
+        return PreprocessCheckpoint.model_validate_json(value)
+    return PreprocessCheckpoint.model_validate(value)
+
+
+def repository_commit_sha(repo_path: str | Path) -> str | None:
+    """Return the checkout's full HEAD SHA, or None for a non-Git source tree."""
+
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(Path(repo_path).resolve()), "rev-parse", "--verify", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    sha = completed.stdout.strip()
+    if completed.returncode != 0 or len(sha) != 40:
+        return None
+    return sha.lower()

--- a/clearwing/sourcehunt/config.py
+++ b/clearwing/sourcehunt/config.py
@@ -141,3 +141,4 @@ class SourceHuntConfig:
     features: FeatureFlags = field(default_factory=FeatureFlags)
     tuning: HuntTuning = field(default_factory=HuntTuning)
     proof: ProofConfig = field(default_factory=ProofConfig)
+    checkpoint: dict[str, Any] | str | None = None

--- a/clearwing/sourcehunt/preprocessor.py
+++ b/clearwing/sourcehunt/preprocessor.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import logging
 import os
 import re
-from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from clearwing.analysis import SourceAnalyzer
 from clearwing.analysis.source_analyzer import AnalyzerFinding as StaticFinding
@@ -29,17 +31,64 @@ from .taint import TaintAnalyzer, TaintPath
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class PreprocessResult:
+class PreprocessResult(BaseModel):
     """Output of the preprocessor — fed into the Ranker."""
+
+    model_config = ConfigDict(extra="forbid")
 
     repo_path: str
     file_targets: list[FileTarget]
     static_findings: list[StaticFinding]
-    semgrep_findings: list[dict] = field(default_factory=list)  # v0.2
+    semgrep_findings: list[dict] = Field(default_factory=list)  # v0.2
     callgraph: CallGraph | None = None  # v0.2
-    fuzz_corpora: list[dict] = field(default_factory=list)  # v0.2
-    taint_paths: list[TaintPath] = field(default_factory=list)  # v0.4
+    fuzz_corpora: list[dict] = Field(default_factory=list)  # v0.2
+    taint_paths: list[TaintPath] = Field(default_factory=list)  # v0.4
+
+    def to_checkpoint(self) -> dict[str, Any]:
+        """Serialize without paths tied to the current worker."""
+
+        payload = self.model_dump(mode="json")
+        payload.pop("repo_path")
+        for target in payload["file_targets"]:
+            target.pop("absolute_path", None)
+        return payload
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        payload: dict[str, Any],
+        repo_path: str | Path,
+    ) -> PreprocessResult:
+        """Restore worker-local paths for a newly materialized checkout."""
+
+        root = Path(repo_path).resolve()
+        saved_targets = payload.get("file_targets")
+        if not isinstance(saved_targets, list):
+            raise ValueError("checkpoint file targets must be a list")
+        targets: list[FileTarget] = []
+        for target in saved_targets:
+            if not isinstance(target, dict):
+                raise ValueError("checkpoint file target must be an object")
+            relative = Path(str(target.get("path") or ""))
+            if not relative.parts or relative.is_absolute():
+                raise ValueError("checkpoint file target must be repository-relative")
+            absolute = (root / relative).resolve()
+            if not absolute.is_relative_to(root):
+                raise ValueError("checkpoint file target escapes repository")
+            if not absolute.is_file():
+                raise ValueError(f"checkpoint file target is missing: {relative.as_posix()}")
+            rebound = dict(target)
+            rebound["path"] = relative.as_posix()
+            rebound["absolute_path"] = str(absolute)
+            targets.append(rebound)
+
+        return cls.model_validate(
+            {
+                **payload,
+                "repo_path": str(root),
+                "file_targets": targets,
+            }
+        )
 
     @property
     def file_count(self) -> int:
@@ -261,9 +310,14 @@ class Preprocessor:
         self._analyzer: SourceAnalyzer | None = None
         self._cloner: SourceAnalyzer | None = None
 
-    def run(self) -> PreprocessResult:
+    def resolve_repository(self) -> str:
+        """Materialize the requested repository without analyzing it."""
+
+        return self._clone_or_use_local()
+
+    def run(self, *, repo_path: str | None = None) -> PreprocessResult:
         """Execute the full preprocess pipeline. See class docstring."""
-        repo_path = self._clone_or_use_local()
+        repo_path = repo_path or self.resolve_repository()
 
         # Pre-scan for static findings — also gives us the file iterator
         logger.info("Preprocessor: running static analyzer")

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -33,6 +33,7 @@ from clearwing.providers import (
 )
 
 from ..sandbox.hunter_sandbox import HunterSandbox
+from .checkpoints import PreprocessCheckpoint, parse_checkpoint
 from .config import SourceHuntConfig
 from .disclosure import (
     DisclosureGenerator,
@@ -88,6 +89,7 @@ class SourceHuntResult:
     spent_per_tier: dict[str, float]
     tokens_used: int
     output_paths: dict[str, str] = field(default_factory=dict)
+    checkpoint: dict[str, Any] | None = None
     session_id: str = ""
     subsystems_hunted: int = 0
     subsystem_spent_usd: float = 0.0
@@ -231,6 +233,7 @@ class SourceHuntRunner:
         exploiter_llm: Any = None,
         sandbox_factory: Any = None,  # callable[[], SandboxContainer]
         parent_session_id: str | None = None,
+        checkpoint: dict[str, Any] | str | None = None,
         agent_mode: str = "auto",  # "auto" | "constrained" | "deep"
         prompt_mode: str = "unconstrained",  # "unconstrained" | "specialist"
         campaign_hint: str | None = None,
@@ -438,6 +441,7 @@ class SourceHuntRunner:
                 emit_rejection_certificates and p.emit_rejection_certificates
             )
             falsify = falsify and p.falsify
+            checkpoint = checkpoint if checkpoint is not None else config.checkpoint
 
         if not repo_url:
             raise ValueError(
@@ -448,6 +452,8 @@ class SourceHuntRunner:
             raise ValueError("sandbox_cpus must be a finite number greater than or equal to 0")
         if flow not in {"legacy", "proof"}:
             raise ValueError("flow must be 'legacy' or 'proof'")
+        if checkpoint is not None and flow != "legacy":
+            raise ValueError("checkpoint restoration is currently supported only for legacy flow")
         if proof_max_actions < 1:
             raise ValueError("proof_max_actions must be positive")
         if proof_max_model_calls < 0 or proof_max_dynamic_actions < 0:
@@ -518,6 +524,7 @@ class SourceHuntRunner:
         self._sandbox_manager: HunterSandbox | None = None
         self._preprocessor: Preprocessor | None = None
         self._session_id = parent_session_id or f"sh-{uuid.uuid4().hex[:8]}"
+        self._checkpoint = parse_checkpoint(checkpoint)
         self._agent_mode_override = agent_mode
         self._prompt_mode = prompt_mode
         self._campaign_hint = campaign_hint
@@ -1044,7 +1051,11 @@ class SourceHuntRunner:
             self._emit_stage(
                 "preprocess",
                 "completed",
-                detail=f"Enumerated {files_ranked} files",
+                detail=(
+                    f"Restored {files_ranked} files from checkpoint"
+                    if self._preprocess_restored
+                    else f"Enumerated {files_ranked} files"
+                ),
                 files=stage_files,
             )
             _t = time.monotonic()
@@ -2255,6 +2266,11 @@ class SourceHuntRunner:
                 spent_per_tier=spent_per_tier,
                 tokens_used=budget_summary["total_tokens"],
                 output_paths=output_paths,
+                checkpoint=(
+                    self._checkpoint.model_dump(mode="json")
+                    if self._checkpoint is not None
+                    else None
+                ),
                 session_id=self._session_id,
                 subsystems_hunted=subsystems_hunted,
                 subsystem_spent_usd=subsystem_spent,
@@ -2638,19 +2654,41 @@ class SourceHuntRunner:
         # v0.2: enable callgraph + reachability + Semgrep by default at
         # standard/deep depths. Quick depth stays cheap — just enumerate
         # and tag files.
+        options = {
+            "tag_files": True,
+            "build_callgraph": self.depth != "quick" and self._preprocessing,
+            "propagate_reachability": self.depth != "quick" and self._preprocessing,
+            "run_semgrep": self.depth != "quick" and self._preprocessing,
+            "run_taint": self.depth != "quick" and self._preprocessing and not self._no_rank,
+            "respect_gitignore": self._respect_gitignore,
+            "subsystem_paths": sorted(self._subsystem_paths or []),
+        }
+        self._preprocess_restored = False
         self._preprocessor = Preprocessor(
             repo_url=self.repo_url,
             branch=self.branch,
             local_path=self.local_path,
-            tag_files=True,
-            build_callgraph=(self.depth != "quick" and self._preprocessing),
-            propagate_reachability=(self.depth != "quick" and self._preprocessing),
-            run_semgrep=(self.depth != "quick" and self._preprocessing),
-            run_taint=(self.depth != "quick" and self._preprocessing and not self._no_rank),
+            tag_files=options["tag_files"],
+            build_callgraph=options["build_callgraph"],
+            propagate_reachability=options["propagate_reachability"],
+            run_semgrep=options["run_semgrep"],
+            run_taint=options["run_taint"],
             respect_gitignore=self._respect_gitignore,
             subsystem_paths=self._subsystem_paths,
         )
-        return self._preprocessor.run()
+        repo_path: str | None = None
+        if self._checkpoint is not None:
+            repo_path = self._preprocessor.resolve_repository()
+            restored = self._checkpoint.restore(repo_path=repo_path, options=options)
+            if restored is not None:
+                self._preprocess_restored = True
+                logger.info("Restored preprocess result from session %s", self._session_id)
+                return restored
+            raise ValueError("preprocess checkpoint is invalid or incompatible with this run")
+
+        result = self._preprocessor.run(repo_path=repo_path)
+        self._checkpoint = PreprocessCheckpoint.from_result(result, options=options)
+        return result
 
     def _ensure_sandbox_factory(self, repo_path: str, files: list[FileTarget]) -> None:
         if self.depth == "quick":
@@ -2825,6 +2863,11 @@ class SourceHuntRunner:
             spent_per_tier={"A": 0.0, "B": 0.0, "C": 0.0},
             tokens_used=budget_summary["total_tokens"],
             output_paths=output_paths,
+            checkpoint=(
+                self._checkpoint.model_dump(mode="json")
+                if self._checkpoint is not None
+                else None
+            ),
             session_id=self._session_id,
             pipeline_status=pipeline_status or PipelineStatus(),
             status=run_status,

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -40,6 +40,11 @@ def add_parser(subparsers):
         help="Source-code vulnerability hunting (source-hunt pipeline)",
     )
     parser.add_argument("repo", nargs="?", help="Git URL or local path to a repository")
+    parser.add_argument(
+        "--checkpoint",
+        metavar="JSON",
+        help="Restore a legacy sourcehunt run from a checkpoint JSON blob",
+    )
     parser.add_argument("--machine-fd", type=int, help=argparse.SUPPRESS)
     parser.add_argument(
         "--flow",
@@ -1142,6 +1147,7 @@ def handle(cli, args):
 
     runner = SourceHuntRunner(
         repo_url=args.repo,
+        checkpoint=args.checkpoint,
         branch=args.branch,
         local_path=args.local_path,
         depth=args.depth,
@@ -1300,7 +1306,7 @@ def _handle_machine(descriptor: int) -> int:
     channel = MachineChannel(descriptor, "sourcehunt")
     try:
         request, routing = channel.read_start()
-        print(f"sourcehunt machine-fd request: {request!r}", file=sys.stderr)
+        print(f"sourcehunt machine-fd request fields: {sorted(request)}", file=sys.stderr)
         parsed = _machine_request(request)
         install_runtime_routing(routing)
         provider_manager = ProviderManager.from_config(routing)
@@ -1325,6 +1331,7 @@ def _handle_machine(descriptor: int) -> int:
                 subsystem_max_parallel=parsed.get("subsystem_max_parallel", 4),
                 subsystem_max_files=parsed.get("subsystem_max_files") or None,
                 output_formats=parsed.get("format"),
+                checkpoint=parsed.get("checkpoint"),
                 provider_manager=provider_manager,
                 on_progress=lambda progress: channel.emit("progress", progress),
             ).arun()
@@ -1357,6 +1364,7 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "subsystem_max_parallel",
         "subsystem_max_files",
         "no_per_file_hunt",
+        "checkpoint",
     }
     unknown = sorted(set(value) - allowed)
     if unknown:
@@ -1394,6 +1402,11 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
     if "format" in value:
         fmt = value["format"]
         parsed["format"] = [fmt] if isinstance(fmt, str) else fmt
+    if "checkpoint" in value:
+        checkpoint = value["checkpoint"]
+        if not isinstance(checkpoint, dict):
+            raise ValueError("checkpoint must be a JSON object")
+        parsed["checkpoint"] = checkpoint
     return parsed
 
 
@@ -1420,6 +1433,7 @@ def _public_result(result: Any) -> dict[str, Any]:
         "cost_usd": result.cost_usd,
         "tokens_used": result.tokens_used,
         "budget_usd": result.budget_usd,
+        "checkpoint": result.checkpoint,
         "pipeline": {
             name: {
                 "outcome": stage.outcome.value,

--- a/tests/test_machine_cli.py
+++ b/tests/test_machine_cli.py
@@ -125,6 +125,20 @@ def test_sourcehunt_request_rejects_paths_credentials_and_provider_fields():
         )
 
 
+def test_sourcehunt_machine_request_accepts_checkpoint_object():
+    checkpoint = {"schema_version": 1, "commit_sha": None, "options": {}, "result": {}}
+
+    parsed = sourcehunt._machine_request(
+        {"repo_url": "https://example.test/repo", "checkpoint": checkpoint}
+    )
+
+    assert parsed["checkpoint"] == checkpoint
+    with pytest.raises(ValueError, match="checkpoint must be a JSON object"):
+        sourcehunt._machine_request(
+            {"repo_url": "https://example.test/repo", "checkpoint": "serialized-json"}
+        )
+
+
 def test_operate_machine_uses_host_routing_and_emits_typed_records():
     parent, channel = _channel("operate", {"target": "host", "goals": ["scan"]})
     request, routing = channel.read_start()
@@ -189,6 +203,14 @@ class _SourceResult:
     output_paths: dict = field(default_factory=lambda: {"report": "/private/report"})
     session_id: str = "source-test"
     pipeline_status: _Pipeline = field(default_factory=_Pipeline)
+    checkpoint: dict = field(
+        default_factory=lambda: {
+            "schema_version": 1,
+            "commit_sha": None,
+            "options": {},
+            "result": {},
+        }
+    )
 
 
 def test_sourcehunt_public_result_removes_host_paths():
@@ -196,6 +218,7 @@ def test_sourcehunt_public_result_removes_host_paths():
     assert result["findings"] == [{"file": "app.py"}]
     assert "repo_path" not in result
     assert "output_paths" not in result
+    assert result["checkpoint"]["schema_version"] == 1
     assert "/private" not in repr(result)
 
 

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clearwing.analysis.source_analyzer import AnalyzerFinding
+from clearwing.sourcehunt.callgraph import CallGraph, FunctionInfo
+from clearwing.sourcehunt.checkpoints import (
+    PreprocessCheckpoint,
+    parse_checkpoint,
+)
+from clearwing.sourcehunt.preprocessor import PreprocessResult
+from clearwing.sourcehunt.runner import SourceHuntRunner
+from clearwing.sourcehunt.taint import TaintPath
+
+OPTIONS = {
+    "tag_files": True,
+    "build_callgraph": False,
+    "propagate_reachability": False,
+    "run_semgrep": False,
+    "run_taint": False,
+    "respect_gitignore": False,
+    "subsystem_paths": [],
+}
+
+
+def _result(repo: Path) -> PreprocessResult:
+    callgraph = CallGraph()
+    callgraph.functions["sample.c"].add("parse")
+    callgraph.function_info["sample.c"].append(FunctionInfo("parse", 1, 4))
+    return PreprocessResult(
+        repo_path=str(repo),
+        file_targets=[{"path": "sample.c", "absolute_path": str(repo / "sample.c")}],
+        static_findings=[
+            AnalyzerFinding(
+                file_path="sample.c",
+                line_number=2,
+                finding_type="command_injection",
+                severity="high",
+                description="test",
+            )
+        ],
+        callgraph=callgraph,
+        taint_paths=[
+            TaintPath(
+                file="sample.c",
+                source_function="read",
+                source_line=1,
+                sink_function="system",
+                sink_line=2,
+                sink_cwe="CWE-78",
+                sink_description="test",
+                severity="high",
+                variable="input",
+            )
+        ],
+    )
+
+
+def _commit(repo: Path, message: str = "checkpoint test") -> str:
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Clearwing Tests",
+            "-c",
+            "user.email=tests@clearwing.local",
+            "commit",
+            "-qm",
+            message,
+        ],
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_preprocess_result_round_trips_nested_types(tmp_path: Path):
+    result = _result(tmp_path)
+
+    restored = PreprocessResult.model_validate_json(result.model_dump_json())
+
+    assert isinstance(restored.file_targets[0], dict)
+    assert isinstance(restored.static_findings[0], AnalyzerFinding)
+    assert isinstance(restored.callgraph, CallGraph)
+    assert isinstance(restored.callgraph.function_info["sample.c"][0], FunctionInfo)
+    assert isinstance(restored.taint_paths[0], TaintPath)
+    assert restored.callgraph.functions["sample.c"] == {"parse"}
+    assert restored == result
+
+
+def test_preprocess_checkpoint_trusts_current_source_and_rebinds_paths(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "sample.c"
+    source.write_text("int sample(void) { return 1; }\n", encoding="utf-8")
+    commit_sha = _commit(repo)
+    checkpoint = PreprocessCheckpoint.from_result(_result(repo), options=OPTIONS)
+    assert checkpoint.commit_sha == commit_sha
+
+    restored = checkpoint.restore(repo_path=str(repo), options=OPTIONS)
+    assert restored is not None
+    assert restored.repo_path == str(repo.resolve())
+    assert restored.file_targets[0]["absolute_path"] == str(source.resolve())
+
+    source.write_text("int sample(void) { return 2; }\n", encoding="utf-8")
+    assert checkpoint.restore(repo_path=str(repo), options=OPTIONS) is not None
+
+
+def test_preprocess_checkpoint_rejects_different_commit(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source = repo / "sample.c"
+    source.write_text("int sample(void) { return 1; }\n", encoding="utf-8")
+    _commit(repo)
+    checkpoint = PreprocessCheckpoint.from_result(_result(repo), options=OPTIONS)
+
+    source.write_text("int sample(void) { return 2; }\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "sample.c"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Clearwing Tests",
+            "-c",
+            "user.email=tests@clearwing.local",
+            "commit",
+            "-qm",
+            "source changed",
+        ],
+        check=True,
+    )
+
+    assert checkpoint.restore(repo_path=str(repo), options=OPTIONS) is None
+
+
+def test_preprocess_checkpoint_rejects_corrupt_payload(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    checkpoint = PreprocessCheckpoint.from_result(_result(repo), options=OPTIONS)
+    payload = checkpoint.model_dump_json().replace(
+        '"schema_version":1', '"schema_version":999', 1
+    )
+    try:
+        parse_checkpoint(payload)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("invalid checkpoint schema was accepted")
+
+
+def test_checkpoint_is_one_self_contained_json_blob(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    checkpoint = PreprocessCheckpoint.from_result(_result(repo), options=OPTIONS)
+    raw = checkpoint.model_dump_json()
+    assert str(repo) not in raw
+    assert "absolute_path" not in raw
+    restored = PreprocessCheckpoint.model_validate_json(raw)
+    assert restored.result["file_targets"][0]["path"] == "sample.c"
+    assert restored.options == OPTIONS
+
+
+def test_preprocess_checkpoint_rejects_different_options(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    result = _result(repo)
+    _commit(repo)
+    checkpoint = PreprocessCheckpoint.from_result(result, options=OPTIONS)
+
+    assert checkpoint.restore(
+        repo_path=str(repo),
+        options={**OPTIONS, "run_semgrep": True},
+    ) is None
+
+
+def test_preprocess_checkpoint_rejects_path_traversal(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    _commit(repo)
+    outside = tmp_path / "outside.c"
+    outside.write_text("int outside(void);\n", encoding="utf-8")
+    result = _result(repo)
+    result.file_targets[0]["path"] = "../outside.c"
+    checkpoint = PreprocessCheckpoint.from_result(result, options=OPTIONS)
+
+    assert checkpoint.restore(repo_path=str(repo), options=OPTIONS) is None
+
+
+def test_runner_restores_preprocess_checkpoint(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    _commit(repo)
+    first = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "results"),
+        depth="quick",
+        parent_session_id="sh-resume",
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+    original = first._preprocess()
+    checkpoint_blob = first._checkpoint.model_dump_json()
+
+    resumed = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "results"),
+        depth="quick",
+        checkpoint=checkpoint_blob,
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("preprocessor ran instead of restoring the checkpoint")
+
+    monkeypatch.setattr("clearwing.sourcehunt.preprocessor.Preprocessor.run", fail_if_called)
+    restored = resumed._preprocess()
+
+    assert resumed._preprocess_restored is True
+    assert restored.file_targets == original.file_targets
+
+
+def test_runner_accepts_checkpoint_as_json_object(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    _commit(repo)
+    first = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "first"),
+        depth="quick",
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+    first._preprocess()
+    checkpoint = first._checkpoint.model_dump(mode="json")
+
+    resumed = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "second"),
+        depth="quick",
+        checkpoint=checkpoint,
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+
+    assert resumed._preprocess().file_targets[0]["path"] == "sample.c"
+    assert resumed._preprocess_restored is True
+
+
+def test_runner_rejects_incompatible_preprocess_checkpoint(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    _commit(repo)
+    checkpoint = PreprocessCheckpoint.from_result(_result(repo), options=OPTIONS)
+    checkpoint.commit_sha = "0" * 40
+    runner = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "results"),
+        depth="quick",
+        checkpoint=checkpoint.model_dump(mode="json"),
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+
+    with pytest.raises(ValueError, match="checkpoint is invalid or incompatible"):
+        runner._preprocess()
+
+
+def test_runner_result_exposes_checkpoint_for_bridge_response(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    runner = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "results"),
+        depth="quick",
+        no_rank=True,
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+        enable_knowledge_graph=False,
+    )
+
+    result = runner.run()
+
+    assert result.checkpoint is not None
+    assert result.checkpoint["result"]["file_targets"][0]["path"] == "sample.c"
+    assert "checkpoint" not in result.output_paths
+
+
+def test_runner_rejects_invalid_checkpoint_json():
+    try:
+        SourceHuntRunner(repo_url="repo", checkpoint="not-json")
+    except ValueError as exc:
+        assert "json" in str(exc).lower()
+    else:
+        raise AssertionError("invalid checkpoint JSON was accepted")


### PR DESCRIPTION
## Summary

Adds portable checkpoint and resume support for the preprocessing stage of legacy SourceHunt.

The checkpoint is a self-contained JSON object intended to round-trip through clearwing-bridge. It is accepted as request input, held in memory during the run, and returned in `SourceHuntResult` and machine-mode responses. Clearwing does not persist a separate checkpoint file.

## Usage

Resume from a JSON blob through the CLI:

    clearwing sourcehunt /path/to/repo --flow legacy --checkpoint "$CHECKPOINT_JSON"

Programmatic callers can provide the JSON object or serialized blob through `SourceHuntConfig.checkpoint` or `SourceHuntRunner(checkpoint=...)`. The completed checkpoint is returned as `SourceHuntResult.checkpoint`.

## Checkpoint behavior

- checkpoints preprocessing only; ranking and later pipeline stages execute normally
- serializes the Pydantic `PreprocessResult` without worker-local `repo_path` or `absolute_path` values
- reconstructs worker-local absolute paths after materializing the requested repository
- records the preprocessing Git commit SHA and all preprocessing options that affect the handoff
- validates the schema and prevents restored paths from escaping the checkout
- fails the run loudly when a supplied checkpoint is stale, incompatible, malformed, or otherwise cannot be restored

The caller remains responsible for repository selection and uncommitted working-tree state. The Git guard compares committed HEAD state.

## Scope

- legacy flow only; proof flow is unchanged
- preprocessing checkpoint only
- hunt, verification, exploitation, and reporting continue normally

## Testing

- `uv run --with pytest-asyncio pytest tests/test_sourcehunt_checkpoints.py tests/test_machine_cli.py -q`

## Stack

Base of a 5-PR checkpointing stack, based on #101 (`feat/cross-file-chatter`). This PR targets `feat/cross-file-chatter` and should merge into it.

---

### Full stack (based on #101)
1. #151 — checkpoint preprocessing stage → `feat/cross-file-chatter`
2. #152 — checkpoint ranking stage → `feat/preprocessing-checkpointing`
3. #153 — checkpoint hunt stage → `feat/rank-checkpointing`
4. #154 — checkpoint verification stage → `feat/hunt-checkpointing`
5. #155 — checkpoint exploitation stage → `feat/verification-checkpointing`
