### PR TITLE
feat(sourcehunt): checkpoint ranking stage

### DIFF
--- a/clearwing/sourcehunt/checkpoints.py
+++ b/clearwing/sourcehunt/checkpoints.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict
 
 from .preprocessor import PreprocessResult
+from .state import FileTarget
 
 CHECKPOINT_SCHEMA_VERSION = 1
 
@@ -61,18 +62,76 @@ class PreprocessCheckpoint(BaseModel):
             return None
 
 
-def parse_checkpoint(
-    value: PreprocessCheckpoint | dict[str, Any] | str | None,
-) -> PreprocessCheckpoint | None:
-    """Validate a bridge-provided checkpoint object or serialized JSON blob."""
+class RankCheckpoint(BaseModel):
+    """Portable state produced by the completed ranking stage."""
 
-    if value is None:
-        return None
-    if isinstance(value, PreprocessCheckpoint):
-        return value.model_copy(deep=True)
-    if isinstance(value, str):
-        return PreprocessCheckpoint.model_validate_json(value)
-    return PreprocessCheckpoint.model_validate(value)
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = CHECKPOINT_SCHEMA_VERSION
+    options: dict[str, Any]
+    ranked_file_targets: list[FileTarget]
+
+    @classmethod
+    def from_result(
+        cls,
+        files: list[FileTarget],
+        *,
+        options: dict[str, Any],
+    ) -> RankCheckpoint:
+        ranked_targets = []
+        for target in files:
+            portable = dict(target)
+            portable.pop("absolute_path", None)
+            ranked_targets.append(portable)
+        return cls(
+            options=options,
+            ranked_file_targets=ranked_targets,
+        )
+
+    def restore(
+        self,
+        files: list[FileTarget],
+        *,
+        options: dict[str, Any],
+    ) -> list[FileTarget] | None:
+        if self.options != options:
+            logger.error("Rank checkpoint options do not match this run")
+            return None
+        if len(files) != len(self.ranked_file_targets):
+            logger.error("Rank checkpoint file count does not match preprocessing")
+            return None
+
+        restored: list[FileTarget] = []
+        for current, saved in zip(files, self.ranked_file_targets, strict=True):
+            if current.get("path") != saved.get("path"):
+                logger.error("Rank checkpoint files do not match preprocessing")
+                return None
+            rebound = dict(saved)
+            if "absolute_path" in current:
+                rebound["absolute_path"] = current["absolute_path"]
+            restored.append(rebound)
+        return restored
+
+
+class SourceHuntCheckpoint(BaseModel):
+    """Stage-keyed sourcehunt checkpoint passed across the bridge boundary."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = CHECKPOINT_SCHEMA_VERSION
+    preprocess: PreprocessCheckpoint | None = None
+    rank: RankCheckpoint | None = None
+
+    @classmethod
+    def from_input(
+        cls,
+        value: SourceHuntCheckpoint | dict[str, Any] | str,
+    ) -> SourceHuntCheckpoint:
+        """Validate a bridge-provided checkpoint object or serialized JSON blob."""
+
+        if isinstance(value, str):
+            return cls.model_validate_json(value)
+        return cls.model_validate(value)
 
 
 def repository_commit_sha(repo_path: str | Path) -> str | None:

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -33,7 +33,11 @@ from clearwing.providers import (
 )
 
 from ..sandbox.hunter_sandbox import HunterSandbox
-from .checkpoints import PreprocessCheckpoint, parse_checkpoint
+from .checkpoints import (
+    PreprocessCheckpoint,
+    RankCheckpoint,
+    SourceHuntCheckpoint,
+)
 from .config import SourceHuntConfig
 from .disclosure import (
     DisclosureGenerator,
@@ -524,7 +528,9 @@ class SourceHuntRunner:
         self._sandbox_manager: HunterSandbox | None = None
         self._preprocessor: Preprocessor | None = None
         self._session_id = parent_session_id or f"sh-{uuid.uuid4().hex[:8]}"
-        self._checkpoint = parse_checkpoint(checkpoint)
+        self._checkpoint = (
+            SourceHuntCheckpoint.from_input(checkpoint) if checkpoint is not None else None
+        )
         self._agent_mode_override = agent_mode
         self._prompt_mode = prompt_mode
         self._campaign_hint = campaign_hint
@@ -1062,127 +1068,9 @@ class SourceHuntRunner:
             self._ensure_sandbox_factory(repo_path, files)
             logger.info("Sandbox factory ready in %.2fs", time.monotonic() - _t)
 
-            # 2. Rank — unless depth=quick AND no LLM available, or --no-rank
-            ranker_llm = (
-                None
-                if self._no_rank
-                else self._get_native_client(
-                    "ranker",
-                    self.ranker_llm,
-                    budget_stage="rank",
-                )
-            )
-            self._emit_stage(
-                "rank",
-                "started",
-                detail=f"{len(files)} files",
-                files=stage_files,
-            )
-            if self._no_rank:
-                logger.info("Ranker skipped (--no-rank); assigning default priority scores")
-                for ft in files:
-                    ft["surface"] = ft.get("surface") or 3
-                    ft["influence"] = ft.get("influence") or 2
-                    ft["reachability"] = ft.get("reachability") or 3
-                    ft["priority"] = (
-                        ft["surface"] * 0.5 + ft["influence"] * 0.2 + ft["reachability"] * 0.3
-                    )
-                pipeline_status.record_degraded(
-                    "ranker",
-                    "All files assigned default priority scores (--no-rank)",
-                )
-                self._emit_stage(
-                    "rank",
-                    "degraded",
-                    detail="Skipped (--no-rank)",
-                    files=stage_files,
-                )
-            elif ranker_llm is not None and files:
-                logger.info("Ranker starting on %d files", len(files))
-                try:
-                    ranker_config = RankerConfig()
-                    if not self._preprocessing:
-                        ranker_config.include_static_hints = False
-                        ranker_config.include_imports_by = False
-                    # Generic "openai" chat gateways (e.g. a custom base_url +
-                    # api_key endpoint like kimi) send no max_tokens from the
-                    # ranker, so output collapses to the budget reservation cap
-                    # (~4096 tokens). A 150-file JSON with two rationales each
-                    # overflows that and truncates mid-string. Use the same
-                    # small chunk as the Responses backends so it fits.
-                    if ranker_llm.provider_name in ("openai_resp", "openai_codex", "openai"):
-                        ranker_config.chunk_size = 30
-                        ranker_config.max_inflight_chunks = self.max_parallel
-                        logger.info(
-                            "Ranker tuned for %s backend: chunk_size=%d max_inflight_chunks=%d",
-                            ranker_llm.provider_name,
-                            ranker_config.chunk_size,
-                            ranker_config.max_inflight_chunks,
-                        )
-                    await Ranker(ranker_llm, ranker_config).arank(files)
-                    logger.info("Ranker completed")
-                    pipeline_status.record_succeeded("ranker")
-                    self._emit_stage(
-                        "rank",
-                        "completed",
-                        detail=f"Ranked {len(files)} files",
-                        files=stage_files,
-                    )
-                except BudgetExceeded:
-                    logger.info("Ranker stopped because the run budget is exhausted")
-                    pipeline_status.record(
-                        "ranker",
-                        StageOutcome.SKIPPED,
-                        fallback_description="Budget exhausted; remaining files use heuristic ranks",
-                    )
-                    self._emit_stage(
-                        "rank",
-                        "budget_exhausted",
-                        detail="Using heuristic ranks",
-                        files=stage_files,
-                    )
-                except Exception:
-                    logger.warning("Ranker failed", exc_info=True)
-                    pipeline_status.record_degraded(
-                        "ranker",
-                        "All files assigned default priority scores (surface=3, influence=2)",
-                    )
-                    self._emit_stage(
-                        "rank",
-                        "degraded",
-                        detail="Default priority scores used",
-                        files=stage_files,
-                    )
-            else:
-                logger.info("Ranker skipped; no LLM available")
-                pipeline_status.record_degraded(
-                    "ranker",
-                    "All files assigned default priority scores (surface=3, influence=2)",
-                )
-                # Fallback: assign reasonable defaults so tier assignment still works
-                for ft in files:
-                    ft["surface"] = ft.get("surface") or 3
-                    ft["influence"] = ft.get("influence") or 2
-                    ft["reachability"] = ft.get("reachability") or 3
-                    ft["priority"] = (
-                        ft["surface"] * 0.5 + ft["influence"] * 0.2 + ft["reachability"] * 0.3
-                    )
-                self._emit_stage(
-                    "rank",
-                    "degraded",
-                    detail="No ranker model available; default priority scores used",
-                    files=stage_files,
-                )
-
-            # Ensure a partial/failed rank pass still leaves every file
-            # schedulable by the deterministic fallback.
-            for ft in files:
-                ft["surface"] = ft.get("surface") or 3
-                ft["influence"] = ft.get("influence") or 2
-                ft["reachability"] = ft.get("reachability") or 3
-                ft["priority"] = ft.get("priority") or (
-                    ft["surface"] * 0.5 + ft["influence"] * 0.2 + ft["reachability"] * 0.3
-                )
+            # 2. Rank
+            files = await self._rank(files, pipeline_status, stage_files)
+            preprocess_result.file_targets = files
 
             # depth=quick exits here with the static_findings as-is
             if self.depth == "quick":
@@ -2677,9 +2565,9 @@ class SourceHuntRunner:
             subsystem_paths=self._subsystem_paths,
         )
         repo_path: str | None = None
-        if self._checkpoint is not None:
+        if self._checkpoint is not None and self._checkpoint.preprocess is not None:
             repo_path = self._preprocessor.resolve_repository()
-            restored = self._checkpoint.restore(repo_path=repo_path, options=options)
+            restored = self._checkpoint.preprocess.restore(repo_path=repo_path, options=options)
             if restored is not None:
                 self._preprocess_restored = True
                 logger.info("Restored preprocess result from session %s", self._session_id)
@@ -2687,8 +2575,121 @@ class SourceHuntRunner:
             raise ValueError("preprocess checkpoint is invalid or incompatible with this run")
 
         result = self._preprocessor.run(repo_path=repo_path)
-        self._checkpoint = PreprocessCheckpoint.from_result(result, options=options)
+        preprocess_checkpoint = PreprocessCheckpoint.from_result(result, options=options)
+        if self._checkpoint is None:
+            self._checkpoint = SourceHuntCheckpoint(preprocess=preprocess_checkpoint)
+        else:
+            self._checkpoint.preprocess = preprocess_checkpoint
         return result
+
+    async def _rank(
+        self,
+        files: list[FileTarget],
+        pipeline_status: PipelineStatus,
+        stage_files: list[str],
+    ) -> list[FileTarget]:
+        """Rank files or restore the completed ranking stage from the checkpoint."""
+
+        options = {
+            "no_rank": self._no_rank,
+            "preprocessing": self._preprocessing,
+        }
+        self._rank_restored = False
+        self._emit_stage("rank", "started", detail=f"{len(files)} files", files=stage_files)
+
+        if self._checkpoint is not None and self._checkpoint.rank is not None:
+            restored = self._checkpoint.rank.restore(files, options=options)
+            if restored is None:
+                raise ValueError("rank checkpoint is invalid or incompatible with this run")
+            self._rank_restored = True
+            pipeline_status.record_succeeded("ranker")
+            self._emit_stage(
+                "rank",
+                "completed",
+                detail=f"Restored {len(restored)} ranked files from checkpoint",
+                files=stage_files,
+            )
+            logger.info("Restored rank result from session %s", self._session_id)
+            return restored
+
+        ranker_llm = (
+            None
+            if self._no_rank
+            else self._get_native_client("ranker", self.ranker_llm, budget_stage="rank")
+        )
+        if self._no_rank:
+            logger.info("Ranker skipped (--no-rank); assigning default priority scores")
+            pipeline_status.record_degraded(
+                "ranker", "All files assigned default priority scores (--no-rank)"
+            )
+            self._emit_stage("rank", "degraded", detail="Skipped (--no-rank)", files=stage_files)
+        elif ranker_llm is not None and files:
+            logger.info("Ranker starting on %d files", len(files))
+            try:
+                ranker_config = RankerConfig()
+                if not self._preprocessing:
+                    ranker_config.include_static_hints = False
+                    ranker_config.include_imports_by = False
+                if ranker_llm.provider_name in ("openai_resp", "openai_codex"):
+                    ranker_config.chunk_size = 30
+                    ranker_config.max_inflight_chunks = self.max_parallel
+                    logger.info(
+                        "Ranker tuned for %s backend: chunk_size=%d max_inflight_chunks=%d",
+                        ranker_llm.provider_name,
+                        ranker_config.chunk_size,
+                        ranker_config.max_inflight_chunks,
+                    )
+                await Ranker(ranker_llm, ranker_config).arank(files)
+                logger.info("Ranker completed")
+                pipeline_status.record_succeeded("ranker")
+                self._emit_stage(
+                    "rank", "completed", detail=f"Ranked {len(files)} files", files=stage_files
+                )
+            except BudgetExceeded:
+                logger.info("Ranker stopped because the run budget is exhausted")
+                pipeline_status.record(
+                    "ranker",
+                    StageOutcome.SKIPPED,
+                    fallback_description="Budget exhausted; remaining files use heuristic ranks",
+                )
+                self._emit_stage(
+                    "rank", "budget_exhausted", detail="Using heuristic ranks", files=stage_files
+                )
+            except Exception:
+                logger.warning("Ranker failed", exc_info=True)
+                pipeline_status.record_degraded(
+                    "ranker",
+                    "All files assigned default priority scores (surface=3, influence=2)",
+                )
+                self._emit_stage(
+                    "rank", "degraded", detail="Default priority scores used", files=stage_files
+                )
+        else:
+            logger.info("Ranker skipped; no LLM available")
+            pipeline_status.record_degraded(
+                "ranker", "All files assigned default priority scores (surface=3, influence=2)"
+            )
+            self._emit_stage(
+                "rank",
+                "degraded",
+                detail="No ranker model available; default priority scores used",
+                files=stage_files,
+            )
+
+        # A partial, skipped, or failed rank pass is still a completed stage once
+        # every file has deterministic fallback scores.
+        for target in files:
+            target["surface"] = target.get("surface") or 3
+            target["influence"] = target.get("influence") or 2
+            target["reachability"] = target.get("reachability") or 3
+            target["priority"] = target.get("priority") or (
+                target["surface"] * 0.5 + target["influence"] * 0.2 + target["reachability"] * 0.3
+            )
+
+        if self._checkpoint is None:
+            raise RuntimeError("ranking requires a preprocessing checkpoint")
+        self._checkpoint.rank = RankCheckpoint.from_result(files, options=options)
+        return files
 
     def _ensure_sandbox_factory(self, repo_path: str, files: list[FileTarget]) -> None:
         if self.depth == "quick":
@@ -2864,9 +2865,7 @@ class SourceHuntRunner:
             tokens_used=budget_summary["total_tokens"],
             output_paths=output_paths,
             checkpoint=(
-                self._checkpoint.model_dump(mode="json")
-                if self._checkpoint is not None
-                else None
+                self._checkpoint.model_dump(mode="json") if self._checkpoint is not None else None
             ),
             session_id=self._session_id,
             pipeline_status=pipeline_status or PipelineStatus(),

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -1069,7 +1069,17 @@ class SourceHuntRunner:
             logger.info("Sandbox factory ready in %.2fs", time.monotonic() - _t)
 
             # 2. Rank
-            files = await self._rank(files, pipeline_status, stage_files)
+            if self._no_rank:
+                logger.info("Ranker skipped (--no-rank); assigning default priority scores")
+                pipeline_status.record_degraded(
+                    "ranker", "All files assigned default priority scores (--no-rank)"
+                )
+                self._emit_stage(
+                    "rank", "degraded", detail="Skipped (--no-rank)", files=stage_files
+                )
+                self._apply_rank_fallbacks(files)
+            else:
+                files = await self._rank(files, pipeline_status, stage_files)
             preprocess_result.file_targets = files
 
             # depth=quick exits here with the static_findings as-is
@@ -2591,7 +2601,6 @@ class SourceHuntRunner:
         """Rank files or restore the completed ranking stage from the checkpoint."""
 
         options = {
-            "no_rank": self._no_rank,
             "preprocessing": self._preprocessing,
         }
         self._rank_restored = False
@@ -2612,18 +2621,8 @@ class SourceHuntRunner:
             logger.info("Restored rank result from session %s", self._session_id)
             return restored
 
-        ranker_llm = (
-            None
-            if self._no_rank
-            else self._get_native_client("ranker", self.ranker_llm, budget_stage="rank")
-        )
-        if self._no_rank:
-            logger.info("Ranker skipped (--no-rank); assigning default priority scores")
-            pipeline_status.record_degraded(
-                "ranker", "All files assigned default priority scores (--no-rank)"
-            )
-            self._emit_stage("rank", "degraded", detail="Skipped (--no-rank)", files=stage_files)
-        elif ranker_llm is not None and files:
+        ranker_llm = self._get_native_client("ranker", self.ranker_llm, budget_stage="rank")
+        if ranker_llm is not None and files:
             logger.info("Ranker starting on %d files", len(files))
             try:
                 ranker_config = RankerConfig()
@@ -2676,8 +2675,19 @@ class SourceHuntRunner:
                 files=stage_files,
             )
 
-        # A partial, skipped, or failed rank pass is still a completed stage once
+        # A partial or failed rank pass is still a completed stage once
         # every file has deterministic fallback scores.
+        self._apply_rank_fallbacks(files)
+
+        if self._checkpoint is None:
+            raise RuntimeError("ranking requires a preprocessing checkpoint")
+        self._checkpoint.rank = RankCheckpoint.from_result(files, options=options)
+        return files
+
+    @staticmethod
+    def _apply_rank_fallbacks(files: list[FileTarget]) -> None:
+        """Ensure every file has deterministic scores when ranking is unavailable."""
+
         for target in files:
             target["surface"] = target.get("surface") or 3
             target["influence"] = target.get("influence") or 2
@@ -2685,11 +2695,6 @@ class SourceHuntRunner:
             target["priority"] = target.get("priority") or (
                 target["surface"] * 0.5 + target["influence"] * 0.2 + target["reachability"] * 0.3
             )
-
-        if self._checkpoint is None:
-            raise RuntimeError("ranking requires a preprocessing checkpoint")
-        self._checkpoint.rank = RankCheckpoint.from_result(files, options=options)
-        return files
 
     def _ensure_sandbox_factory(self, repo_path: str, files: list[FileTarget]) -> None:
         if self.depth == "quick":

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -2629,7 +2629,7 @@ class SourceHuntRunner:
                 if not self._preprocessing:
                     ranker_config.include_static_hints = False
                     ranker_config.include_imports_by = False
-                if ranker_llm.provider_name in ("openai_resp", "openai_codex"):
+                if ranker_llm.provider_name in ("openai_resp", "openai_codex", "openai"):
                     ranker_config.chunk_size = 30
                     ranker_config.max_inflight_chunks = self.max_parallel
                     logger.info(

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -9,10 +9,12 @@ from clearwing.analysis.source_analyzer import AnalyzerFinding
 from clearwing.sourcehunt.callgraph import CallGraph, FunctionInfo
 from clearwing.sourcehunt.checkpoints import (
     PreprocessCheckpoint,
-    parse_checkpoint,
+    RankCheckpoint,
+    SourceHuntCheckpoint,
 )
 from clearwing.sourcehunt.preprocessor import PreprocessResult
 from clearwing.sourcehunt.runner import SourceHuntRunner
+from clearwing.sourcehunt.state import PipelineStatus
 from clearwing.sourcehunt.taint import TaintPath
 
 OPTIONS = {
@@ -151,11 +153,10 @@ def test_preprocess_checkpoint_rejects_corrupt_payload(tmp_path: Path):
     repo.mkdir()
     (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
     checkpoint = PreprocessCheckpoint.from_result(_result(repo), options=OPTIONS)
-    payload = checkpoint.model_dump_json().replace(
-        '"schema_version":1', '"schema_version":999', 1
-    )
+    payload = SourceHuntCheckpoint(preprocess=checkpoint).model_dump_json()
+    payload = payload.replace('"schema_version":1', '"schema_version":999', 1)
     try:
-        parse_checkpoint(payload)
+        SourceHuntCheckpoint.from_input(payload)
     except ValueError:
         pass
     else:
@@ -175,6 +176,21 @@ def test_checkpoint_is_one_self_contained_json_blob(tmp_path: Path):
     assert restored.options == OPTIONS
 
 
+def test_sourcehunt_checkpoint_rejects_flat_phase_payload(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    checkpoint = PreprocessCheckpoint.from_result(_result(repo), options=OPTIONS)
+
+    with pytest.raises(ValueError):
+        SourceHuntCheckpoint.from_input(checkpoint.model_dump(mode="json"))
+
+
+def test_sourcehunt_checkpoint_preserves_checkpoint_instance():
+    checkpoint = SourceHuntCheckpoint()
+
+    assert SourceHuntCheckpoint.from_input(checkpoint) is checkpoint
+
+
 def test_preprocess_checkpoint_rejects_different_options(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -183,10 +199,13 @@ def test_preprocess_checkpoint_rejects_different_options(tmp_path: Path):
     _commit(repo)
     checkpoint = PreprocessCheckpoint.from_result(result, options=OPTIONS)
 
-    assert checkpoint.restore(
-        repo_path=str(repo),
-        options={**OPTIONS, "run_semgrep": True},
-    ) is None
+    assert (
+        checkpoint.restore(
+            repo_path=str(repo),
+            options={**OPTIONS, "run_semgrep": True},
+        )
+        is None
+    )
 
 
 def test_preprocess_checkpoint_rejects_path_traversal(tmp_path: Path):
@@ -282,13 +301,110 @@ def test_runner_rejects_incompatible_preprocess_checkpoint(tmp_path: Path):
         local_path=str(repo),
         output_dir=str(tmp_path / "results"),
         depth="quick",
-        checkpoint=checkpoint.model_dump(mode="json"),
+        checkpoint=SourceHuntCheckpoint(preprocess=checkpoint).model_dump(mode="json"),
         enable_mechanism_memory=False,
         enable_calibration=False,
     )
 
     with pytest.raises(ValueError, match="checkpoint is invalid or incompatible"):
         runner._preprocess()
+
+
+@pytest.mark.asyncio
+async def test_runner_checkpoints_and_restores_ranking(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    _commit(repo)
+    first = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "first"),
+        depth="quick",
+        no_rank=True,
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+    preprocessed = first._preprocess()
+    ranked = await first._rank(
+        preprocessed.file_targets,
+        PipelineStatus(),
+        ["sample.c"],
+    )
+
+    assert isinstance(first._checkpoint, SourceHuntCheckpoint)
+    assert isinstance(first._checkpoint.rank, RankCheckpoint)
+    assert ranked[0]["priority"] == pytest.approx(2.8)
+    assert "absolute_path" not in first._checkpoint.rank.ranked_file_targets[0]
+
+    resumed = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "resumed"),
+        depth="quick",
+        no_rank=True,
+        checkpoint=first._checkpoint.model_dump(mode="json"),
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+    restored_preprocess = resumed._preprocess()
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("ranker client resolved instead of restoring the checkpoint")
+
+    monkeypatch.setattr(resumed, "_get_native_client", fail_if_called)
+    restored = await resumed._rank(
+        restored_preprocess.file_targets,
+        PipelineStatus(),
+        ["sample.c"],
+    )
+
+    assert resumed._rank_restored is True
+    assert restored == ranked
+
+
+@pytest.mark.asyncio
+async def test_runner_restores_independent_stage_payloads(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    _commit(repo)
+    preprocess = PreprocessCheckpoint.from_result(_result(repo), options=OPTIONS)
+    ranked = [{"path": "sample.c", "priority": 4.2}]
+    rank = RankCheckpoint.from_result(
+        ranked,
+        options={"no_rank": True, "preprocessing": True},
+    )
+    runner = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "results"),
+        depth="quick",
+        no_rank=True,
+        checkpoint={
+            "schema_version": 1,
+            "preprocess": preprocess.model_dump(mode="json"),
+            "rank": rank.model_dump(mode="json"),
+        },
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+
+    restored_preprocess = runner._preprocess()
+    monkeypatch.setattr(
+        runner,
+        "_get_native_client",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("ranker called")),
+    )
+    restored_rank = await runner._rank(
+        restored_preprocess.file_targets,
+        PipelineStatus(),
+        ["sample.c"],
+    )
+
+    assert runner._preprocess_restored is True
+    assert runner._rank_restored is True
+    assert restored_rank[0]["priority"] == pytest.approx(4.2)
 
 
 def test_runner_result_exposes_checkpoint_for_bridge_response(tmp_path: Path):
@@ -309,7 +425,8 @@ def test_runner_result_exposes_checkpoint_for_bridge_response(tmp_path: Path):
     result = runner.run()
 
     assert result.checkpoint is not None
-    assert result.checkpoint["result"]["file_targets"][0]["path"] == "sample.c"
+    assert result.checkpoint["preprocess"]["result"]["file_targets"][0]["path"] == "sample.c"
+    assert result.checkpoint["rank"]["ranked_file_targets"][0]["priority"] == pytest.approx(2.8)
     assert "checkpoint" not in result.output_paths
 
 

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -321,10 +321,10 @@ async def test_runner_checkpoints_and_restores_ranking(tmp_path: Path, monkeypat
         local_path=str(repo),
         output_dir=str(tmp_path / "first"),
         depth="quick",
-        no_rank=True,
         enable_mechanism_memory=False,
         enable_calibration=False,
     )
+    monkeypatch.setattr(first, "_get_native_client", lambda *args, **kwargs: None)
     preprocessed = first._preprocess()
     ranked = await first._rank(
         preprocessed.file_targets,
@@ -342,7 +342,6 @@ async def test_runner_checkpoints_and_restores_ranking(tmp_path: Path, monkeypat
         local_path=str(repo),
         output_dir=str(tmp_path / "resumed"),
         depth="quick",
-        no_rank=True,
         checkpoint=first._checkpoint.model_dump(mode="json"),
         enable_mechanism_memory=False,
         enable_calibration=False,
@@ -373,14 +372,13 @@ async def test_runner_restores_independent_stage_payloads(tmp_path: Path, monkey
     ranked = [{"path": "sample.c", "priority": 4.2}]
     rank = RankCheckpoint.from_result(
         ranked,
-        options={"no_rank": True, "preprocessing": True},
+        options={"preprocessing": True},
     )
     runner = SourceHuntRunner(
         repo_url=str(repo),
         local_path=str(repo),
         output_dir=str(tmp_path / "results"),
         depth="quick",
-        no_rank=True,
         checkpoint={
             "schema_version": 1,
             "preprocess": preprocess.model_dump(mode="json"),
@@ -407,7 +405,7 @@ async def test_runner_restores_independent_stage_payloads(tmp_path: Path, monkey
     assert restored_rank[0]["priority"] == pytest.approx(4.2)
 
 
-def test_runner_result_exposes_checkpoint_for_bridge_response(tmp_path: Path):
+def test_no_rank_bypasses_ranking_and_exposes_preprocess_checkpoint(tmp_path: Path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
@@ -422,11 +420,16 @@ def test_runner_result_exposes_checkpoint_for_bridge_response(tmp_path: Path):
         enable_knowledge_graph=False,
     )
 
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("_rank ran despite --no-rank")
+
+    monkeypatch.setattr(runner, "_rank", fail_if_called)
+
     result = runner.run()
 
     assert result.checkpoint is not None
     assert result.checkpoint["preprocess"]["result"]["file_targets"][0]["path"] == "sample.c"
-    assert result.checkpoint["rank"]["ranked_file_targets"][0]["priority"] == pytest.approx(2.8)
+    assert result.checkpoint["rank"] is None
     assert "checkpoint" not in result.output_paths
 
 


### PR DESCRIPTION
## Summary

- add an independent `RankCheckpoint` for the completed ranking phase
- wrap phase state in a stage-keyed `SourceHuntCheckpoint` payload
- restore preprocessing and ranking from their own checkpoint payloads
- serialize the updated checkpoint envelope in the sourcehunt response

## Checkpoint payload

```json
{
  "schema_version": 1,
  "preprocess": { "...": "..." },
  "rank": { "...": "..." }
}
```

## Testing

- `.venv/bin/ruff check clearwing/sourcehunt/checkpoints.py clearwing/sourcehunt/runner.py tests/test_sourcehunt_checkpoints.py`
- `.venv/bin/pytest tests/test_sourcehunt_checkpoints.py -q` (16 passed)

## Stack

Draft follow-up to #151. This PR targets `feat/preprocessing-checkpointing` and should merge into that branch.

---

### Full stack (based on #101)
1. #151 — checkpoint preprocessing stage → `feat/cross-file-chatter`
2. #152 — checkpoint ranking stage → `feat/preprocessing-checkpointing`
3. #153 — checkpoint hunt stage → `feat/rank-checkpointing`
4. #154 — checkpoint verification stage → `feat/hunt-checkpointing`
5. #155 — checkpoint exploitation stage → `feat/verification-checkpointing`
