### PR TITLE
feat(sourcehunt): checkpoint exploitation stage

### DIFF
--- a/clearwing/sourcehunt/checkpoints.py
+++ b/clearwing/sourcehunt/checkpoints.py
@@ -180,6 +180,37 @@ class VerificationCheckpoint(BaseModel):
         return self.result.model_copy(deep=True)
 
 
+class ExploitationResult(BaseModel):
+    """State handed from exploitation to reporting and optional follow-ups."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    verified: list[Finding]
+    exploited: list[Finding]
+
+
+class ExploitationCheckpoint(BaseModel):
+    """Portable state produced by the completed exploitation stage."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = CHECKPOINT_SCHEMA_VERSION
+    options: dict[str, Any]
+    result: ExploitationResult
+
+    @classmethod
+    def from_result(
+        cls, result: ExploitationResult, *, options: dict[str, Any]
+    ) -> ExploitationCheckpoint:
+        return cls(options=options, result=result)
+
+    def restore(self, *, options: dict[str, Any]) -> ExploitationResult | None:
+        if self.options != options:
+            logger.error("Exploitation checkpoint options do not match this run")
+            return None
+        return self.result.model_copy(deep=True)
+
+
 class SourceHuntCheckpoint(BaseModel):
     """Stage-keyed sourcehunt checkpoint passed across the bridge boundary."""
 
@@ -190,6 +221,7 @@ class SourceHuntCheckpoint(BaseModel):
     rank: RankCheckpoint | None = None
     hunt: HuntCheckpoint | None = None
     verification: VerificationCheckpoint | None = None
+    exploitation: ExploitationCheckpoint | None = None
 
     @classmethod
     def from_input(

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -34,6 +34,8 @@ from clearwing.providers import (
 
 from ..sandbox.hunter_sandbox import HunterSandbox
 from .checkpoints import (
+    ExploitationCheckpoint,
+    ExploitationResult,
     HuntCheckpoint,
     HuntResult,
     PreprocessCheckpoint,
@@ -1454,82 +1456,12 @@ class SourceHuntRunner:
                 verified = stable_verified + non_poc
 
             # 5. Exploit-triage (unless --no-exploit) — gated on evidence_level
-            self._emit_stage(
-                "exploit",
-                "started",
-                findings_so_far=len(all_findings),
-                files=[str(finding.file or "") for finding in verified],
-                symbols=self._finding_symbols(verified),
-                finding_ids=[finding.id for finding in verified],
-            )
-            exploited: list[Finding] = []
+            exploitation_result = await self._exploit(verified, findings_pool=findings_pool)
+            verified = exploitation_result.verified
+            exploited = exploitation_result.exploited
             # 5.5 v0.3: Auto-patch (opt-in) — runs after exploiter on verified
             #          critical/high findings with root_cause_explained evidence.
             patched: list[Finding] = []
-            if not self.no_exploit and not self._budget_exhausted():
-                exploiter_llm = self._get_native_client(
-                    "sourcehunt_exploit",
-                    self.exploiter_llm,
-                    budget_stage="exploit",
-                )
-                if exploiter_llm is not None:
-                    eligible = filter_by_evidence(verified, "crash_reproduced")
-                    has_sandbox = (
-                        self._sandbox_manager is not None or self.sandbox_factory is not None
-                    )
-                    if eligible and has_sandbox:
-                        agentic = AgenticExploiter(
-                            llm=exploiter_llm,
-                            sandbox_manager=self._sandbox_manager,
-                            sandbox_factory=self.sandbox_factory,
-                            findings_pool=findings_pool,
-                            budget_band=self._exploit_budget_band,
-                            output_dir=str(self._ensure_output_dir_layout()),
-                            project_name=(
-                                self.repo_url.split("/")[-1] if self.repo_url else "target"
-                            ),
-                        )
-                        for finding in eligible:
-                            if self._budget_exhausted():
-                                logger.info(
-                                    "Exploit phase halted: budget $%.2f exhausted ($%.2f spent)",
-                                    self.budget_usd,
-                                    self._run_spent_usd(),
-                                )
-                                break
-                            try:
-                                exploit_result = await agentic.aattempt(finding)
-                                apply_exploiter_result(finding, exploit_result)
-                                if exploit_result.success:
-                                    exploited.append(finding)
-                                if exploit_result.partial and findings_pool is not None:
-                                    finding["primitive_type"] = (
-                                        exploit_result.primitive_type
-                                        or finding.get("primitive_type", "")
-                                    )
-                                    await findings_pool.add(finding)
-                            except BudgetExceeded:
-                                logger.info("Exploit generation stopped at the run budget")
-                                break
-                            except Exception:
-                                logger.warning(
-                                    "Agentic exploiter failed for %s",
-                                    finding.get("id"),
-                                    exc_info=True,
-                                )
-                    elif eligible:
-                        e = Exploiter(exploiter_llm)
-                        for finding in eligible:
-                            try:
-                                exploit_result = await e.aattempt(finding)
-                                apply_exploiter_result(finding, exploit_result)
-                                if exploit_result.success:
-                                    exploited.append(finding)
-                            except BudgetExceeded:
-                                logger.info("Exploit triage stopped at the run budget")
-                                break
-                            except Exception:
-                                logger.warning("Exploiter failed", exc_info=True)
 
             # 5.25. Stage 1.5: Exploit elaboration (autonomous, opt-in).
             elaborated: list[Finding] = []
@@ -1943,6 +1875,87 @@ class SourceHuntRunner:
             )
         except Exception:
             logger.debug("gh pr create failed", exc_info=True)
+
+    async def _exploit(self, verified: list[Finding], *, findings_pool: Any) -> ExploitationResult:
+        """Run or restore the completed exploitation stage."""
+
+        options = {
+            "no_exploit": self.no_exploit,
+            "exploit_budget_band": self._exploit_budget_band,
+            "agent_mode": self._effective_agent_mode,
+        }
+        self._exploitation_restored = False
+        self._emit_stage(
+            "exploit",
+            "started",
+            findings_so_far=len(verified),
+            files=[str(finding.file or "") for finding in verified],
+            symbols=self._finding_symbols(verified),
+            finding_ids=[finding.id for finding in verified],
+        )
+        if self._checkpoint is not None and self._checkpoint.exploitation is not None:
+            restored = self._checkpoint.exploitation.restore(options=options)
+            if restored is None:
+                raise ValueError("exploitation checkpoint is invalid or incompatible with this run")
+            self._exploitation_restored = True
+            self._emit_stage(
+                "exploit",
+                "completed",
+                findings_so_far=len(restored.exploited),
+                detail=f"Restored {len(restored.exploited)} exploited findings from checkpoint",
+                finding_ids=[finding.id for finding in restored.exploited],
+            )
+            return restored
+
+        result = ExploitationResult(verified=verified, exploited=[])
+        if not self.no_exploit and not self._budget_exhausted():
+            exploiter_llm = self._get_native_client(
+                "sourcehunt_exploit", self.exploiter_llm, budget_stage="exploit"
+            )
+            if exploiter_llm is not None:
+                eligible = filter_by_evidence(result.verified, "crash_reproduced")
+                has_sandbox = self._sandbox_manager is not None or self.sandbox_factory is not None
+                if eligible and has_sandbox:
+                    exploiter = AgenticExploiter(
+                        llm=exploiter_llm,
+                        sandbox_manager=self._sandbox_manager,
+                        sandbox_factory=self.sandbox_factory,
+                        findings_pool=findings_pool,
+                        budget_band=self._exploit_budget_band,
+                        output_dir=str(self._ensure_output_dir_layout()),
+                        project_name=self.repo_url.split("/")[-1] if self.repo_url else "target",
+                    )
+                else:
+                    exploiter = Exploiter(exploiter_llm)
+                for finding in eligible:
+                    if self._budget_exhausted():
+                        break
+                    try:
+                        exploit_result = await exploiter.aattempt(finding)
+                        apply_exploiter_result(finding, exploit_result)
+                        if exploit_result.success:
+                            result.exploited.append(finding)
+                        if has_sandbox and exploit_result.partial and findings_pool is not None:
+                            finding["primitive_type"] = (
+                                exploit_result.primitive_type or finding.get("primitive_type", "")
+                            )
+                            await findings_pool.add(finding)
+                    except BudgetExceeded:
+                        logger.info("Exploitation stopped at the run budget")
+                        break
+                    except Exception:
+                        logger.warning("Exploiter failed for %s", finding.id, exc_info=True)
+        if self._checkpoint is None:
+            raise RuntimeError("exploitation requires a preprocessing checkpoint")
+        self._checkpoint.exploitation = ExploitationCheckpoint.from_result(result, options=options)
+        self._emit_stage(
+            "exploit",
+            "completed" if not self._budget_exhausted() else "budget_exhausted",
+            findings_so_far=len(result.exploited),
+            detail=f"{len(result.exploited)} exploited findings",
+            finding_ids=[finding.id for finding in result.exploited],
+        )
+        return result
 
     async def _verify(
         self,

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -8,6 +8,8 @@ import pytest
 from clearwing.analysis.source_analyzer import AnalyzerFinding
 from clearwing.sourcehunt.callgraph import CallGraph, FunctionInfo
 from clearwing.sourcehunt.checkpoints import (
+    ExploitationCheckpoint,
+    ExploitationResult,
     HuntCheckpoint,
     HuntResult,
     PreprocessCheckpoint,
@@ -563,3 +565,44 @@ def test_verification_checkpoint_rejects_different_options():
         VerificationResult(verified=[], rejected=[]), options={"validator_mode": "v2"}
     )
     assert checkpoint.restore(options={"validator_mode": "v1"}) is None
+
+
+@pytest.mark.asyncio
+async def test_runner_checkpoints_and_restores_exploitation(tmp_path: Path, monkeypatch):
+    finding = Finding(
+        id="finding-1", file="sample.c", severity="high", evidence_level="crash_reproduced"
+    )
+    first = SourceHuntRunner(
+        repo_url=str(tmp_path), output_dir=str(tmp_path), enable_mechanism_memory=False
+    )
+    first._checkpoint = SourceHuntCheckpoint()
+    monkeypatch.setattr(first, "_get_native_client", lambda *args, **kwargs: None)
+    result = await first._exploit([finding], findings_pool=None)
+    assert isinstance(first._checkpoint.exploitation, ExploitationCheckpoint)
+    assert result.verified[0].id == "finding-1"
+
+    saved = ExploitationResult(verified=[finding], exploited=[finding])
+    first._checkpoint.exploitation = ExploitationCheckpoint.from_result(
+        saved, options=first._checkpoint.exploitation.options
+    )
+    resumed = SourceHuntRunner(
+        repo_url=str(tmp_path),
+        output_dir=str(tmp_path),
+        checkpoint=first._checkpoint.model_dump(mode="json"),
+        enable_mechanism_memory=False,
+    )
+    monkeypatch.setattr(
+        resumed,
+        "_get_native_client",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("exploiter called")),
+    )
+    restored = await resumed._exploit([finding], findings_pool=None)
+    assert resumed._exploitation_restored is True
+    assert restored.exploited[0].id == "finding-1"
+
+
+def test_exploitation_checkpoint_rejects_different_options():
+    checkpoint = ExploitationCheckpoint.from_result(
+        ExploitationResult(verified=[], exploited=[]), options={"no_exploit": False}
+    )
+    assert checkpoint.restore(options={"no_exploit": True}) is None


### PR DESCRIPTION
## Summary

- wrap exploitation in a dedicated `_exploit()` phase method
- add typed Pydantic `ExploitationResult` and `ExploitationCheckpoint` payloads
- preserve both mutated verified findings and successfully exploited findings
- restore exploitation without resolving or invoking the exploiter model
- validate exploit skip state, budget band, and agent mode

## Testing

- `.venv/bin/ruff check clearwing/sourcehunt/checkpoints.py clearwing/sourcehunt/runner.py tests/test_sourcehunt_checkpoints.py`
- `.venv/bin/pytest tests/test_sourcehunt_checkpoints.py -q` (22 passed)
- `.venv/bin/pytest tests/test_sourcehunt_runner.py -q` (16 passed)

## Stack

Draft follow-up to #154. This PR targets `feat/verification-checkpointing` and should merge into that branch.

---

### Full stack (based on #101)
1. #151 — checkpoint preprocessing stage → `feat/cross-file-chatter`
2. #152 — checkpoint ranking stage → `feat/preprocessing-checkpointing`
3. #153 — checkpoint hunt stage → `feat/rank-checkpointing`
4. #154 — checkpoint verification stage → `feat/hunt-checkpointing`
5. #155 — checkpoint exploitation stage → `feat/verification-checkpointing`
