### PR TITLE
Persist SourceHunt checkpoints across machine runs

### DIFF
--- a/clearwing/sourcehunt/checkpoints.py
+++ b/clearwing/sourcehunt/checkpoints.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
+import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
@@ -233,6 +235,33 @@ class SourceHuntCheckpoint(BaseModel):
         if isinstance(value, str):
             return cls.model_validate_json(value)
         return cls.model_validate(value)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> SourceHuntCheckpoint:
+        """Load and validate a checkpoint from its host-selected JSON path."""
+
+        return cls.model_validate_json(Path(path).read_text(encoding="utf-8"))
+
+    def dump(self, path: str | Path) -> Path:
+        """Atomically write the complete checkpoint model to a JSON file."""
+
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        payload = self.model_dump_json(indent=2).encode("utf-8") + b"\n"
+        descriptor, temporary = tempfile.mkstemp(dir=target.parent, suffix=".tmp")
+        try:
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, target)
+        except BaseException:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+            raise
+        return target
 
 
 def repository_commit_sha(repo_path: str | Path) -> str | None:

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -244,6 +244,7 @@ class SourceHuntRunner:
         sandbox_factory: Any = None,  # callable[[], SandboxContainer]
         parent_session_id: str | None = None,
         checkpoint: dict[str, Any] | str | None = None,
+        checkpoint_path: str | Path | None = None,
         agent_mode: str = "auto",  # "auto" | "constrained" | "deep"
         prompt_mode: str = "unconstrained",  # "unconstrained" | "specialist"
         campaign_hint: str | None = None,
@@ -534,9 +535,17 @@ class SourceHuntRunner:
         self._sandbox_manager: HunterSandbox | None = None
         self._preprocessor: Preprocessor | None = None
         self._session_id = parent_session_id or f"sh-{uuid.uuid4().hex[:8]}"
-        self._checkpoint = (
-            SourceHuntCheckpoint.from_input(checkpoint) if checkpoint is not None else None
+        self._checkpoint_path = (
+            Path(checkpoint_path)
+            if checkpoint_path is not None
+            else Path(self.output_dir) / self._session_id / "checkpoint.json"
         )
+        if checkpoint is not None:
+            self._checkpoint = SourceHuntCheckpoint.from_input(checkpoint)
+        elif self._checkpoint_path.is_file():
+            self._checkpoint = SourceHuntCheckpoint.from_file(self._checkpoint_path)
+        else:
+            self._checkpoint = None
         self._agent_mode_override = agent_mode
         self._prompt_mode = prompt_mode
         self._campaign_hint = campaign_hint
@@ -594,6 +603,11 @@ class SourceHuntRunner:
         self._instrumentation_finalized = False
         self._last_reporting_error: dict[str, str] | None = None
         self._on_progress = on_progress
+
+    def _dump_checkpoint(self) -> None:
+        if self._checkpoint is None:
+            return
+        self._checkpoint.dump(self._checkpoint_path)
 
     @staticmethod
     def _check_runtime_available(runtime: str | None) -> str | None:
@@ -1957,6 +1971,7 @@ class SourceHuntRunner:
         if self._checkpoint is None:
             raise RuntimeError("exploitation requires a preprocessing checkpoint")
         self._checkpoint.exploitation = ExploitationCheckpoint.from_result(result, options=options)
+        self._dump_checkpoint()
         self._emit_stage(
             "exploit",
             "completed" if not self._budget_exhausted() else "budget_exhausted",
@@ -2041,6 +2056,7 @@ class SourceHuntRunner:
             self._checkpoint.verification = VerificationCheckpoint.from_result(
                 result, options=options
             )
+            self._dump_checkpoint()
             detail = (
                 "Verification skipped (--no-verify)"
                 if self.no_verify
@@ -2525,6 +2541,7 @@ class SourceHuntRunner:
         if self._checkpoint is None:
             raise RuntimeError("hunting requires a preprocessing checkpoint")
         self._checkpoint.hunt = HuntCheckpoint.from_result(result, options=options)
+        self._dump_checkpoint()
         return result
 
     async def _hunt_subsystems(
@@ -2710,6 +2727,7 @@ class SourceHuntRunner:
             self._checkpoint = SourceHuntCheckpoint(preprocess=preprocess_checkpoint)
         else:
             self._checkpoint.preprocess = preprocess_checkpoint
+        self._dump_checkpoint()
         return result
 
     async def _rank(
@@ -2802,6 +2820,7 @@ class SourceHuntRunner:
         if self._checkpoint is None:
             raise RuntimeError("ranking requires a preprocessing checkpoint")
         self._checkpoint.rank = RankCheckpoint.from_result(files, options=options)
+        self._dump_checkpoint()
         return files
 
     @staticmethod

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1308,16 +1308,19 @@ def _handle_machine(descriptor: int) -> int:
         request, routing = channel.read_start()
         print(f"sourcehunt machine-fd request fields: {sorted(request)}", file=sys.stderr)
         parsed = _machine_request(request)
+        workspace = channel.workspace or {}
         install_runtime_routing(routing)
         provider_manager = ProviderManager.from_config(routing)
         result = asyncio.run(
             SourceHuntRunner(
                 repo_url=parsed["repo_url"],
+                local_path=workspace.get("local_path"),
                 branch=parsed["branch"],
                 depth=parsed["depth"],
                 budget_usd=parsed["budget_usd"],
                 max_parallel=parsed["max_parallel"],
-                output_dir=os.path.abspath("results/sourcehunt"),
+                output_dir=workspace.get("output_dir") or os.path.abspath("results/sourcehunt"),
+                checkpoint_path=workspace.get("checkpoint_path"),
                 no_verify=not parsed["verify"],
                 no_exploit=not parsed["exploit"],
                 flow=parsed["flow"],

--- a/clearwing/ui/machine.py
+++ b/clearwing/ui/machine.py
@@ -36,6 +36,7 @@ class MachineChannel:
         os.close(descriptor)
         self._sequence = 0
         self._terminal = False
+        self.workspace: dict[str, Any] | None = None
 
     def read_start(self) -> tuple[dict[str, Any], dict[str, Any] | None]:
         """Read and validate the command's start record."""
@@ -50,7 +51,7 @@ class MachineChannel:
             raise MachineProtocolError("start record must be UTF-8 JSON") from exc
         if not isinstance(record, dict):
             raise MachineProtocolError("start record must be an object")
-        allowed = {"v", "type", "request", "provider_routing"}
+        allowed = {"v", "type", "request", "provider_routing", "workspace"}
         unknown = sorted(set(record) - allowed)
         if unknown:
             raise MachineProtocolError(f"unknown start field(s): {', '.join(unknown)}")
@@ -61,6 +62,10 @@ class MachineChannel:
         request = record.get("request")
         if not isinstance(request, dict):
             raise MachineProtocolError("request must be an object")
+        workspace = record.get("workspace")
+        if workspace is not None and not isinstance(workspace, dict):
+            raise MachineProtocolError("workspace must be an object")
+        self.workspace = workspace
         routing = _decode_provider_routing(
             record.get("provider_routing"), required=self.require_provider_routing
         )

--- a/tests/test_machine_cli.py
+++ b/tests/test_machine_cli.py
@@ -39,19 +39,22 @@ def _routing(value: dict | None = None) -> dict:
     return {"encoding": "base64url", "value": encoded}
 
 
-def _channel(operation: str, request: dict, routing: dict | None = None):
+def _channel(
+    operation: str,
+    request: dict,
+    routing: dict | None = None,
+    workspace: dict | None = None,
+):
     parent, child = socket.socketpair()
-    parent.sendall(
-        json.dumps(
-            {
-                "v": 1,
-                "type": f"{operation}.start",
-                "request": request,
-                "provider_routing": routing or _routing(),
-            }
-        ).encode()
-        + b"\n"
-    )
+    record = {
+        "v": 1,
+        "type": f"{operation}.start",
+        "request": request,
+        "provider_routing": routing or _routing(),
+    }
+    if workspace is not None:
+        record["workspace"] = workspace
+    parent.sendall(json.dumps(record).encode() + b"\n")
     return parent, MachineChannel(child.detach(), operation)
 
 
@@ -77,6 +80,25 @@ def test_channel_rejects_unknown_and_oversized_start_records():
     channel = MachineChannel(child.detach(), "operate")
     with pytest.raises(MachineProtocolError, match="unknown start"):
         channel.read_start()
+    channel.close()
+    parent.close()
+
+
+def test_channel_accepts_host_selected_workspace_paths():
+    workspace = {
+        "local_path": "/workspaces/run/source",
+        "output_dir": "/workspaces/run/sourcehunt",
+        "checkpoint_path": "/workspaces/run/sourcehunt/pipeline/checkpoint.json",
+    }
+    parent, channel = _channel(
+        "sourcehunt",
+        {"repo_url": "https://example.test/repo"},
+        workspace=workspace,
+    )
+
+    channel.read_start()
+
+    assert channel.workspace == workspace
     channel.close()
     parent.close()
 
@@ -122,6 +144,13 @@ def test_sourcehunt_request_rejects_paths_credentials_and_provider_fields():
     with pytest.raises(ValueError, match="unknown request field.*model"):
         sourcehunt._machine_request(
             {"repo_url": "https://example.test/repo", "model": "guest-model"}
+        )
+    with pytest.raises(ValueError, match="unknown request field.*stage"):
+        sourcehunt._machine_request(
+            {
+                "repo_url": "https://example.test/repo",
+                "stage": "hunt",
+            }
         )
 
 

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -197,6 +197,28 @@ def test_sourcehunt_checkpoint_preserves_checkpoint_instance():
     assert SourceHuntCheckpoint.from_input(checkpoint) is checkpoint
 
 
+def test_sourcehunt_checkpoint_dumps_one_atomic_aggregate_file(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    preprocess = PreprocessCheckpoint.from_result(_result(repo), options=OPTIONS)
+    checkpoint = SourceHuntCheckpoint(preprocess=preprocess)
+    target = tmp_path / "workspace" / "sourcehunt" / "pipeline" / "checkpoint.json"
+
+    assert checkpoint.dump(target) == target
+    restored = SourceHuntCheckpoint.model_validate_json(target.read_text(encoding="utf-8"))
+    assert restored.preprocess == preprocess
+    assert restored.rank is None
+
+    checkpoint.rank = RankCheckpoint.from_result(
+        [{"path": "sample.c", "priority": 4.2}], options={"preprocessing": True}
+    )
+    checkpoint.dump(target)
+    restored = SourceHuntCheckpoint.model_validate_json(target.read_text(encoding="utf-8"))
+    assert restored.rank == checkpoint.rank
+    assert list(target.parent.glob("*.tmp")) == []
+
+
 def test_preprocess_checkpoint_rejects_different_options(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -244,6 +266,11 @@ def test_runner_restores_preprocess_checkpoint(tmp_path: Path, monkeypatch):
     )
     original = first._preprocess()
     checkpoint_blob = first._checkpoint.model_dump_json()
+    checkpoint_path = tmp_path / "results" / "sh-resume" / "checkpoint.json"
+    assert (
+        SourceHuntCheckpoint.model_validate_json(checkpoint_path.read_text(encoding="utf-8"))
+        == first._checkpoint
+    )
 
     resumed = SourceHuntRunner(
         repo_url=str(repo),
@@ -293,6 +320,49 @@ def test_runner_accepts_checkpoint_as_json_object(tmp_path: Path):
 
     assert resumed._preprocess().file_targets[0]["path"] == "sample.c"
     assert resumed._preprocess_restored is True
+
+
+def test_runner_loads_and_updates_bridge_checkpoint_path(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    _commit(repo)
+    checkpoint_path = tmp_path / "workspace" / "pipeline" / "checkpoint.json"
+    output_dir = tmp_path / "workspace" / "sourcehunt"
+    first = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(output_dir),
+        parent_session_id="bridge-session",
+        checkpoint_path=checkpoint_path,
+        depth="quick",
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+
+    original = first._preprocess()
+
+    assert checkpoint_path.is_file()
+    assert not (output_dir / "bridge-session" / "checkpoint.json").exists()
+    resumed = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(output_dir),
+        parent_session_id="another-session",
+        checkpoint_path=checkpoint_path,
+        depth="quick",
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("preprocessor ran instead of loading checkpoint_path")
+
+    monkeypatch.setattr("clearwing.sourcehunt.preprocessor.Preprocessor.run", fail_if_called)
+    restored = resumed._preprocess()
+
+    assert resumed._preprocess_restored is True
+    assert restored.file_targets == original.file_targets
 
 
 def test_runner_rejects_incompatible_preprocess_checkpoint(tmp_path: Path):


### PR DESCRIPTION
## Summary

- persist the aggregate SourceHunt checkpoint atomically after each completed pipeline stage
- load and update checkpoints through an optional host-selected checkpoint path
- accept optional workspace metadata in machine start records and use its source, output, and checkpoint paths for SourceHunt runs
- preserve the existing inline checkpoint input and default output behavior for callers that do not provide workspace metadata

## Test plan

- `uv run --extra dev ruff check` on all six changed files
- `uv run --extra dev pytest -q tests/test_machine_cli.py tests/test_sourcehunt_checkpoints.py` (37 passed)
