### PR TITLE
fix(sourcehunt): propagate subsystem budget exhaustion

### DIFF
--- a/clearwing/sourcehunt/checkpoints.py
+++ b/clearwing/sourcehunt/checkpoints.py
@@ -128,6 +128,9 @@ class HuntResult(BaseModel):
     band_stats: dict[str, Any] | None = None
     subsystems_hunted: int = 0
     subsystem_spent_usd: float = 0.0
+    subsystem_status: Literal["completed", "skipped", "budget_exhausted", "degraded"] = (
+        "completed"
+    )
 
 
 class HuntCheckpoint(BaseModel):

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -1699,12 +1699,20 @@ class SourceHuntRunner:
             if ledger_subsystem_spend:
                 subsystem_spent = ledger_subsystem_spend
 
-            run_status = "budget_exhausted" if self._budget_exhausted() else "completed"
+            run_status = (
+                "budget_exhausted"
+                if self._budget_exhausted() or hunt_result.subsystem_status == "budget_exhausted"
+                else "completed"
+            )
             if run_status == "budget_exhausted":
                 pipeline_status.record(
                     "budget",
                     StageOutcome.SKIPPED,
-                    fallback_description="Dollar cap reached; partial results retained",
+                    fallback_description=(
+                        "Dollar cap reached; partial results retained"
+                        if self._budget_exhausted()
+                        else "Subsystem hunt budget exhausted; partial results retained"
+                    ),
                 )
             budget_summary = self._finalize_spend_ledger(run_status)
             _pool_stats = findings_pool.pool_stats() if findings_pool is not None else None
@@ -2376,10 +2384,25 @@ class SourceHuntRunner:
                 finding_ids=[finding.id for finding in restored.findings],
             )
             if self._enable_subsystem_hunt:
+                if restored.subsystem_status == "budget_exhausted":
+                    pipeline_status.record(
+                        "subsystem_hunt",
+                        StageOutcome.SKIPPED,
+                        fallback_description=(
+                            "Budget exhausted; partial subsystem results retained"
+                        ),
+                    )
+                elif restored.subsystem_status == "degraded":
+                    pipeline_status.record_degraded(
+                        "subsystem_hunt",
+                        "Subsystem hunt failed; only per-file findings available",
+                    )
+                elif restored.subsystem_status == "completed":
+                    pipeline_status.record_succeeded("subsystem_hunt")
                 self._emit_stage(
                     "subsystem_hunt",
-                    "completed",
-                    findings_so_far=restored.subsystems_hunted,
+                    restored.subsystem_status,
+                    findings_so_far=len(restored.findings),
                     cost_usd=restored.subsystem_spent_usd,
                     detail=(
                         f"Restored {restored.subsystems_hunted} hunted subsystems from checkpoint"
@@ -2560,6 +2583,18 @@ class SourceHuntRunner:
         if not self._enable_subsystem_hunt:
             return
         if self._budget_exhausted():
+            result.subsystem_status = "budget_exhausted"
+            pipeline_status.record(
+                "subsystem_hunt",
+                StageOutcome.SKIPPED,
+                fallback_description="Budget exhausted before subsystem hunting",
+            )
+            self._emit_stage(
+                "subsystem_hunt",
+                "budget_exhausted",
+                cost_usd=self._run_spent_usd(),
+                detail="Run budget was exhausted before subsystem hunting",
+            )
             logger.info(
                 "Subsystem hunt skipped: budget $%.2f exhausted ($%.2f spent)",
                 self.budget_usd,
@@ -2662,9 +2697,20 @@ class SourceHuntRunner:
             result.findings.extend(subsystem_findings)
             result.subsystems_hunted = len(subsystem_targets)
             result.subsystem_spent_usd = subsystem_runner.total_spent
+            result.subsystem_status = (
+                "budget_exhausted" if subsystem_runner.budget_exhausted else "completed"
+            )
+            if result.subsystem_status == "budget_exhausted":
+                pipeline_status.record(
+                    "subsystem_hunt",
+                    StageOutcome.SKIPPED,
+                    fallback_description="Budget exhausted; partial subsystem results retained",
+                )
+            else:
+                pipeline_status.record_succeeded("subsystem_hunt")
             self._emit_stage(
                 "subsystem_hunt",
-                "completed",
+                result.subsystem_status,
                 findings_so_far=len(subsystem_findings),
                 cost_usd=result.subsystem_spent_usd,
                 files=subsystem_files,
@@ -2672,6 +2718,7 @@ class SourceHuntRunner:
                 finding_ids=[finding.id for finding in subsystem_findings],
             )
         except Exception as exc:
+            result.subsystem_status = "degraded"
             logger.warning("Subsystem hunt failed", exc_info=True)
             pipeline_status.record_degraded(
                 "subsystem_hunt",

--- a/clearwing/sourcehunt/subsystem.py
+++ b/clearwing/sourcehunt/subsystem.py
@@ -264,6 +264,7 @@ class SubsystemHuntRunner:
         self.config = config
         self._spent: float = 0.0
         self._subsystems_completed: int = 0
+        self._budget_exhausted = False
 
     @property
     def total_spent(self) -> float:
@@ -272,6 +273,11 @@ class SubsystemHuntRunner:
     @property
     def subsystems_completed(self) -> int:
         return self._subsystems_completed
+
+    @property
+    def budget_exhausted(self) -> bool:
+        """Whether any subsystem stopped before completion at its budget limit."""
+        return self._budget_exhausted
 
     async def arun(self) -> list[Finding]:
         """Run all subsystem hunts. Returns merged findings."""
@@ -284,6 +290,7 @@ class SubsystemHuntRunner:
         async def _guarded_run(subsystem: SubsystemTarget) -> list[Finding]:
             async with sem:
                 if self.config.total_budget_usd > 0 and self._spent >= self.config.total_budget_usd:
+                    self._budget_exhausted = True
                     logger.info(
                         "Subsystem %s skipped: total budget exhausted",
                         subsystem.name,
@@ -308,8 +315,10 @@ class SubsystemHuntRunner:
                     )
                 self._spent += cost
                 self._subsystems_completed += 1
+                if stop == "budget_exhausted":
+                    self._budget_exhausted = True
                 logger.info(
-                    "Subsystem %s completed: %d findings, $%.4f, stop=%s",
+                    "Subsystem %s finished: %d findings, $%.4f, stop=%s",
                     subsystem.name,
                     len(findings),
                     cost,
@@ -330,6 +339,7 @@ class SubsystemHuntRunner:
                 findings = await coro
                 all_findings.extend(findings)
             except BudgetExceeded:
+                self._budget_exhausted = True
                 logger.info("Subsystem hunt stopped because the run budget is exhausted")
                 for task in tasks:
                     if not task.done():

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -598,6 +598,41 @@ def test_hunt_checkpoint_rejects_different_options():
     assert checkpoint.restore(options={"agent_mode": "deep"}) is None
 
 
+def test_hunt_checkpoint_preserves_subsystem_budget_exhaustion():
+    checkpoint = HuntCheckpoint.from_result(
+        HuntResult(
+            findings=[],
+            spent_per_tier={},
+            subsystem_status="budget_exhausted",
+        ),
+        options={},
+    )
+
+    restored = checkpoint.restore(options={})
+
+    assert restored is not None
+    assert restored.subsystem_status == "budget_exhausted"
+
+
+def test_legacy_hunt_checkpoint_defaults_subsystem_status_to_completed():
+    checkpoint = HuntCheckpoint.model_validate(
+        {
+            "schema_version": 1,
+            "options": {},
+            "result": {
+                "findings": [],
+                "spent_per_tier": {},
+                "subsystems_hunted": 1,
+            },
+        }
+    )
+
+    restored = checkpoint.restore(options={})
+
+    assert restored is not None
+    assert restored.subsystem_status == "completed"
+
+
 @pytest.mark.asyncio
 async def test_runner_checkpoints_and_restores_verification(tmp_path: Path, monkeypatch):
     finding = Finding(id="finding-1", file="sample.c", severity="high")

--- a/tests/test_sourcehunt_subsystem.py
+++ b/tests/test_sourcehunt_subsystem.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
 
-from clearwing.sourcehunt.state import FileTarget, SubsystemTarget
+from clearwing.sourcehunt.runner import SourceHuntRunner
+from clearwing.sourcehunt.state import FileTarget, StageOutcome, SubsystemTarget
 from clearwing.sourcehunt.subsystem import (
     SubsystemHuntConfig,
     SubsystemHuntRunner,
@@ -428,6 +430,132 @@ async def test_subsystem_hunt_runner_no_subsystems():
     ))
     result = await runner.arun()
     assert result == []
+
+
+@pytest.mark.asyncio
+async def test_subsystem_hunt_runner_preserves_budget_exhaustion(monkeypatch):
+    runner = SubsystemHuntRunner(
+        SubsystemHuntConfig(
+            subsystems=[SubsystemTarget(name="test", root_path="src", files=[])],
+            repo_path="/tmp",
+            llm=MagicMock(),
+        )
+    )
+
+    async def budget_exhausted(*args, **kwargs):
+        return [], 1.0, 10, "budget_exhausted"
+
+    monkeypatch.setattr(runner, "_run_one_subsystem", budget_exhausted)
+
+    assert await runner.arun() == []
+    assert runner.budget_exhausted is True
+
+
+def test_subsystem_budget_stop_marks_sourcehunt_run_incomplete(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "clearwing.sourcehunt.checkpoints.repository_commit_sha",
+        lambda repo_path: "a" * 40,
+    )
+
+    class BudgetExhaustedSubsystemRunner:
+        def __init__(self, config):
+            self.total_spent = 1.0
+            self.budget_exhausted = True
+
+        async def arun(self):
+            return []
+
+    monkeypatch.setattr(
+        "clearwing.sourcehunt.subsystem.SubsystemHuntRunner",
+        BudgetExhaustedSubsystemRunner,
+    )
+    repo = tmp_path / "repo"
+    source_dir = repo / "src"
+    source_dir.mkdir(parents=True)
+    (source_dir / "app.py").write_text("def main():\n    return 0\n", encoding="utf-8")
+    progress = []
+    runner_options = {
+        "repo_url": str(repo),
+        "local_path": str(repo),
+        "depth": "standard",
+        "output_formats": ["json"],
+        "no_rank": True,
+        "no_verify": True,
+        "no_exploit": True,
+        "enable_mechanism_memory": False,
+        "enable_knowledge_graph": False,
+        "enable_behavior_monitor": False,
+        "enable_findings_pool": False,
+        "enable_subsystem_hunt": True,
+        "subsystem_paths": ["src"],
+        "no_per_file_hunt": True,
+        "preprocessing": False,
+        "shard_entry_points": False,
+        "hunter_llm": MagicMock(),
+        "sandbox_factory": lambda: None,
+        "on_progress": progress.append,
+    }
+    output = tmp_path / "out"
+    runner = SourceHuntRunner(
+        output_dir=str(output),
+        **runner_options,
+    )
+
+    result = runner.run()
+    manifest = json.loads(
+        (output / result.session_id / "manifest.json").read_text(encoding="utf-8")
+    )
+
+    assert runner._spend_ledger is not None
+    assert runner._spend_ledger.exhausted is False
+    assert result.status == "budget_exhausted"
+    assert result.exit_code == 3
+    assert result.checkpoint is not None
+    assert result.checkpoint["hunt"]["result"]["subsystem_status"] == "budget_exhausted"
+    assert result.pipeline_status.stages["subsystem_hunt"].outcome is StageOutcome.SKIPPED
+    fresh_budget_event = next(
+        event
+        for event in progress
+        if event.stage == "subsystem_hunt" and event.status == "budget_exhausted"
+    )
+    assert fresh_budget_event.findings_so_far == 0
+    assert fresh_budget_event.cost_usd == 1.0
+    assert manifest["status"] == "budget_exhausted"
+    assert manifest["complete"] is False
+
+    class UnexpectedSubsystemRunner:
+        def __init__(self, config):
+            raise AssertionError("subsystem hunt ran instead of restoring its checkpoint")
+
+    monkeypatch.setattr(
+        "clearwing.sourcehunt.subsystem.SubsystemHuntRunner",
+        UnexpectedSubsystemRunner,
+    )
+    resumed_output = tmp_path / "resumed-out"
+    first_run_event_count = len(progress)
+    resumed = SourceHuntRunner(
+        output_dir=str(resumed_output),
+        checkpoint=result.checkpoint,
+        **runner_options,
+    )
+
+    resumed_result = resumed.run()
+    resumed_manifest = json.loads(
+        (resumed_output / resumed_result.session_id / "manifest.json").read_text(encoding="utf-8")
+    )
+
+    assert resumed_result.status == "budget_exhausted"
+    assert resumed_result.exit_code == 3
+    assert resumed_result.pipeline_status.stages["subsystem_hunt"].outcome is StageOutcome.SKIPPED
+    resumed_budget_event = next(
+        event
+        for event in progress[first_run_event_count:]
+        if event.stage == "subsystem_hunt" and event.status == "budget_exhausted"
+    )
+    assert resumed_budget_event.findings_so_far == 0
+    assert resumed_budget_event.cost_usd == 1.0
+    assert resumed_manifest["status"] == "budget_exhausted"
+    assert resumed_manifest["complete"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A subsystem hunter can terminate normally with stop_reason=budget_exhausted before the run-wide SpendLedger reaches its exact dollar cap. SubsystemHuntRunner discarded that stop reason, so the parent emitted completed and SourceHunt returned exit 0 with manifest status=completed and complete=true.

This was reproduced on the jq CVE smoke test: the subsystem stopped after 79 model calls and $9.113757 of a $10 ledger, but the run reported success with zero findings.

## Fix

- Preserve subsystem budget exhaustion as a monotonic runner flag.
- Carry the terminal state in HuntResult and the persisted hunt checkpoint.
- Emit and record subsystem_hunt=budget_exhausted while retaining partial findings and spend.
- Return exit 3 and write status=budget_exhausted / complete=false even when the global ledger itself is not yet marked exhausted.
- Preserve the incomplete status when restoring the persisted checkpoint; the subsystem is not incorrectly rerun or relabeled completed.
- Keep schema-v1 checkpoints readable by defaulting the new field to the prior completed behavior.

This is deliberately limited to terminal-status propagation. It does not add per-agent-turn conversational resume.

## Validation

- Full SourceHunt and spend-budget suite: 906 passed.
- Focused subsystem, checkpoint, runner, and spend-budget suite: 100 passed.
- Ruff check passed.
- git diff --check passed.
- End-to-end regression explicitly holds SpendLedger.exhausted=false while asserting fresh and restored results both return exit 3 and incomplete manifests.