### PR TITLE
fix(sourcehunt): staged pipeline checkpoint resumption

### DIFF
--- a/clearwing/sourcehunt/ranker.py
+++ b/clearwing/sourcehunt/ranker.py
@@ -21,6 +21,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from clearwing.core.events import EventBus
 from clearwing.llm import AsyncLLMClient, BudgetExceeded
 from clearwing.llm.native import extract_json_array, extract_json_object
 
@@ -200,6 +201,10 @@ class Ranker:
                     "Ranker progress %d/%d chunks completed",
                     completed,
                     total_chunks,
+                )
+                EventBus().emit_message(
+                    f"ranking progress  {completed}/{total_chunks} chunks ranked",
+                    "info",
                 )
         except BudgetExceeded:
             for task in tasks:

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -289,6 +289,7 @@ class SourceHuntRunner:
         retain_incomplete_certificates: bool = True,
         emit_rejection_certificates: bool = True,
         falsify: bool = True,
+        stop_after: str | None = None,
         on_progress: SourceHuntProgressCallback | None = None,
     ):
         # --- Resolve from SourceHuntConfig when provided ----------------------
@@ -562,6 +563,7 @@ class SourceHuntRunner:
         self._subsystem_paths = subsystem_paths
         self._no_per_file_hunt = no_per_file_hunt
         self._no_rank = no_rank
+        self._stop_after = stop_after
         self._subsystem_budget_usd = subsystem_budget_usd
         self._subsystem_max_parallel = subsystem_max_parallel
         # None = library default (DEFAULT_MAX_FILES_PER_SUBSYSTEM for auto
@@ -1084,6 +1086,17 @@ class SourceHuntRunner:
                 ),
                 files=stage_files,
             )
+
+            if self._stop_after == "preprocess":
+                logger.info("--stop-after preprocess: exiting early")
+                return self._build_quick_result(
+                    start_time=start_time,
+                    repo_path=repo_path,
+                    preprocess_result=preprocess_result,
+                    files_ranked=files_ranked,
+                    pipeline_status=pipeline_status,
+                )
+
             _t = time.monotonic()
             self._ensure_sandbox_factory(repo_path, files)
             logger.info("Sandbox factory ready in %.2fs", time.monotonic() - _t)
@@ -1110,6 +1123,16 @@ class SourceHuntRunner:
             else:
                 files = await self._rank(files, pipeline_status, stage_files)
             preprocess_result.file_targets = files
+
+            if self._stop_after == "rank":
+                logger.info("--stop-after rank: exiting early")
+                return self._build_quick_result(
+                    start_time=start_time,
+                    repo_path=repo_path,
+                    preprocess_result=preprocess_result,
+                    files_ranked=files_ranked,
+                    pipeline_status=pipeline_status,
+                )
 
             # depth=quick exits here with the static_findings as-is
             if self.depth == "quick":
@@ -1312,6 +1335,16 @@ class SourceHuntRunner:
                 finally:
                     historical_db.close()
 
+            if self._stop_after == "hunt":
+                logger.info("--stop-after hunt: exiting early")
+                return self._build_quick_result(
+                    start_time=start_time,
+                    repo_path=repo_path,
+                    preprocess_result=preprocess_result,
+                    files_ranked=files_ranked,
+                    pipeline_status=pipeline_status,
+                )
+
             # 4. Verify (unless --no-verify)
             verification_result = await self._verify(
                 all_findings, repo_path=repo_path, pipeline_status=pipeline_status
@@ -1477,6 +1510,16 @@ class SourceHuntRunner:
                         stable_verified.append(finding)
                 non_poc = [f for f in verified if f not in stability_eligible]
                 verified = stable_verified + non_poc
+
+            if self._stop_after == "verify":
+                logger.info("--stop-after verify: exiting early")
+                return self._build_quick_result(
+                    start_time=start_time,
+                    repo_path=repo_path,
+                    preprocess_result=preprocess_result,
+                    files_ranked=files_ranked,
+                    pipeline_status=pipeline_status,
+                )
 
             # 5. Exploit-triage (unless --no-exploit) — gated on evidence_level
             exploitation_result = await self._exploit(verified, findings_pool=findings_pool)
@@ -1747,7 +1790,13 @@ class SourceHuntRunner:
             exit_findings = all_findings if self.no_verify else verified
             return SourceHuntResult(
                 exit_code=(
-                    3 if run_status == "budget_exhausted" else self._exit_code(exit_findings)
+                    0
+                    if self._stop_after
+                    else (
+                        3
+                        if run_status == "budget_exhausted"
+                        else self._exit_code(exit_findings)
+                    )
                 ),
                 repo_url=self.repo_url,
                 repo_path=repo_path,
@@ -2694,7 +2743,7 @@ class SourceHuntRunner:
             "build_callgraph": self.depth != "quick" and self._preprocessing,
             "propagate_reachability": self.depth != "quick" and self._preprocessing,
             "run_semgrep": self.depth != "quick" and self._preprocessing,
-            "run_taint": self.depth != "quick" and self._preprocessing and not self._no_rank,
+            "run_taint": self.depth != "quick" and self._preprocessing,
             "respect_gitignore": self._respect_gitignore,
             "subsystem_paths": sorted(self._subsystem_paths or []),
         }
@@ -2719,7 +2768,13 @@ class SourceHuntRunner:
                 self._preprocess_restored = True
                 logger.info("Restored preprocess result from session %s", self._session_id)
                 return restored
-            raise ValueError("preprocess checkpoint is invalid or incompatible with this run")
+            if self._stop_after == "preprocess":
+                logger.warning(
+                    "Stale preprocess checkpoint does not match current options; re-running"
+                )
+                self._checkpoint.preprocess = None
+            else:
+                raise ValueError("preprocess checkpoint is invalid or incompatible with this run")
 
         result = self._preprocessor.run(repo_path=repo_path)
         preprocess_checkpoint = PreprocessCheckpoint.from_result(result, options=options)
@@ -2995,7 +3050,11 @@ class SourceHuntRunner:
         )
         duration = time.monotonic() - start_time
         return SourceHuntResult(
-            exit_code=(3 if run_status == "budget_exhausted" else self._exit_code(all_findings)),
+            exit_code=(
+                0
+                if self._stop_after
+                else (3 if run_status == "budget_exhausted" else self._exit_code(all_findings))
+            ),
             repo_url=self.repo_url,
             repo_path=repo_path,
             findings=all_findings,

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1347,6 +1347,7 @@ def _handle_machine(descriptor: int) -> int:
                 subsystem_max_files=parsed.get("subsystem_max_files") or None,
                 output_formats=parsed.get("format"),
                 checkpoint=parsed.get("checkpoint"),
+                stop_after=parsed.get("stop_after"),
                 provider_manager=provider_manager,
                 on_progress=lambda progress: channel.emit("progress", progress),
             ).arun()
@@ -1380,6 +1381,7 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "subsystem_max_files",
         "no_per_file_hunt",
         "checkpoint",
+        "stop_after",
     }
     unknown = sorted(set(value) - allowed)
     if unknown:
@@ -1422,6 +1424,12 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         if not isinstance(checkpoint, dict):
             raise ValueError("checkpoint must be a JSON object")
         parsed["checkpoint"] = checkpoint
+    if "stop_after" in value:
+        valid_stages = {"preprocess", "rank", "hunt", "verify"}
+        sa = value["stop_after"]
+        if sa not in valid_stages:
+            raise ValueError(f"stop_after must be one of {sorted(valid_stages)}, got {sa!r}")
+        parsed["stop_after"] = sa
     return parsed
 
 

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -45,6 +45,16 @@ def add_parser(subparsers):
         metavar="JSON",
         help="Restore a legacy sourcehunt run from a checkpoint JSON blob",
     )
+    parser.add_argument(
+        "--checkpoint-path",
+        metavar="PATH",
+        help="Where to save the checkpoint file (default: <output-dir>/<session>/checkpoint.json)",
+    )
+    parser.add_argument(
+        "--stop-after",
+        choices=["preprocess", "rank", "hunt", "verify", "exploit"],
+        help="Stop after the named stage completes (checkpoint is saved for resumption)",
+    )
     parser.add_argument("--machine-fd", type=int, help=argparse.SUPPRESS)
     parser.add_argument(
         "--flow",
@@ -1216,6 +1226,8 @@ def handle(cli, args):
         retain_incomplete_certificates=args.retain_incomplete_certificates,
         emit_rejection_certificates=args.emit_rejection_certificates,
         falsify=args.falsify,
+        checkpoint_path=getattr(args, "checkpoint_path", None),
+        stop_after=getattr(args, "stop_after", None),
     )
 
     cli.console.print(

--- a/evaluations/cve-2026-27775-staged.sh
+++ b/evaluations/cve-2026-27775-staged.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# CVE-2026-27775 — Gitea pre-receive hook: staged pipeline execution
+#
+# Runs clearwing sourcehunt in discrete stages with checkpoint resumption:
+#   1. Clone → 2. Preprocess → 3. Rank → 4. Hunt → 5. Visualize
+#
+# Each stage resumes from the checkpoint left by the previous one.
+#
+# Usage:
+#   ./evaluations/cve-2026-27775-staged.sh
+#   OUT_DIR=/tmp/results ./evaluations/cve-2026-27775-staged.sh
+#   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-27775-staged.sh
+set -euxo pipefail
+
+CLONE_URL="https://github.com/go-gitea/gitea.git"
+VULNERABLE_COMMIT="f6e2ca4388a531c4a5996fc8043c38f1cf57897f"
+
+DEPTH="${DEPTH:-deep}"
+BUDGET="${BUDGET:-0}"
+OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-27775-staged}"
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(realpath "$OUT_DIR")"
+
+REPO_DIR="$(realpath "$(mktemp -d -t gitea-cve-2026-27775-XXXX)")"
+HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-27775-hunt-XXXX)")"
+CKPT="$OUT_DIR/checkpoint.json"
+rm -f "$CKPT"
+
+COMMON_ARGS=(
+    "$CLONE_URL"
+    --local-path "$REPO_DIR"
+    --depth "$DEPTH"
+    --budget "$BUDGET"
+    --output-dir "$HUNT_OUT"
+    --checkpoint-path "$CKPT"
+    --format json
+    --live
+)
+
+# ──── 1. Clone ────
+echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
+git init "$REPO_DIR"
+git -C "$REPO_DIR" remote add origin "$CLONE_URL"
+git -C "$REPO_DIR" fetch --filter=blob:none --depth=50 origin "$VULNERABLE_COMMIT"
+git -C "$REPO_DIR" checkout FETCH_HEAD
+
+# ──── 2. Preprocess ────
+echo "// STAGE preprocess"
+GENAI_DEBUG_REQUESTS=1 CLEARWING_LLM_LOG=1 \
+uv run clearwing sourcehunt "${COMMON_ARGS[@]}" \
+    --subsystem-hunt \
+    --subsystem routers/private/hook_pre_receive.go \
+    --no-per-file-hunt \
+    --no-rank --no-verify --no-exploit \
+    --agent-mode deep \
+    --stop-after preprocess
+
+# ──── 3. Rank ────
+echo "// STAGE rank"
+GENAI_DEBUG_REQUESTS=1 CLEARWING_LLM_LOG=1 \
+uv run clearwing sourcehunt "${COMMON_ARGS[@]}" \
+    --subsystem-hunt \
+    --subsystem routers/private/hook_pre_receive.go \
+    --no-per-file-hunt \
+    --no-verify --no-exploit \
+    --agent-mode deep \
+    --stop-after rank
+
+# ──── 4. Hunt ────
+echo "// STAGE hunt"
+HUNT_EXIT=0
+GENAI_DEBUG_REQUESTS=1 CLEARWING_LLM_LOG=1 \
+uv run clearwing sourcehunt "${COMMON_ARGS[@]}" \
+    --subsystem-hunt \
+    --subsystem routers/private/hook_pre_receive.go \
+    --no-per-file-hunt \
+    --no-rank --no-verify --no-exploit \
+    --agent-mode deep \
+|| HUNT_EXIT=$?
+
+# ──── 5. Visualize ────
+echo "// STAGE visualize"
+uv run clearwing visualize "$CKPT" --output "$OUT_DIR/callgraph.html" --no-open || true
+
+# ──── Collect artifacts ────
+SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"
+
+if [[ -n "$SESSION_DIR" && -f "$SESSION_DIR/findings.json" ]]; then
+    cp "$SESSION_DIR/findings.json" "$OUT_DIR/findings.json"
+    [[ -f "$SESSION_DIR/findings_pool.jsonl" ]] && \
+        cp "$SESSION_DIR/findings_pool.jsonl" "$OUT_DIR/findings_pool.jsonl" || true
+fi
+echo "$HUNT_EXIT" > "$OUT_DIR/hunt_exit_code"
+
+echo ""
+echo "// DEPLOYED"
+echo "  checkpoint.json -> $CKPT"
+echo "  callgraph.html  -> $OUT_DIR/callgraph.html"
+echo "  findings.json   -> $OUT_DIR/findings.json"
+echo "  session         -> $SESSION_DIR"
+echo "  repo            -> $REPO_DIR"
+echo "  hunt output     -> $HUNT_OUT"

--- a/evaluations/cve-2026-27775.sh
+++ b/evaluations/cve-2026-27775.sh
@@ -23,13 +23,17 @@ REPO_DIR="$(realpath "$(mktemp -d -t gitea-cve-2026-27775-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-27775-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+git init "$REPO_DIR"
+git -C "$REPO_DIR" remote add origin "$CLONE_URL"
+git -C "$REPO_DIR" fetch --filter=blob:none --depth=50 origin "$VULNERABLE_COMMIT"
+git -C "$REPO_DIR" checkout FETCH_HEAD
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
 HUNT_EXIT=0
-clearwing sourcehunt "$CLONE_URL" \
+GENAI_DEBUG_REQUESTS=1 \
+CLEARWING_LLM_LOG=1 \
+uv run clearwing sourcehunt "$CLONE_URL" \
     --local-path "$REPO_DIR" \
     --subsystem-hunt \
     --subsystem routers/private/hook_pre_receive.go \
@@ -41,6 +45,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-verify \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
+    --checkpoint-path "$OUT_DIR/checkpoint.json" \
     --format json \
     --live
 || HUNT_EXIT=$?
@@ -55,12 +60,15 @@ fi
 cp "$SESSION_DIR/findings.json"       "$OUT_DIR/findings.json"
 [[ -f "$SESSION_DIR/findings_pool.jsonl" ]] && \
     cp "$SESSION_DIR/findings_pool.jsonl" "$OUT_DIR/findings_pool.jsonl" || true
+[[ -f "$SESSION_DIR/checkpoint.json" ]] && \
+    cp "$SESSION_DIR/checkpoint.json" "$OUT_DIR/checkpoint.json" || true
 echo "$HUNT_EXIT" > "$OUT_DIR/hunt_exit_code"
 
 echo ""
 echo "// DEPLOYED"
 echo "  findings.json       -> $OUT_DIR/findings.json"
 echo "  findings_pool.jsonl -> $OUT_DIR/findings_pool.jsonl"
+echo "  checkpoint.json     -> $OUT_DIR/checkpoint.json"
 echo "  session             -> $SESSION_DIR"
 echo "  repo                -> $REPO_DIR"
 echo "  hunt output         -> $HUNT_OUT"


### PR DESCRIPTION
Add --stop-after and --checkpoint-path CLI flags for discrete stage
execution with checkpoint resumption between invocations.

Fixes:
- Force exit_code=0 when --stop-after is active (prevents set -e kills)
- Decouple run_taint from --no-rank in preprocess options (was causing
  checkpoint mismatch between stages with different flag combinations)
- Gracefully re-run preprocessing when stale checkpoint doesn't match
  current options (instead of hard error on --stop-after preprocess)

Includes staged evaluation script (cve-2026-27775-staged.sh) that
exercises clone → preprocess → rank → hunt → visualize as separate
process invocations sharing a single checkpoint file.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>