### PR TITLE
Machine-mode observability: EventBus forwarding, checkpoint stage records, workspace validation

### DIFF
--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -547,6 +547,17 @@ class SourceHuntRunner:
             self._checkpoint = SourceHuntCheckpoint.from_file(self._checkpoint_path)
         else:
             self._checkpoint = None
+        if self._checkpoint is not None:
+            available = [
+                name
+                for name in ("preprocess", "rank", "hunt", "verification", "exploitation")
+                if getattr(self._checkpoint, name, None) is not None
+            ]
+            logger.info(
+                "Checkpoint loaded: stages=%s source=%s",
+                ",".join(available) or "(empty)",
+                "caller_input" if checkpoint is not None else str(self._checkpoint_path),
+            )
         self._agent_mode_override = agent_mode
         self._prompt_mode = prompt_mode
         self._campaign_hint = campaign_hint
@@ -606,10 +617,27 @@ class SourceHuntRunner:
         self._last_reporting_error: dict[str, str] | None = None
         self._on_progress = on_progress
 
-    def _dump_checkpoint(self) -> None:
+    def _dump_checkpoint(self, stage: str = "", **diagnostics: Any) -> None:
         if self._checkpoint is None:
             return
         self._checkpoint.dump(self._checkpoint_path)
+        # Emit a stage record so a machine-mode host can see what was persisted.
+        saved_stages = [
+            name
+            for name in ("preprocess", "rank", "hunt", "verification", "exploitation")
+            if getattr(self._checkpoint, name, None) is not None
+        ]
+        detail_parts = [
+            f"saved={','.join(saved_stages)}",
+            f"path={self._checkpoint_path}",
+        ]
+        if diagnostics:
+            detail_parts.extend(f"{key}={value}" for key, value in diagnostics.items())
+        self._emit_stage(
+            stage or (saved_stages[-1] if saved_stages else "unknown"),
+            "checkpoint_saved",
+            detail="; ".join(detail_parts),
+        )
 
     @staticmethod
     def _check_runtime_available(runtime: str | None) -> str | None:
@@ -1980,9 +2008,9 @@ class SourceHuntRunner:
             self._exploitation_restored = True
             self._emit_stage(
                 "exploit",
-                "completed",
+                "checkpoint_restored",
                 findings_so_far=len(restored.exploited),
-                detail=f"Restored {len(restored.exploited)} exploited findings from checkpoint",
+                detail=f"verified={len(restored.verified)}; exploited={len(restored.exploited)}",
                 finding_ids=[finding.id for finding in restored.exploited],
             )
             return restored
@@ -2028,7 +2056,11 @@ class SourceHuntRunner:
         if self._checkpoint is None:
             raise RuntimeError("exploitation requires a preprocessing checkpoint")
         self._checkpoint.exploitation = ExploitationCheckpoint.from_result(result, options=options)
-        self._dump_checkpoint()
+        self._dump_checkpoint(
+            "exploit",
+            verified=len(result.verified),
+            exploited=len(result.exploited),
+        )
         self._emit_stage(
             "exploit",
             "completed" if not self._budget_exhausted() else "budget_exhausted",
@@ -2072,6 +2104,12 @@ class SourceHuntRunner:
             pipeline_status.record_succeeded("verifier")
             result = restored
             result.status = "completed"
+            self._emit_stage(
+                "verify",
+                "checkpoint_restored",
+                findings_so_far=len(result.verified),
+                detail=f"verified={len(result.verified)}; rejected={len(result.rejected)}",
+            )
             detail = f"Restored {len(result.verified)} verified findings from checkpoint"
         else:
             result = VerificationResult(verified=[], rejected=[])
@@ -2113,7 +2151,11 @@ class SourceHuntRunner:
             self._checkpoint.verification = VerificationCheckpoint.from_result(
                 result, options=options
             )
-            self._dump_checkpoint()
+            self._dump_checkpoint(
+                "verify",
+                verified=len(result.verified),
+                rejected=len(result.rejected),
+            )
             detail = (
                 "Verification skipped (--no-verify)"
                 if self.no_verify
@@ -2425,9 +2467,14 @@ class SourceHuntRunner:
             pipeline_status.record_succeeded("hunter_pool")
             self._emit_stage(
                 "hunt",
-                "completed",
+                "checkpoint_restored",
                 findings_so_far=len(restored.findings),
-                detail=f"Restored {len(restored.findings)} findings from checkpoint",
+                detail=(
+                    f"findings={len(restored.findings)}; "
+                    f"files_hunted={restored.files_hunted}; "
+                    f"subsystems_hunted={restored.subsystems_hunted}; "
+                    f"spent_usd={sum(restored.spent_per_tier.values()):.4f}"
+                ),
                 files=[str(finding.file or "") for finding in restored.findings],
                 symbols=self._finding_symbols(restored.findings),
                 finding_ids=[finding.id for finding in restored.findings],
@@ -2613,7 +2660,13 @@ class SourceHuntRunner:
         if self._checkpoint is None:
             raise RuntimeError("hunting requires a preprocessing checkpoint")
         self._checkpoint.hunt = HuntCheckpoint.from_result(result, options=options)
-        self._dump_checkpoint()
+        self._dump_checkpoint(
+            "hunt",
+            findings=len(result.findings),
+            files_hunted=result.files_hunted,
+            subsystems_hunted=result.subsystems_hunted,
+            spent_usd=sum(result.spent_per_tier.values()),
+        )
         return result
 
     async def _hunt_subsystems(
@@ -2813,6 +2866,15 @@ class SourceHuntRunner:
             restored = self._checkpoint.preprocess.restore(repo_path=repo_path, options=options)
             if restored is not None:
                 self._preprocess_restored = True
+                self._emit_stage(
+                    "preprocess",
+                    "checkpoint_restored",
+                    detail=(
+                        f"files={len(restored.file_targets)}; "
+                        f"commit={self._checkpoint.preprocess.commit_sha or 'unknown'}; "
+                        f"static_findings={len(restored.static_findings)}"
+                    ),
+                )
                 logger.info("Restored preprocess result from session %s", self._session_id)
                 return restored
             if self._stop_after == "preprocess":
@@ -2829,7 +2891,11 @@ class SourceHuntRunner:
             self._checkpoint = SourceHuntCheckpoint(preprocess=preprocess_checkpoint)
         else:
             self._checkpoint.preprocess = preprocess_checkpoint
-        self._dump_checkpoint()
+        self._dump_checkpoint(
+            "preprocess",
+            files=len(result.file_targets),
+            commit=preprocess_checkpoint.commit_sha or "unknown",
+        )
         return result
 
     async def _rank(
@@ -2854,8 +2920,11 @@ class SourceHuntRunner:
             pipeline_status.record_succeeded("ranker")
             self._emit_stage(
                 "rank",
-                "completed",
-                detail=f"Restored {len(restored)} ranked files from checkpoint",
+                "checkpoint_restored",
+                detail=(
+                    f"files={len(restored)}; "
+                    f"top_surface={restored[0].get('surface', '?') if restored else '?'}"
+                ),
                 files=stage_files,
             )
             logger.info("Restored rank result from session %s", self._session_id)
@@ -2922,7 +2991,7 @@ class SourceHuntRunner:
         if self._checkpoint is None:
             raise RuntimeError("ranking requires a preprocessing checkpoint")
         self._checkpoint.rank = RankCheckpoint.from_result(files, options=options)
-        self._dump_checkpoint()
+        self._dump_checkpoint("rank", files_ranked=len(files))
         return files
 
     @staticmethod

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1349,7 +1349,9 @@ def _handle_machine(descriptor: int) -> int:
                 checkpoint=parsed.get("checkpoint"),
                 stop_after=parsed.get("stop_after"),
                 provider_manager=provider_manager,
-                on_progress=lambda progress: channel.emit("progress", progress),
+                # on_progress is intentionally omitted: the channel's EventBus
+                # subscription already forwards SOURCEHUNT_STAGE events, so
+                # passing it too would emit every stage transition twice.
             ).arun()
         )
         channel.result(_public_result(result))

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1320,7 +1320,7 @@ def _handle_machine(descriptor: int) -> int:
         request, routing = channel.read_start()
         print(f"sourcehunt machine-fd request fields: {sorted(request)}", file=sys.stderr)
         parsed = _machine_request(request)
-        workspace = channel.workspace or {}
+        workspace = _machine_workspace(channel.workspace)
         install_runtime_routing(routing)
         provider_manager = ProviderManager.from_config(routing)
         result = asyncio.run(
@@ -1361,6 +1361,22 @@ def _handle_machine(descriptor: int) -> int:
         return 130 if isinstance(exc, KeyboardInterrupt) else 1
     finally:
         channel.close()
+
+
+def _machine_workspace(value: dict[str, Any] | None) -> dict[str, str]:
+    """Validate host-owned workspace paths received outside the guest request."""
+    if value is None:
+        return {}
+    allowed = {"local_path", "output_dir", "checkpoint_path"}
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        raise ValueError(f"unknown workspace field(s): {', '.join(unknown)}")
+    workspace: dict[str, str] = {}
+    for key, path in value.items():
+        if not isinstance(path, str) or not os.path.isabs(path):
+            raise ValueError(f"workspace {key} must be an absolute path")
+        workspace[key] = path
+    return workspace
 
 
 def _machine_request(value: dict[str, Any]) -> dict[str, Any]:

--- a/clearwing/ui/machine.py
+++ b/clearwing/ui/machine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import threading
 from dataclasses import asdict, is_dataclass
 from enum import Enum
 from typing import Any
@@ -36,6 +37,8 @@ class MachineChannel:
         os.close(descriptor)
         self._sequence = 0
         self._terminal = False
+        self._closed = False
+        self._write_lock = threading.Lock()
         self.workspace: dict[str, Any] | None = None
 
     def read_start(self) -> tuple[dict[str, Any], dict[str, Any] | None]:
@@ -84,24 +87,35 @@ class MachineChannel:
         self._write("error", {"error": str(error)}, terminal=True)
 
     def close(self) -> None:
-        """Close both sides of the inherited channel."""
-        self._reader.close()
-        self._writer.close()
+        """Close both sides of the inherited channel.
+
+        Idempotent: a second call is a no-op rather than an error on an
+        already-closed descriptor.
+        """
+        with self._write_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._reader.close()
+            self._writer.close()
 
     def _write(self, kind: str, payload: dict[str, Any], *, terminal: bool) -> None:
-        if self._terminal:
-            raise MachineProtocolError("terminal record already emitted")
-        self._sequence += 1
-        record = {
-            "v": PROTOCOL_VERSION,
-            "type": f"{self.operation}.{kind}",
-            "seq": self._sequence,
-            **payload,
-        }
-        encoded = json.dumps(record, separators=(",", ":"), ensure_ascii=False).encode()
-        self._writer.write(encoded + b"\n")
-        if terminal:
-            self._terminal = True
+        with self._write_lock:
+            if self._closed:
+                raise MachineProtocolError("machine channel is closed")
+            if self._terminal:
+                raise MachineProtocolError("terminal record already emitted")
+            self._sequence += 1
+            record = {
+                "v": PROTOCOL_VERSION,
+                "type": f"{self.operation}.{kind}",
+                "seq": self._sequence,
+                **payload,
+            }
+            encoded = json.dumps(record, separators=(",", ":"), ensure_ascii=False).encode()
+            self._writer.write(encoded + b"\n")
+            if terminal:
+                self._terminal = True
 
 
 def _decode_provider_routing(value: Any, *, required: bool) -> dict[str, Any] | None:

--- a/clearwing/ui/machine.py
+++ b/clearwing/ui/machine.py
@@ -39,7 +39,52 @@ class MachineChannel:
         self._terminal = False
         self._closed = False
         self._write_lock = threading.Lock()
+        self._eventbus_subscriptions: list[tuple[Any, Any, Any]] = []
         self.workspace: dict[str, Any] | None = None
+        self._subscribe_eventbus()
+
+    def _subscribe_eventbus(self) -> None:
+        """Forward EventBus activity onto this channel as progress records.
+
+        A machine-mode host only sees what crosses the descriptor. Stage
+        transitions reach it through the runner's on_progress callback, but
+        tool calls, findings, costs and errors are published on the EventBus
+        and were previously visible only in the guest's own logs.
+
+        Subscriptions are released in close(). No-op when clearwing.core.events
+        is unavailable.
+        """
+        try:
+            from clearwing.core.events import EventBus, EventType
+        except ImportError:
+            return
+
+        FORWARDED = (
+            EventType.TOOL_START,
+            EventType.TOOL_RESULT,
+            EventType.MESSAGE,
+            EventType.FLAG_FOUND,
+            EventType.COST_UPDATE,
+            EventType.ERROR,
+            EventType.SOURCEHUNT_STAGE,
+            EventType.HUNTER_STATUS,
+            EventType.FINDING_RECORDED,
+        )
+
+        def _to_dict(data: object) -> dict:
+            if isinstance(data, dict):
+                return data
+            if is_dataclass(data) and not isinstance(data, type):
+                return asdict(data)
+            return {"data": data}
+
+        bus = EventBus()
+        for etype in FORWARDED:
+            def forward(data: object, event_type=etype) -> None:
+                self.emit("progress", {"event": event_type.value, **_to_dict(data)})
+
+            bus.subscribe(etype, forward)
+            self._eventbus_subscriptions.append((bus, etype, forward))
 
     def read_start(self) -> tuple[dict[str, Any], dict[str, Any] | None]:
         """Read and validate the command's start record."""
@@ -92,6 +137,9 @@ class MachineChannel:
         Idempotent: a second call is a no-op rather than an error on an
         already-closed descriptor.
         """
+        for bus, event_type, handler in self._eventbus_subscriptions:
+            bus.unsubscribe(event_type, handler)
+        self._eventbus_subscriptions.clear()
         with self._write_lock:
             if self._closed:
                 return


### PR DESCRIPTION
Machine-mode hosts currently see almost nothing of a run in progress, and the sourcehunt machine handler trusts the `workspace` record it is handed. This adds channel-level observability and closes that gap.

### 1. Serialize channel writes

`MachineChannel._write` mutated `_sequence` and wrote to the descriptor with no synchronization. That holds only while one thread emits. Two concurrent producers can interleave their `json.dumps` payloads inside a single write, breaking NDJSON framing so the host sees a truncated record and drops the remainder of the run.

This is a prerequisite for the next commit: `EventBus.emit` copies its handler list and then invokes handlers *outside* the bus lock, so forwarded events genuinely arrive on several threads at once.

`close()` becomes idempotent under the same lock — it is reached from both the normal path and error teardown.

No behaviour change for single-threaded callers.

### 2. Forward EventBus activity over the channel

A machine-mode host only sees what crosses FD3. Stage transitions arrive through the runner's `on_progress` callback, but everything else the run publishes — tool calls and results, messages, findings, cost updates, errors, hunter status — goes to the `EventBus` and never leaves the guest. A host driving sourcehunt with `--machine-fd` therefore cannot show any activity between stage boundaries.

`MachineChannel` now subscribes to those types and re-emits them as `progress` records tagged with the event name, releasing the handlers in `close()`.

`on_progress` is dropped from the sourcehunt machine handler in the same commit: `SOURCEHUNT_STAGE` is now forwarded through the bus, so keeping the callback would emit every stage transition twice. That coupling is why these two edits are one commit.

### 3. Checkpoint save/restore as stage records

Checkpointing is currently silent. `_dump_checkpoint()` writes the file and returns, and the restore paths report themselves as ordinary `"completed"` stages — so from the outside a resumed run is indistinguishable from a fresh one. When a resume produces the wrong results there is no way to tell whether a stage was recomputed or replayed, which stage the bundle on disk actually held, or where that file is.

The two halves get distinct, symmetric statuses:

- **`checkpoint_saved`** — the stages now in the bundle, the checkpoint path, and per-stage counts from the caller (findings and spend for hunt, verified/rejected for verify, files and commit for preprocess, …).
- **`checkpoint_restored`** in place of `"completed"`, with restored counts instead of prose. `verify` and `preprocess` emitted *nothing* on the restore path and now report like the rest.

Plus a constructor log line recording the stage set and whether the checkpoint came from the caller or was picked up off disk at the default path.

`SourceHuntProgress.status` is a free-form `str` and no consumer matches on a closed set, so the new values are additive: a stage reported as completed on a fresh run still is.

### 4. Validate the `workspace` record

`MachineChannel.read_start` checks that `workspace` is an object and stops there. The sourcehunt machine handler then read `local_path`, `output_dir` and `checkpoint_path` straight out of it into `SourceHuntRunner`, so whatever the record contained became filesystem paths:

- a **relative** path resolves against the guest's working directory, not where the host meant;
- a **non-string** fails later inside `pathlib`, with a message that does not name the field;
- a **misspelled key** is silently ignored, leaving the run writing to the default output directory while the host waits on the path it thought it had requested.

Decoding now goes through a helper that rejects unknown keys and requires absolute paths, so a malformed workspace fails at the protocol boundary naming the offending field.

### Testing

`tests/test_machine_cli.py`, `test_sourcehunt_checkpoints.py`, `test_event_bus.py`, `test_events.py`, `test_event_payloads.py` — 77 passed. Broader `-k "sourcehunt or machine or checkpoint"` run was green where it got to; leaving the full suite to CI.

Unrelated pre-existing failure worth flagging: `test_operate_machine_uses_host_routing_and_emits_typed_records` fails on unmodified `main` whenever `CLEARWING_MODEL` is set in the environment (it resolved to `glm-5.2` instead of the test's `host-model`). The test isn't hermetic against that variable. Not touched here.
