### PR TITLE
feat(sourcehunt): add callgraph visualization CLI

### DIFF
--- a/clearwing/sourcehunt/callgraph.py
+++ b/clearwing/sourcehunt/callgraph.py
@@ -214,6 +214,40 @@ class CallGraph:
     def empty(self) -> bool:
         return not self.functions
 
+    def to_json(self) -> dict:
+        """Serialize to a JSON-safe dict for checkpoint storage."""
+        return {
+            "functions": {k: sorted(v) for k, v in self.functions.items()},
+            "calls_out": {k: sorted(v) for k, v in self.calls_out.items()},
+            "defined_in": {k: sorted(v) for k, v in self.defined_in.items()},
+            "function_info": {
+                k: [{"name": fi.name, "start_line": fi.start_line, "end_line": fi.end_line} for fi in v]
+                for k, v in self.function_info.items()
+            },
+            "func_calls_out": {
+                file: {func: sorted(callees) for func, callees in func_map.items()}
+                for file, func_map in self.func_calls_out.items()
+            },
+        }
+
+    @classmethod
+    def from_json(cls, data: dict) -> CallGraph:
+        """Restore from a checkpoint dict."""
+        cg = cls()
+        for file, funcs in data.get("functions", {}).items():
+            cg.functions[file] = set(funcs)
+        for file, calls in data.get("calls_out", {}).items():
+            cg.calls_out[file] = set(calls)
+        for name, files in data.get("defined_in", {}).items():
+            cg.defined_in[name] = set(files)
+        for file, infos in data.get("function_info", {}).items():
+            cg.function_info[file] = [
+                FunctionInfo(name=fi["name"], start_line=fi["start_line"], end_line=fi["end_line"])
+                for fi in infos
+            ]
+        for file, func_map in data.get("func_calls_out", {}).items():
+            cg.func_calls_out[file] = {func: set(callees) for func, callees in func_map.items()}
+        return cg
 
 # --- Builder -----------------------------------------------------------------
 

--- a/clearwing/sourcehunt/preprocessor.py
+++ b/clearwing/sourcehunt/preprocessor.py
@@ -51,6 +51,9 @@ class PreprocessResult(BaseModel):
         payload.pop("repo_path")
         for target in payload["file_targets"]:
             target.pop("absolute_path", None)
+        # Serialize callgraph via its own method (plain dataclass, not pydantic)
+        if self.callgraph is not None:
+            payload["callgraph"] = self.callgraph.to_json()
         return payload
 
     @classmethod
@@ -82,13 +85,17 @@ class PreprocessResult(BaseModel):
             rebound["absolute_path"] = str(absolute)
             targets.append(rebound)
 
-        return cls.model_validate(
-            {
-                **payload,
-                "repo_path": str(root),
-                "file_targets": targets,
-            }
-        )
+        # Restore callgraph from serialized dict
+        callgraph = None
+        cg_data = payload.get("callgraph")
+        if isinstance(cg_data, dict):
+            callgraph = CallGraph.from_json(cg_data)
+
+        restored = dict(payload)
+        restored["repo_path"] = str(root)
+        restored["file_targets"] = targets
+        restored["callgraph"] = callgraph
+        return cls.model_validate(restored)
 
     @property
     def file_count(self) -> int:

--- a/clearwing/ui/commands/__init__.py
+++ b/clearwing/ui/commands/__init__.py
@@ -20,6 +20,7 @@ from . import (
     setup,
     sourcehunt,
     tool,
+    visualize,
     webui,
 )
 
@@ -44,4 +45,5 @@ ALL_COMMANDS = [
     campaign,
     bench,
     eval,
+    visualize,
 ]

--- a/clearwing/ui/commands/visualize.py
+++ b/clearwing/ui/commands/visualize.py
@@ -1,5 +1,6 @@
 """Visualize callgraph in browser."""
 
+import json
 import tempfile
 import webbrowser
 from pathlib import Path
@@ -156,10 +157,8 @@ def _render_html(cg, max_nodes: int = 500) -> str:
         if max_nodes and next_id >= max_nodes:
             break
 
-    import json
-
-    nodes_json = json.dumps(nodes)
-    edges_json = json.dumps(edges)
+    nodes_json = _json_for_script(nodes)
+    edges_json = _json_for_script(edges)
     truncated = max_nodes and next_id >= max_nodes
 
     return f"""\
@@ -215,3 +214,15 @@ document.getElementById('filter').addEventListener('input', function(e) {{
 </script>
 </body>
 </html>"""
+
+
+def _json_for_script(value: object) -> str:
+    """Serialize JSON without allowing data to terminate the script element."""
+    return (
+        json.dumps(value)
+        .replace("&", "\\u0026")
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )

--- a/clearwing/ui/commands/visualize.py
+++ b/clearwing/ui/commands/visualize.py
@@ -1,0 +1,217 @@
+"""Visualize callgraph in browser."""
+
+import tempfile
+import webbrowser
+from pathlib import Path
+
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser(
+        "visualize", help="Open interactive callgraph visualization in browser"
+    )
+    parser.add_argument(
+        "path",
+        help="Path to repository OR checkpoint.json file",
+    )
+    parser.add_argument("--output", help="Output HTML file path (default: temp file)")
+    parser.add_argument("--no-open", action="store_true", help="Do not open in browser")
+    parser.add_argument(
+        "--max-nodes",
+        type=int,
+        default=500,
+        help="Max nodes to render (default 500, 0=unlimited)",
+    )
+    return parser
+
+
+def handle(cli, args):
+    """Build callgraph from repo or load from checkpoint, render in browser."""
+    from ...sourcehunt.callgraph import CallGraph, CallGraphBuilder
+
+    target = Path(args.path).resolve()
+
+    if target.is_file() and target.suffix == ".json":
+        # Load from checkpoint
+        cli.console.print(f"[dim]Loading callgraph from checkpoint {target}...[/dim]")
+        from ...sourcehunt.checkpoints import SourceHuntCheckpoint
+
+        ckpt = SourceHuntCheckpoint.from_file(target)
+        if ckpt.preprocess is None or ckpt.preprocess.result is None:
+            cli.console.print("[red]Checkpoint has no preprocess result[/red]")
+            return
+        cg_data = ckpt.preprocess.result.get("callgraph")
+        if not cg_data:
+            cli.console.print("[red]Checkpoint has no callgraph data[/red]")
+            return
+        cg = CallGraph.from_json(cg_data)
+    else:
+        # Build from source
+        repo_path = str(target)
+        cli.console.print(f"[dim]Building callgraph for {repo_path}...[/dim]")
+        builder = CallGraphBuilder()
+        cg = builder.build(repo_path)
+
+    n_files = len(cg.functions)
+    n_funcs = sum(len(fns) for fns in cg.functions.values())
+    n_edges = sum(
+        len(callees)
+        for func_map in cg.func_calls_out.values()
+        for callees in func_map.values()
+    )
+
+    cli.console.print(
+        f"[green]Callgraph:[/green] {n_files} files, {n_funcs} functions, {n_edges} call edges"
+    )
+
+    html = _render_html(cg, max_nodes=args.max_nodes)
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(html, encoding="utf-8")
+        cli.console.print(f"[green]Saved to {output_path}[/green]")
+    else:
+        with tempfile.NamedTemporaryFile(
+            "w", delete=False, suffix=".html", encoding="utf-8"
+        ) as f:
+            f.write(html)
+            output_path = Path(f.name)
+        cli.console.print(f"[green]Rendered to {output_path}[/green]")
+
+    if not args.no_open:
+        webbrowser.open(f"file://{output_path.absolute()}")
+
+
+def _render_html(cg, max_nodes: int = 500) -> str:
+    """Build a self-contained HTML page with vis-network graph."""
+    # Collect nodes and edges
+    nodes = []
+    edges = []
+    node_ids: dict[str, int] = {}  # "file::func" → id
+    next_id = 0
+
+    # Assign colors per file (cycle through palette)
+    palette = [
+        "#4fc3f7", "#81c784", "#ffb74d", "#e57373", "#ba68c8",
+        "#4dd0e1", "#aed581", "#ff8a65", "#f06292", "#7986cb",
+    ]
+    file_color: dict[str, str] = {}
+    color_idx = 0
+
+    for file_path, func_map in cg.func_calls_out.items():
+        if file_path not in file_color:
+            file_color[file_path] = palette[color_idx % len(palette)]
+            color_idx += 1
+
+        for caller, callees in func_map.items():
+            caller_key = f"{file_path}::{caller}"
+            if caller_key not in node_ids:
+                node_ids[caller_key] = next_id
+                nodes.append({
+                    "id": next_id,
+                    "label": caller,
+                    "title": f"{file_path}:{caller}",
+                    "color": file_color[file_path],
+                    "file": file_path,
+                })
+                next_id += 1
+
+            for callee in callees:
+                # Find where callee is defined
+                callee_files = cg.defined_in.get(callee, set())
+                if not callee_files:
+                    # External / unresolved — create a gray node
+                    callee_key = f"?::{callee}"
+                    if callee_key not in node_ids:
+                        node_ids[callee_key] = next_id
+                        nodes.append({
+                            "id": next_id,
+                            "label": callee,
+                            "title": f"(unresolved) {callee}",
+                            "color": "#616161",
+                            "file": "",
+                        })
+                        next_id += 1
+                    edges.append({"from": node_ids[caller_key], "to": node_ids[callee_key]})
+                else:
+                    for cf in callee_files:
+                        callee_key = f"{cf}::{callee}"
+                        if callee_key not in node_ids:
+                            if cf not in file_color:
+                                file_color[cf] = palette[color_idx % len(palette)]
+                                color_idx += 1
+                            node_ids[callee_key] = next_id
+                            nodes.append({
+                                "id": next_id,
+                                "label": callee,
+                                "title": f"{cf}:{callee}",
+                                "color": file_color[cf],
+                                "file": cf,
+                            })
+                            next_id += 1
+                        edges.append({"from": node_ids[caller_key], "to": node_ids[callee_key]})
+
+            if max_nodes and next_id >= max_nodes:
+                break
+        if max_nodes and next_id >= max_nodes:
+            break
+
+    import json
+
+    nodes_json = json.dumps(nodes)
+    edges_json = json.dumps(edges)
+    truncated = max_nodes and next_id >= max_nodes
+
+    return f"""\
+<!DOCTYPE html>
+<html>
+<head>
+<title>Callgraph Visualization</title>
+<script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+<style>
+  body {{ margin: 0; background: #1e1e1e; color: #eee; font-family: monospace; }}
+  #graph {{ width: 100vw; height: 100vh; }}
+  #info {{ position: fixed; top: 10px; left: 10px; background: rgba(30,30,30,0.9);
+           padding: 10px 15px; border-radius: 6px; font-size: 13px; z-index: 10; }}
+  #info span {{ color: #4fc3f7; }}
+  #search {{ position: fixed; top: 10px; right: 10px; background: rgba(30,30,30,0.9);
+             padding: 8px 12px; border-radius: 6px; z-index: 10; }}
+  #search input {{ background: #333; border: 1px solid #555; color: #eee; padding: 4px 8px;
+                   border-radius: 3px; font-family: monospace; width: 200px; }}
+</style>
+</head>
+<body>
+<div id="info">
+  <span>{len(nodes)}</span> nodes &middot; <span>{len(edges)}</span> edges
+  {"&middot; <span style='color:#ffb74d'>truncated to " + str(max_nodes) + "</span>" if truncated else ""}
+</div>
+<div id="search"><input type="text" id="filter" placeholder="filter functions..."></div>
+<div id="graph"></div>
+<script>
+var nodes = new vis.DataSet({nodes_json});
+var edges = new vis.DataSet({edges_json});
+var container = document.getElementById('graph');
+var data = {{ nodes: nodes, edges: edges }};
+var options = {{
+  nodes: {{ shape: 'dot', size: 8, font: {{ size: 11, color: '#ccc' }} }},
+  edges: {{ arrows: 'to', color: {{ color: '#555', highlight: '#4fc3f7' }}, smooth: {{ type: 'continuous' }} }},
+  physics: {{ solver: 'forceAtlas2Based', forceAtlas2Based: {{ gravitationalConstant: -30, springLength: 80 }} }},
+  interaction: {{ hover: true, tooltipDelay: 100 }},
+  layout: {{ improvedLayout: false }}
+}};
+var network = new vis.Network(container, data, options);
+
+document.getElementById('filter').addEventListener('input', function(e) {{
+  var q = e.target.value.toLowerCase();
+  if (!q) {{
+    nodes.forEach(function(n) {{ nodes.update({{id: n.id, hidden: false}}); }});
+    return;
+  }}
+  nodes.forEach(function(n) {{
+    var match = n.label.toLowerCase().includes(q) || (n.file || '').toLowerCase().includes(q);
+    nodes.update({{id: n.id, hidden: !match}});
+  }});
+}});
+</script>
+</body>
+</html>"""

--- a/clearwing/ui/commands/visualize.py
+++ b/clearwing/ui/commands/visualize.py
@@ -166,7 +166,7 @@ def _render_html(cg, max_nodes: int = 500) -> str:
 <html>
 <head>
 <title>Callgraph Visualization</title>
-<script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+<script src="https://unpkg.com/vis-network@9.1.9/standalone/umd/vis-network.min.js"></script>
 <style>
   body {{ margin: 0; background: #1e1e1e; color: #eee; font-family: monospace; }}
   #graph {{ width: 100vw; height: 100vh; }}

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -1,0 +1,31 @@
+from clearwing.sourcehunt.callgraph import CallGraph, FunctionInfo
+from clearwing.ui.commands.visualize import _render_html
+
+
+def _callgraph(file_name: str = "src/main.c", function_name: str = "main") -> CallGraph:
+    graph = CallGraph()
+    graph.functions[file_name].add(function_name)
+    graph.defined_in[function_name].add(file_name)
+    graph.function_info[file_name].append(FunctionInfo(function_name, 1, 3))
+    graph.func_calls_out[file_name][function_name].add("external")
+    return graph
+
+
+def test_callgraph_json_round_trip() -> None:
+    original = _callgraph()
+
+    restored = CallGraph.from_json(original.to_json())
+
+    assert restored.functions == original.functions
+    assert restored.defined_in == original.defined_in
+    assert restored.function_info == original.function_info
+    assert restored.func_calls_out == original.func_calls_out
+
+
+def test_render_html_escapes_repository_controlled_script_markup() -> None:
+    graph = _callgraph("src/</script><script>alert(1)</script>.c", "danger")
+
+    html = _render_html(graph)
+
+    assert "</script><script>alert(1)</script>" not in html
+    assert r"\u003c/script\u003e\u003cscript\u003ealert(1)" in html


### PR DESCRIPTION
## Summary
- add a standalone clearwing visualize command for repositories and SourceHunt checkpoints
- persist callgraphs in preprocess checkpoints via explicit JSON serialization
- render searchable interactive callgraphs with a configurable node limit
- safely encode repository-controlled names before embedding graph data in HTML

## Testing
- Ruff passed on all touched Python files
- Focused visualization, callgraph, checkpoint, and preprocessor suite: 80 passed

## Integration
The open-PR conflict scan found no direct blockers or overlapping hunks. PR #160 also touches clearwing/sourcehunt/preprocessor.py, but its large-repository policy change is separate from this PR's callgraph checkpoint serialization and merges cleanly.