### PR TITLE
feat(sourcehunt): expand single-file --subsystem to callgraph neighborhood

### DIFF
--- a/clearwing/sourcehunt/subsystem.py
+++ b/clearwing/sourcehunt/subsystem.py
@@ -166,6 +166,27 @@ def identify_subsystems_auto(
     return subsystems
 
 
+def _callgraph_neighbor_paths(seed_path: str, callgraph: Any) -> set[str]:
+    """Return the 1-hop callgraph neighborhood of *seed_path*.
+
+    Both directions: files the seed calls into (callees) and files that call
+    into the seed (callers). The seed itself is excluded. Returns an empty set
+    if the callgraph exposes no edges for the file.
+    """
+    neighbors: set[str] = set()
+    calls_out = getattr(callgraph, "calls_out", None) or {}
+    defined_in = getattr(callgraph, "defined_in", None) or {}
+    # Callees: files defining any function the seed calls.
+    for func_name in calls_out.get(seed_path, set()):
+        neighbors |= set(defined_in.get(func_name, set()))
+    # Callers: files that call any function defined in the seed.
+    callers_of_file = getattr(callgraph, "callers_of_file", None)
+    if callable(callers_of_file):
+        neighbors |= set(callers_of_file(seed_path))
+    neighbors.discard(seed_path)
+    return neighbors
+
+
 def subsystem_from_path(
     path: str,
     file_targets: list[FileTarget],
@@ -173,13 +194,21 @@ def subsystem_from_path(
     entry_points_by_file: dict | None = None,
     max_files: int | None = None,
 ) -> SubsystemTarget:
-    """Build a SubsystemTarget from a directory path or glob pattern.
+    """Build a SubsystemTarget from a directory path, glob pattern, or single file.
 
     Raises ValueError if no files match.
 
+    When *path* resolves to a single file (not a glob, exact path match), the
+    scope is expanded to that file plus its **1-hop callgraph neighborhood**
+    (direct callers + callees) so the cross-file hunt has real cross-file
+    context instead of a group of one. The seed file is always pinned into scope
+    and anchors the target's ``root_path``. Directory prefixes and globs keep
+    their prefix/glob matching unchanged.
+
     An explicit path is a deliberate operator scope, so *max_files* defaults to
-    ``None`` (no cap) — the full matched set is hunted. If a cap is supplied and
-    exceeded, files are dropped with a loud WARNING rather than silently.
+    ``None`` (no cap) — the full matched (or expanded) set is hunted. If a cap is
+    supplied and exceeded, files are dropped with a loud WARNING rather than
+    silently; the seed file is never dropped.
     """
     normalized = path.rstrip("/")
     is_glob = "*" in normalized or "?" in normalized
@@ -197,17 +226,62 @@ def subsystem_from_path(
     if not matched:
         raise ValueError(f"No files match subsystem path: {path}")
 
-    matched.sort(key=lambda f: f.get("priority", 0.0), reverse=True)
-    if max_files is not None and len(matched) > max_files:
-        _warn_files_dropped(
-            f"{path!r}",
-            kept=max_files,
-            dropped=matched[max_files:],
-            explicit=True,
-        )
-        capped = matched[:max_files]
+    # Single-file target: expand to its 1-hop callgraph neighborhood. A file
+    # path can only match via ``fp == normalized`` (a real file is never a path
+    # prefix of another), so an exact match means the operator named one file.
+    seed = next((ft for ft in matched if ft.get("path", "") == normalized), None)
+    seed_pinned = False
+    if seed is not None and not is_glob and callgraph is not None:
+        neighbor_paths = _callgraph_neighbor_paths(normalized, callgraph)
+        by_path = {ft.get("path", ""): ft for ft in file_targets}
+        neighbors = [
+            by_path[p]
+            for p in neighbor_paths
+            if p in by_path and by_path[p] is not seed
+        ]
+        if neighbors:
+            neighbors.sort(key=lambda f: f.get("priority", 0.0), reverse=True)
+            matched = [seed] + neighbors
+            seed_pinned = True
+            logger.info(
+                "Expanded single-file subsystem %r to %d files via 1-hop "
+                "callgraph neighborhood (direct callers + callees).",
+                normalized,
+                len(matched),
+            )
+        else:
+            logger.info(
+                "Single-file subsystem %r has no callgraph neighbors; hunting "
+                "the file alone.",
+                normalized,
+            )
+
+    if seed_pinned:
+        # Seed is pinned at index 0; neighbors follow in priority order. Keep the
+        # seed even when a cap drops neighbors off the tail.
+        if max_files is not None and len(matched) > max_files:
+            kept = max(max_files, 1)
+            _warn_files_dropped(
+                f"{path!r} (callgraph neighborhood)",
+                kept=kept,
+                dropped=matched[kept:],
+                explicit=True,
+            )
+            capped = matched[:kept]
+        else:
+            capped = matched
     else:
-        capped = matched
+        matched.sort(key=lambda f: f.get("priority", 0.0), reverse=True)
+        if max_files is not None and len(matched) > max_files:
+            _warn_files_dropped(
+                f"{path!r}",
+                kept=max_files,
+                dropped=matched[max_files:],
+                explicit=True,
+            )
+            capped = matched[:max_files]
+        else:
+            capped = matched
     priority = max(f.get("priority", 0.0) for f in capped)
 
     eps: list = []

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -272,8 +272,10 @@ def add_parser(subparsers):
         default=[],
         metavar="PATH",
         dest="subsystem_paths",
-        help="Manually specify a subsystem directory to hunt (repeatable). "
-        "Implies --subsystem-hunt. Example: --subsystem net/ipv4/",
+        help="Manually specify a subsystem to hunt (repeatable). Accepts a "
+        "directory prefix (net/ipv4/), a glob (libavcodec/h264*), or a single "
+        "file — a file path is expanded to that file plus its 1-hop callgraph "
+        "neighborhood (direct callers + callees). Implies --subsystem-hunt.",
     )
     parser.add_argument(
         "--subsystem-max-files",

--- a/tests/test_sourcehunt_subsystem.py
+++ b/tests/test_sourcehunt_subsystem.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from clearwing.llm import NativeToolSpec
+from clearwing.sourcehunt.callgraph import CallGraph
 from clearwing.sourcehunt.runner import SourceHuntRunner
 from clearwing.sourcehunt.state import FileTarget, StageOutcome, SubsystemTarget
 from clearwing.sourcehunt.subsystem import (
@@ -202,6 +203,103 @@ def test_subsystem_from_path_max_files():
     files = [_ft(f"net/ipv4/f_{i}.c", float(i % 5)) for i in range(80)]
     result = subsystem_from_path("net/ipv4", files, max_files=50)
     assert len(result.files) == 50
+
+
+# ---------------------------------------------------------------------------
+# subsystem_from_path — single-file callgraph-neighborhood expansion
+# ---------------------------------------------------------------------------
+
+
+def _callgraph_seed_with_neighbors():
+    """CallGraph where the seed calls a callee and is called by a caller."""
+    cg = CallGraph()
+    seed = "crypto/aes/aes_core.c"
+    # Seed -> callee (aes_asm defines a function the seed calls).
+    cg.calls_out[seed] = {"aes_encrypt"}
+    cg.defined_in["aes_encrypt"] = {"crypto/aes/aes_asm.c"}
+    # Caller -> seed (cbc calls a function the seed defines).
+    cg.calls_out["crypto/modes/cbc.c"] = {"AES_set_key"}
+    cg.defined_in["AES_set_key"] = {seed}
+    return cg
+
+
+def test_subsystem_from_path_single_file_expands_neighborhood():
+    files = [
+        _ft("crypto/aes/aes_core.c", 4.0),
+        _ft("crypto/aes/aes_asm.c", 3.0),   # callee
+        _ft("crypto/modes/cbc.c", 3.5),     # caller
+        _ft("fs/ext4/inode.c", 2.0),        # unrelated
+    ]
+    result = subsystem_from_path(
+        "crypto/aes/aes_core.c", files, callgraph=_callgraph_seed_with_neighbors()
+    )
+    paths = {f.get("path") for f in result.files}
+    assert paths == {
+        "crypto/aes/aes_core.c",
+        "crypto/aes/aes_asm.c",
+        "crypto/modes/cbc.c",
+    }
+    # Seed anchors the target; unrelated file is excluded.
+    assert result.root_path == "crypto/aes/aes_core.c"
+    assert result.source == "manual"
+
+
+def test_subsystem_from_path_single_file_no_callgraph():
+    # Without a callgraph, a single file stays a single-file subsystem.
+    files = [_ft("crypto/aes/aes_core.c", 4.0), _ft("crypto/aes/aes_asm.c", 3.0)]
+    result = subsystem_from_path("crypto/aes/aes_core.c", files)
+    assert len(result.files) == 1
+    assert result.files[0].get("path") == "crypto/aes/aes_core.c"
+
+
+def test_subsystem_from_path_single_file_no_neighbors():
+    # Callgraph present but the file has no edges -> hunt it alone.
+    files = [_ft("crypto/aes/aes_core.c", 4.0), _ft("crypto/aes/aes_asm.c", 3.0)]
+    result = subsystem_from_path(
+        "crypto/aes/aes_core.c", files, callgraph=CallGraph()
+    )
+    assert len(result.files) == 1
+
+
+def test_subsystem_from_path_single_file_neighbor_without_target_skipped():
+    # A neighbor path with no FileTarget (e.g. a system header) is skipped.
+    files = [_ft("crypto/aes/aes_core.c", 4.0)]  # callee/caller have no targets
+    result = subsystem_from_path(
+        "crypto/aes/aes_core.c", files, callgraph=_callgraph_seed_with_neighbors()
+    )
+    assert len(result.files) == 1
+    assert result.files[0].get("path") == "crypto/aes/aes_core.c"
+
+
+def test_subsystem_from_path_single_file_cap_keeps_seed():
+    cg = CallGraph()
+    seed = "crypto/aes/aes_core.c"
+    # Seed calls into 10 callee files, all lower priority than the seed.
+    cg.calls_out[seed] = {f"f{i}" for i in range(10)}
+    for i in range(10):
+        cg.defined_in[f"f{i}"] = {f"crypto/aes/callee_{i}.c"}
+    files = [_ft(seed, 1.0)] + [
+        _ft(f"crypto/aes/callee_{i}.c", float(i)) for i in range(10)
+    ]
+    result = subsystem_from_path(seed, files, callgraph=cg, max_files=3)
+    paths = {f.get("path") for f in result.files}
+    assert len(result.files) == 3
+    assert seed in paths  # seed pinned despite its low priority
+
+
+def test_subsystem_from_path_directory_not_expanded():
+    # A directory prefix keeps prefix matching even when a callgraph is present:
+    # neighbors outside the prefix are not pulled in.
+    files = [
+        _ft("crypto/aes/aes_core.c", 4.0),
+        _ft("crypto/aes/aes_asm.c", 3.0),
+        _ft("crypto/modes/cbc.c", 3.5),
+    ]
+    result = subsystem_from_path(
+        "crypto/aes", files, callgraph=_callgraph_seed_with_neighbors()
+    )
+    paths = {f.get("path") for f in result.files}
+    assert paths == {"crypto/aes/aes_core.c", "crypto/aes/aes_asm.c"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Passing a single **file** to `--subsystem` now expands the hunt scope to that file **plus its 1-hop callgraph neighborhood** (direct callers + callees).

## How

- New `_callgraph_neighbor_paths()` — callees via `calls_out → defined_in`, callers via `CallGraph.callers_of_file`.
- `subsystem_from_path` detects the single-file case (exact path match, not a glob) and expands via the callgraph.
- **Seed is always pinned** into scope and anchors `root_path`.
- **Uncapped by default**; `--subsystem-max-files` still bounds the set but never drops the seed (neighbors fill remaining slots by priority, WARN on drop).
- Falls back to the file alone when there's no callgraph, no edges, or a neighbor has no `FileTarget`.
- Directory prefixes and globs keep their existing matching untouched.

## Behavior

```
--subsystem crypto/aes/aes_core.c
  → seed:    crypto/aes/aes_core.c   (pinned, anchors root_path)
  → callees: files the seed calls into
  → callers: files that call into the seed
```

## Tests

6 new tests: expansion, no-callgraph fallback, no-neighbors fallback, missing-target skip, seed-pinned cap, directory-not-expanded. Full file: 45 passed, ruff clean.

## Notes

- `--subsystem` help text updated to document file/dir/glob inputs + expansion.