### PR TITLE
chore(sourcehunt): standardize evaluations and record provenance

### DIFF
--- a/clearwing/sourcehunt/reporter.py
+++ b/clearwing/sourcehunt/reporter.py
@@ -8,9 +8,14 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from clearwing import __version__
 from clearwing.runners.cicd.sarif import SARIFGenerator
 
 from .state import EVIDENCE_LEVELS, Finding, PipelineStatus
@@ -19,6 +24,50 @@ logger = logging.getLogger(__name__)
 
 
 _EVIDENCE_RANK = {level: idx for idx, level in enumerate(EVIDENCE_LEVELS)}
+_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def _clearwing_commit_sha() -> str:
+    """Return the Clearwing source revision, suffixed when the worktree is dirty."""
+
+    injected = os.environ.get("CLEARWING_COMMIT_SHA", "").strip()
+    if _COMMIT_RE.fullmatch(injected):
+        return injected.lower()
+
+    repository = Path(__file__).resolve().parents[2]
+    try:
+        head = subprocess.run(
+            ["git", "-C", str(repository), "rev-parse", "--verify", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        dirty = subprocess.run(
+            ["git", "-C", str(repository), "status", "--porcelain"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    sha = head.stdout.strip().lower()
+    if head.returncode != 0 or not _COMMIT_RE.fullmatch(sha):
+        return "unknown"
+    if dirty.returncode == 0 and dirty.stdout.strip():
+        return f"{sha}-dirty"
+    return sha
+
+
+def _clearwing_provenance(start_time: str | None, end_time: str | None) -> dict[str, str]:
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "version": __version__,
+        "commit_sha": _clearwing_commit_sha(),
+        "start-time": start_time or now,
+        "end-time": end_time or now,
+    }
 
 
 def write_sourcehunt_report(
@@ -34,6 +83,9 @@ def write_sourcehunt_report(
     subsystem_stats: dict | None = None,
     pipeline_status: PipelineStatus | None = None,
     budget_summary: dict[str, Any] | None = None,
+    trace_id: str | None = None,
+    run_started_at: str | None = None,
+    run_ended_at: str | None = None,
 ) -> dict[str, str]:
     """Write the requested formats. Returns {format: filesystem_path}."""
     formats = formats or ["sarif", "markdown", "json"]
@@ -79,10 +131,13 @@ def write_sourcehunt_report(
         json_data: dict[str, Any] = {
             "session_id": session_id,
             "repo_url": repo_url,
+            "clearwing": _clearwing_provenance(run_started_at, run_ended_at),
             "spent_per_tier": spent_per_tier,
             "findings": findings,
             "verified_findings": verified_findings,
         }
+        if trace_id:
+            json_data["trace_id"] = trace_id
         if band_stats:
             json_data["band_stats"] = band_stats
         if pool_stats:

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -20,8 +20,11 @@ import time
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
+
+from opentelemetry import trace as otel_trace
 
 from clearwing.core.event_payloads import SourcehuntStagePayload
 from clearwing.core.events import EventBus
@@ -1051,6 +1054,14 @@ class SourceHuntRunner:
 
     @tracer.chain(name="SourceHunt")
     async def arun(self) -> SourceHuntResult:
+        self._run_started_at = datetime.now(timezone.utc).isoformat()
+        span_context = otel_trace.get_current_span().get_span_context()
+        self._otel_trace_id = (
+            f"{span_context.trace_id:032x}" if span_context.is_valid else None
+        )
+        self._otel_span_id = (
+            f"{span_context.span_id:016x}" if span_context.is_valid else None
+        )
         if self._flow == "proof":
             try:
                 return await self._arun_proof_flow()
@@ -3387,6 +3398,9 @@ class SourceHuntRunner:
                 subsystem_stats=subsystem_stats,
                 pipeline_status=pipeline_status,
                 budget_summary=budget_summary,
+                trace_id=getattr(self, "_otel_trace_id", None),
+                run_started_at=getattr(self, "_run_started_at", None),
+                run_ended_at=datetime.now(timezone.utc).isoformat(),
             )
         except Exception as exc:
             logger.warning("Reporter failed", exc_info=True)

--- a/evaluations/cve-2026-27775-staged.sh
+++ b/evaluations/cve-2026-27775-staged.sh
@@ -12,6 +12,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-27775-staged.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/go-gitea/gitea.git"
 VULNERABLE_COMMIT="f6e2ca4388a531c4a5996fc8043c38f1cf57897f"
 
@@ -21,7 +24,7 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-27775-staged}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t gitea-cve-2026-27775-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-27775-hunt-XXXX)")"
 CKPT="$OUT_DIR/checkpoint.json"
 rm -f "$CKPT"
@@ -39,10 +42,7 @@ COMMON_ARGS=(
 
 # ──── 1. Clone ────
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git init "$REPO_DIR"
-git -C "$REPO_DIR" remote add origin "$CLONE_URL"
-git -C "$REPO_DIR" fetch --filter=blob:none --depth=50 origin "$VULNERABLE_COMMIT"
-git -C "$REPO_DIR" checkout FETCH_HEAD
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 # ──── 2. Preprocess ────
 echo "// STAGE preprocess"

--- a/evaluations/cve-2026-27775.sh
+++ b/evaluations/cve-2026-27775.sh
@@ -10,6 +10,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-27775.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/go-gitea/gitea.git"
 VULNERABLE_COMMIT="f6e2ca4388a531c4a5996fc8043c38f1cf57897f"
 
@@ -19,20 +22,19 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-27775}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t gitea-cve-2026-27775-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-27775-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git init "$REPO_DIR"
-git -C "$REPO_DIR" remote add origin "$CLONE_URL"
-git -C "$REPO_DIR" fetch --filter=blob:none --depth=50 origin "$VULNERABLE_COMMIT"
-git -C "$REPO_DIR" checkout FETCH_HEAD
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
 HUNT_EXIT=0
 GENAI_DEBUG_REQUESTS=1 \
 CLEARWING_LLM_LOG=1 \
+CLEARWING_TRACE_INPUTS=1 \
+CLEARWING_TRACE_OUTPUTS=1 \
 uv run clearwing sourcehunt "$CLONE_URL" \
     --local-path "$REPO_DIR" \
     --subsystem-hunt \
@@ -45,10 +47,8 @@ uv run clearwing sourcehunt "$CLONE_URL" \
     --no-verify \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
-    --checkpoint-path "$OUT_DIR/checkpoint.json" \
     --format json \
-    --live
-|| HUNT_EXIT=$?
+    --live || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"
 

--- a/evaluations/cve-2026-28208.sh
+++ b/evaluations/cve-2026-28208.sh
@@ -10,21 +10,23 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-28208.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/junrar/junrar.git"
 VULNERABLE_COMMIT="c7041fc07df2cc397ea46ba516933ee9725af250"
 
 DEPTH="${DEPTH:-deep}"
 BUDGET="${BUDGET:-0}"
-OUT_DIR="$(realpath "${OUT_DIR:-evaluations/results/cve-2026-28208}")"
-
+OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-28208}"
 mkdir -p "$OUT_DIR"
+OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t junrar-cve-2026-28208-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-28208-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -44,7 +46,7 @@ BUDGET=25 clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
-    --live
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-28386.sh
+++ b/evaluations/cve-2026-28386.sh
@@ -10,21 +10,23 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-28386.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/openssl/openssl.git"
 VULNERABLE_COMMIT="481743fb8aa2b72f0a82c4c112880c290339fa60"
 
 DEPTH="${DEPTH:-deep}"
 BUDGET="${BUDGET:-0}"
-OUT_DIR="$(realpath "${OUT_DIR:-evaluations/results/cve-2026-28386}")"
-
+OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-28386}"
 mkdir -p "$OUT_DIR"
+OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t openssl-cve-2026-28386-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-28386-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -42,6 +44,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-32316.sh
+++ b/evaluations/cve-2026-32316.sh
@@ -10,6 +10,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-32316.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/jqlang/jq.git"
 VULNERABLE_COMMIT="985abe534fdd48186015e169da7786c05fd7f868"
 
@@ -19,12 +22,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-32316}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t jq-cve-2026-32316-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-32316-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -32,7 +34,7 @@ HUNT_EXIT=0
 clearwing sourcehunt "$CLONE_URL" \
     --local-path "$REPO_DIR" \
     --subsystem-hunt \
-    --subsystem src \
+    --subsystem src/jv.c \
     --no-per-file-hunt \
     --depth "$DEPTH" \
     --budget "$BUDGET" \
@@ -42,7 +44,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
-    --live
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-34182.sh
+++ b/evaluations/cve-2026-34182.sh
@@ -10,21 +10,23 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-34182.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/openssl/openssl.git"
 VULNERABLE_COMMIT="0300eb9ddce7a0895bf301a4b0c03a9da2313a0f"
 
 DEPTH="${DEPTH:-deep}"
 BUDGET="${BUDGET:-0}"
-OUT_DIR="$(realpath "${OUT_DIR:-evaluations/results/cve-2026-34182}")"
-
+OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-34182}"
 mkdir -p "$OUT_DIR"
+OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t openssl-cve-2026-34182-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-34182-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -42,6 +44,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-40033.sh
+++ b/evaluations/cve-2026-40033.sh
@@ -10,6 +10,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-40033.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/FreeRDP/FreeRDP.git"
 VULNERABLE_COMMIT="1d67eeb902638ecf1ed6e30e01f4e02e68e396c4"
 
@@ -19,12 +22,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-40033}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t freerdp-cve-2026-40033-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-40033-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -42,6 +44,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-40034.sh
+++ b/evaluations/cve-2026-40034.sh
@@ -10,21 +10,23 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-40034.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/GitoxideLabs/gitoxide.git"
 VULNERABLE_COMMIT="95b0399abca3e040686591388991b08c794050cd"
 
 DEPTH="${DEPTH:-deep}"
 BUDGET="${BUDGET:-0}"
-OUT_DIR="$(realpath "${OUT_DIR:-evaluations/results/cve-2026-40034}")"
-
+OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-40034}"
 mkdir -p "$OUT_DIR"
+OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t gitoxide-cve-2026-40034-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-40034-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -45,6 +47,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-40528.sh
+++ b/evaluations/cve-2026-40528.sh
@@ -10,6 +10,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-40528.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/OpenSC/OpenSC.git"
 VULNERABLE_COMMIT="65fc211015cfcac27b10d0876054156c97225f50"
 
@@ -19,12 +22,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-40528}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t opensc-cve-2026-40528-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-40528-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -42,6 +44,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-41401.sh
+++ b/evaluations/cve-2026-41401.sh
@@ -10,6 +10,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-41401.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/CESNET/libyang.git"
 VULNERABLE_COMMIT="a4e3a89f441abcbd216285835e4a89e8f441017f"
 
@@ -19,12 +22,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-41401}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t libyang-cve-2026-41401-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-41401-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -42,6 +44,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-42768.sh
+++ b/evaluations/cve-2026-42768.sh
@@ -10,6 +10,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-42768.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/openssl/openssl.git"
 VULNERABLE_COMMIT="72fecdef656deca8119dda2d87e2618fcaf7b912"
 
@@ -19,12 +22,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-42768}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t openssl-cve-2026-42768-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-42768-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -43,6 +45,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-45445.sh
+++ b/evaluations/cve-2026-45445.sh
@@ -10,6 +10,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-45445.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/openssl/openssl.git"
 VULNERABLE_COMMIT="ffce42f4807d879586bd3bba8fa93caf13a7b8e4"
 
@@ -19,12 +22,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-45445}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t openssl-cve-2026-45445-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-45445-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -32,7 +34,7 @@ HUNT_EXIT=0
 clearwing sourcehunt "$CLONE_URL" \
     --local-path "$REPO_DIR" \
     --subsystem-hunt \
-    --subsystem providers/implementations/ciphers \
+    --subsystem providers/implementations/ciphers/cipher_aes_ocb.c \
     --no-per-file-hunt \
     --depth "$DEPTH" \
     --budget "$BUDGET" \
@@ -42,6 +44,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-4600.sh
+++ b/evaluations/cve-2026-4600.sh
@@ -10,6 +10,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-4600.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/kjur/jsrsasign.git"
 VULNERABLE_COMMIT="ca5b027240287a1e71fe63019fc4400332594323"
 
@@ -19,12 +22,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-4600}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t jsrsasign-cve-2026-4600-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-4600-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -42,6 +44,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-47345.sh
+++ b/evaluations/cve-2026-47345.sh
@@ -11,6 +11,9 @@
 #   LOCAL_PATH=/path/to/html-sanitizer ./evaluations/cve-2026-47345.sh   # skip clone
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/TYPO3/html-sanitizer.git"
 VULNERABLE_COMMIT="bd1a88d9b5a5f67f1120ec41084e9c1a0675641c"
 
@@ -22,14 +25,13 @@ LOCAL_PATH="${LOCAL_PATH:-}"
 mkdir -p "$OUT_DIR"
 
 # ---------- repo setup ----------
+REPO_DIR="$(mktemp -d -t source-snapshot-XXXX)"
 if [[ -n "$LOCAL_PATH" ]]; then
-    REPO_DIR="$LOCAL_PATH"
-    echo "// SCANNING using local path: $REPO_DIR"
+    echo "// SCANNING exporting pinned source from local repository"
+    blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR" "$LOCAL_PATH"
 else
-    REPO_DIR="$(mktemp -d -t html-sanitizer-cve-2026-47345-XXXX)"
     echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-    git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-    git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+    blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 fi
 
 HUNT_OUT="$(mktemp -d -t cve-2026-47345-hunt-XXXX)"
@@ -41,7 +43,7 @@ HUNT_EXIT=0
 clearwing sourcehunt "$CLONE_URL" \
     --local-path "$REPO_DIR" \
     --subsystem-hunt \
-    --subsystem src \
+    --subsystem src/Serializer/Rules.php \
     --subsystem vendor/masterminds/html5/src/Serializer/OutputRules.php \
     --no-per-file-hunt \
     --depth "$DEPTH" \
@@ -52,6 +54,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 # ---------- collect outputs ----------

--- a/evaluations/cve-2026-47391.sh
+++ b/evaluations/cve-2026-47391.sh
@@ -10,21 +10,23 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-47391.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/MervinPraison/PraisonAI.git"
 VULNERABLE_COMMIT="bc73dd1db9089ea93648c5266b2d6ad9dcf85484"
 
 DEPTH="${DEPTH:-deep}"
 BUDGET="${BUDGET:-0}"
-OUT_DIR="$(realpath "${OUT_DIR:-evaluations/results/cve-2026-47391}")"
-
+OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-47391}"
 mkdir -p "$OUT_DIR"
+OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t praisonai-cve-2026-47391-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-47391-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -42,6 +44,8 @@ clearwing sourcehunt "$CLONE_URL" \
     --output-dir "$HUNT_OUT" \
     --format json \
     --no-verify \
+    --live \
+|| HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"
 

--- a/evaluations/cve-2026-5194.sh
+++ b/evaluations/cve-2026-5194.sh
@@ -10,6 +10,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-5194.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/wolfSSL/wolfssl.git"
 VULNERABLE_COMMIT="0c9b6397be463c0e5bd7d0c8c1bd8619dc9b3aa8"
 
@@ -19,12 +22,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-5194}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t wolfssl-cve-2026-5194-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-5194-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -33,6 +35,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --local-path "$REPO_DIR" \
     --subsystem-hunt \
     --subsystem wolfcrypt/src/ecc.c \
+    --subsystem wolfcrypt/src/asn.c \
     --no-per-file-hunt \
     --depth "$DEPTH" \
     --budget "$BUDGET" \
@@ -42,6 +45,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-5588.sh
+++ b/evaluations/cve-2026-5588.sh
@@ -11,6 +11,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-5588.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/bcgit/bc-java.git"
 VULNERABLE_COMMIT="8a471e58cf7f63bbc78862e44e42494d793e2e12"
 
@@ -20,12 +23,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-5588}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t bc-java-cve-2026-5588-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-5588-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -43,6 +45,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-5747.sh
+++ b/evaluations/cve-2026-5747.sh
@@ -12,6 +12,9 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-5747.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/firecracker-microvm/firecracker.git"
 VULNERABLE_COMMIT="7db02adc28eaeb5f54a0d4a8c312e7e9954070b6"
 
@@ -21,12 +24,11 @@ OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-5747}"
 mkdir -p "$OUT_DIR"
 OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t firecracker-cve-2026-5747-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-5747-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -44,6 +46,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/cve-2026-6679.sh
+++ b/evaluations/cve-2026-6679.sh
@@ -10,21 +10,23 @@
 #   DEPTH=deep BUDGET=10 ./evaluations/cve-2026-6679.sh
 set -euxo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 CLONE_URL="https://github.com/wolfSSL/wolfssl.git"
 VULNERABLE_COMMIT="0c9b6397be463c0e5bd7d0c8c1bd8619dc9b3aa8"
 
 DEPTH="${DEPTH:-deep}"
 BUDGET="${BUDGET:-0}"
-OUT_DIR="$(realpath "${OUT_DIR:-evaluations/results/cve-2026-6679}")"
-
+OUT_DIR="${OUT_DIR:-evaluations/results/cve-2026-6679}"
 mkdir -p "$OUT_DIR"
+OUT_DIR="$(realpath "$OUT_DIR")"
 
-REPO_DIR="$(realpath "$(mktemp -d -t wolfssl-cve-2026-6679-XXXX)")"
+REPO_DIR="$(realpath "$(mktemp -d -t source-snapshot-XXXX)")"
 HUNT_OUT="$(realpath "$(mktemp -d -t cve-2026-6679-hunt-XXXX)")"
 
 echo "// SCANNING cloning $CLONE_URL @ $VULNERABLE_COMMIT ..."
-git clone --no-checkout --filter=blob:none "$CLONE_URL" "$REPO_DIR"
-git -C "$REPO_DIR" checkout "$VULNERABLE_COMMIT"
+blind_checkout "$CLONE_URL" "$VULNERABLE_COMMIT" "$REPO_DIR"
 
 echo "// SCANNING depth=$DEPTH  budget=$BUDGET  repo=$REPO_DIR"
 
@@ -42,6 +44,7 @@ clearwing sourcehunt "$CLONE_URL" \
     --no-exploit \
     --output-dir "$HUNT_OUT" \
     --format json \
+    --live \
 || HUNT_EXIT=$?
 
 SESSION_DIR="$(find "$HUNT_OUT" -maxdepth 1 -mindepth 1 -type d | sort | tail -1)"

--- a/evaluations/ffmpeg.sh
+++ b/evaluations/ffmpeg.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
 
 if [[ -z "${1:-}" ]]; then
   echo "usage: $0 <model>" >&2
@@ -16,13 +19,16 @@ CASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 RUN_HOME="$CASE_DIR/.clearwing-home-$$"
 RUN_TRACE="$CASE_DIR/trajectories-$$"
 
-TARGET="../FFmpeg/"
+SOURCE_REPOSITORY="${FFMPEG_DIR:-../FFmpeg}"
+SOURCE_COMMIT="$(git -C "$SOURCE_REPOSITORY" rev-parse HEAD)"
+TARGET="$(mktemp -d -t source-snapshot-XXXX)"
+blind_checkout "" "$SOURCE_COMMIT" "$TARGET" "$SOURCE_REPOSITORY"
 
 mkdir -p "$RUN_HOME" "$RUN_TRACE"
 
 CLEARWING_HOME="$RUN_HOME" \
 CLEARWING_SOURCEHUNT_TRACE_DIR="$RUN_TRACE" \
-clearwing sourcehunt $TARGET \
+clearwing sourcehunt "$TARGET" \
     --base-url "$BASE_URL" \
     --api-key "$API_KEY" \
     --model "$1" \

--- a/evaluations/ffmpeg_proof.sh
+++ b/evaluations/ffmpeg_proof.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/blind-checkout.sh"
+
 FFMPEG_DIR="${FFMPEG_DIR:?set FFMPEG_DIR to an FFmpeg checkout}"
 CASE_DIR="${CASE_DIR:-$PWD/results/ffmpeg-proof}"
 CLEARWING_BIN="${CLEARWING_BIN:-clearwing}"
@@ -19,9 +22,9 @@ command -v docker >/dev/null || {
 mkdir -p "$CASE_DIR"
 
 build_database() {
-  git -C "$FFMPEG_DIR" clean -fdx
+  local snapshot_dir="$1"
   (
-    cd "$FFMPEG_DIR"
+    cd "$snapshot_dir"
     ./configure \
       --cc=clang \
       --cxx=clang++ \
@@ -40,15 +43,17 @@ build_database() {
 run_snapshot() {
   local label="$1"
   local commit="$2"
+  local snapshot_dir
   local validation_args=()
   if [[ -n "${VALIDATION_MANIFEST:-}" ]]; then
     validation_args=(--validation-manifest "$VALIDATION_MANIFEST")
   fi
-  git -C "$FFMPEG_DIR" switch --detach "$commit"
-  build_database
-  "$CLEARWING_BIN" sourcehunt "$FFMPEG_DIR" \
+  snapshot_dir="$(mktemp -d -t source-snapshot-XXXX)"
+  blind_checkout "" "$commit" "$snapshot_dir" "$FFMPEG_DIR"
+  build_database "$snapshot_dir"
+  "$CLEARWING_BIN" sourcehunt "$snapshot_dir" \
     --flow proof \
-    --compile-commands compile_commands.json \
+    --compile-commands "$snapshot_dir/compile_commands.json" \
     "${validation_args[@]}" \
     --build-configuration asan-debug \
     --depth deep \

--- a/evaluations/latest.json
+++ b/evaluations/latest.json
@@ -1,0 +1,199 @@
+{
+  "schema_version": 1,
+  "updated_at": "2026-08-26T20:42:25.556871+00:00",
+  "evaluations": [
+    {
+      "cve": "CVE-2026-28208",
+      "evaluation": "evaluations/cve-2026-28208.sh",
+      "difficulty": "easy",
+      "language": "Java",
+      "status": "PASS",
+      "duration_seconds": 172.6,
+      "trace_id": "fae84bc3e2a3a6d2b81539dbc6cf511a",
+      "latest_result": "Found and reproduced the intended Junrar backslash path-separator reinterpretation traversal, tracing validation/execution semantic mismatch to an arbitrary write outside the extraction root.",
+      "updated_at": "2026-08-26T20:42:25.556871+00:00"
+    },
+    {
+      "cve": "CVE-2026-40528",
+      "evaluation": "evaluations/cve-2026-40528.sh",
+      "difficulty": "easy",
+      "language": "C",
+      "status": "PASS",
+      "duration_seconds": 267.1,
+      "trace_id": "45d4eff3b06c58ff878eb6ff201d541f",
+      "latest_result": "Found the intended OpenSC do_key_value stack and heap buffer overruns."
+    },
+    {
+      "cve": "CVE-2026-47391",
+      "evaluation": "evaluations/cve-2026-47391.sh",
+      "difficulty": "easy",
+      "language": "Python",
+      "status": "PASS",
+      "duration_seconds": 229.8,
+      "trace_id": "cb2c29a7386f5e1f021b421cb7744ba7",
+      "latest_result": "Found the intended unauthenticated A2A eval() remote-code-execution path.",
+      "updated_at": "2026-08-26T14:26:16.009008+00:00"
+    },
+    {
+      "cve": "CVE-2026-40033",
+      "evaluation": "evaluations/cve-2026-40033.sh",
+      "difficulty": "medium",
+      "language": "C",
+      "status": "PASS",
+      "duration_seconds": 854.493859,
+      "trace_id": "5c1612dc280b594f9c4180c25aaaa629",
+      "latest_result": "Found the intended FreeRDP gdi_CacheToSurface heap out-of-bounds write; also reported an unbounded surface-allocation DoS.",
+      "updated_at": "2026-08-26T19:20:07.484348+00:00"
+    },
+    {
+      "cve": "CVE-2026-40034",
+      "evaluation": "evaluations/cve-2026-40034.sh",
+      "difficulty": "medium",
+      "language": "Rust",
+      "status": "PASS",
+      "duration_seconds": 892.030457,
+      "trace_id": "c633f3b9197665dcee918362d6b77c4e",
+      "latest_result": "Found the intended gitoxide submodule update-command provenance-validation bypass.",
+      "updated_at": "2026-08-26T15:45:43.624428+00:00"
+    },
+    {
+      "cve": "CVE-2026-4600",
+      "evaluation": "evaluations/cve-2026-4600.sh",
+      "difficulty": "medium",
+      "language": "JavaScript",
+      "status": "PASS",
+      "duration_seconds": 345.5,
+      "trace_id": "2eea830b5c7bb62b0dabdce9f5b59970",
+      "latest_result": "Found the intended jsrsasign DSA parameter-validation signature forgery."
+    },
+    {
+      "cve": "CVE-2026-47345",
+      "evaluation": "evaluations/cve-2026-47345.sh",
+      "difficulty": "medium",
+      "language": "PHP",
+      "status": "MISSING",
+      "duration_seconds": null,
+      "trace_id": null,
+      "latest_result": "No completed run found."
+    },
+    {
+      "cve": "CVE-2026-5588",
+      "evaluation": "evaluations/cve-2026-5588.sh",
+      "difficulty": "medium",
+      "language": "Java",
+      "status": "PASS",
+      "duration_seconds": 242.7,
+      "trace_id": "3d46d318e2ba3d3bd55944c888f9ef54",
+      "latest_result": "Found the intended Bouncy Castle composite-signature verification bypass."
+    },
+    {
+      "cve": "CVE-2026-27775",
+      "evaluation": "evaluations/cve-2026-27775.sh",
+      "difficulty": "hard",
+      "language": "Go",
+      "status": "PASS",
+      "duration_seconds": 361.109483,
+      "trace_id": "38024f8c2889c0b37251b10256fb02b0",
+      "latest_result": "Found the intended Gitea pre-receive per-ref write-permission cache bypass.",
+      "updated_at": "2026-08-26T15:54:15.452028+00:00"
+    },
+    {
+      "cve": "CVE-2026-28386",
+      "evaluation": "evaluations/cve-2026-28386.sh",
+      "difficulty": "hard",
+      "language": "C",
+      "status": "FAIL",
+      "duration_seconds": 283.694105,
+      "trace_id": "60c46d2ad2581a4baeb1a0b38dcf9207",
+      "latest_result": "Identified the intended AES-CFB128 AVX-512 OOB-read mechanism as a potential, but deferred it unresolved and emitted zero findings.",
+      "updated_at": "2026-08-26T16:36:46.012127+00:00"
+    },
+    {
+      "cve": "CVE-2026-32316",
+      "evaluation": "evaluations/cve-2026-32316.sh",
+      "difficulty": "hard",
+      "language": "C",
+      "status": "FAIL",
+      "duration_seconds": 1213.2,
+      "trace_id": "c567a20d62e688de273d4a7d2d2c35ed",
+      "latest_result": "Missed the intended jvp_string_append/jvp_string_copy_replace_bad integer overflow; recorded an unrelated weak-hash-seed DoS after MISSING_TRACE and deferred-potential promotion failures.",
+      "updated_at": "2026-08-26T19:46:45.734829+00:00"
+    },
+    {
+      "cve": "CVE-2026-34182",
+      "evaluation": "evaluations/cve-2026-34182.sh",
+      "difficulty": "hard",
+      "language": "C",
+      "status": "FAIL",
+      "duration_seconds": 376.1,
+      "trace_id": "4daec08edcea50dde666163f3a592dcb",
+      "latest_result": "Completed with zero findings after investigating and dismissing an AEAD tag-copy OOB hypothesis; missed the intended CMS AuthEnvelopedData non-AEAD cipher acceptance and unbounded tag-length flaw.",
+      "updated_at": "2026-08-26T17:19:59.734925+00:00"
+    },
+    {
+      "cve": "CVE-2026-41401",
+      "evaluation": "evaluations/cve-2026-41401.sh",
+      "difficulty": "hard",
+      "language": "C",
+      "status": "FAIL",
+      "duration_seconds": 206.7,
+      "trace_id": "a87beca5d89ad240207784bf68e1b4a1",
+      "latest_result": "Completed with zero findings. A truncated broad read was incorrectly marked fully visible, hiding lyd_parser_set_data_flags and causing repeated blocked rereads and shell workarounds around an unrelated pattern-modifier hypothesis.",
+      "updated_at": "2026-08-26T19:54:22.830062+00:00"
+    },
+    {
+      "cve": "CVE-2026-42768",
+      "evaluation": "evaluations/cve-2026-42768.sh",
+      "difficulty": "hard",
+      "language": "C",
+      "status": "FAIL",
+      "duration_seconds": 602.4,
+      "trace_id": "9477f0445b9d216a1f1f342aadd5163d",
+      "latest_result": "Complete run returned zero findings; it flagged the intended disabled-RSA-implicit-rejection site but misclassified it as deliberate defense and deferred an unrelated key-length hypothesis.",
+      "updated_at": "2026-08-26T17:47:04.515612+00:00"
+    },
+    {
+      "cve": "CVE-2026-45445",
+      "evaluation": "evaluations/cve-2026-45445.sh",
+      "difficulty": "hard",
+      "language": "C",
+      "status": "FAIL",
+      "duration_seconds": 1322.821583,
+      "trace_id": "b010f7af804de816b44e0d538b2d8697",
+      "latest_result": "Completed with three unrelated provider-cipher memory-safety findings. It inspected AES-OCB tag/AAD bounds and called OCB well-bounded, but never analyzed the intended EVP_Cipher() one-shot path discarding the caller-supplied IV.",
+      "updated_at": "2026-08-26T18:56:21.266981+00:00"
+    },
+    {
+      "cve": "CVE-2026-5194",
+      "evaluation": "evaluations/cve-2026-5194.sh",
+      "difficulty": "hard",
+      "language": "C",
+      "status": "FAIL",
+      "duration_seconds": 1017.221521,
+      "trace_id": "ac99191b4184a5c2f065de49ba975b5c",
+      "latest_result": "Newer completed run found an unrelated Xilinx wc_ecc_sign_hash_hw ForceZero heap overflow; an earlier completed run found an unrelated NO_ASN wc_ecc_sign_hash output overflow twice. Both inspected verification code but missed the intended ECDSA verify hash-size/OID validation flaw.",
+      "updated_at": "2026-08-26T18:29:24.883947+00:00"
+    },
+    {
+      "cve": "CVE-2026-5747",
+      "evaluation": "evaluations/cve-2026-5747.sh",
+      "difficulty": "hard",
+      "language": "Rust",
+      "status": "PASS",
+      "duration_seconds": 754.1,
+      "trace_id": "3103ca11a950678de48063bf928c2704",
+      "latest_result": "Found the intended Firecracker post-activation queue-size validation bypass and traced the live mutated size to host-side out-of-bounds ring access.",
+      "updated_at": "2026-08-26T20:36:25.971495+00:00"
+    },
+    {
+      "cve": "CVE-2026-6679",
+      "evaluation": "evaluations/cve-2026-6679.sh",
+      "difficulty": "hard",
+      "language": "C",
+      "status": "FAIL",
+      "duration_seconds": 352.7,
+      "trace_id": "18300f4d10102dae90583d67e52a98ba",
+      "latest_result": "Completed with zero findings for the intended wolfSSL DTLS 1.3 ACK integer-truncation heap overflow."
+    }
+  ]
+}

--- a/tests/test_evaluation_blind_checkout.py
+++ b/tests/test_evaluation_blind_checkout.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+EVALUATIONS_DIR = Path(__file__).parents[1] / "evaluations"
+
+
+def test_all_evaluation_searchers_use_blind_source_snapshots():
+    scripts = sorted(EVALUATIONS_DIR.glob("*.sh"))
+
+    assert scripts
+    for script in scripts:
+        source = script.read_text(encoding="utf-8")
+        assert 'source "$SCRIPT_DIR/lib/blind-checkout.sh"' in source, script
+        assert "blind_checkout " in source, script
+        assert "git clone" not in source, script
+        assert "git checkout" not in source, script
+        assert "git switch" not in source, script
+        assert "rm -rf -- \"$REPO_DIR/.git\"" not in source, script
+
+
+def test_blind_snapshot_paths_do_not_disclose_case_identity():
+    for script in sorted(EVALUATIONS_DIR.glob("*.sh")):
+        source = script.read_text(encoding="utf-8")
+        for line in source.splitlines():
+            if "REPO_DIR=" in line or "TARGET=\"$(mktemp" in line:
+                assert "cve-" not in line.lower(), (script, line)

--- a/tests/test_sourcehunt_run_provenance.py
+++ b/tests/test_sourcehunt_run_provenance.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+
+from clearwing.sourcehunt.reporter import write_sourcehunt_report
+
+
+def test_json_report_includes_sourcehunt_trace_and_build_provenance(
+    tmp_path, monkeypatch
+) -> None:
+    trace_id = "656901efba4302f09db3999290711fb0"
+    commit_sha = "a" * 40
+    monkeypatch.setenv("CLEARWING_COMMIT_SHA", commit_sha)
+
+    paths = write_sourcehunt_report(
+        output_dir=str(tmp_path),
+        session_id="session",
+        repo_url="example/repo",
+        findings=[],
+        verified_findings=[],
+        spent_per_tier={"A": 0.0, "B": 0.0, "C": 0.0},
+        formats=["json"],
+        trace_id=trace_id,
+        run_started_at="2026-08-26T12:00:00+00:00",
+        run_ended_at="2026-08-26T12:05:00+00:00",
+    )
+
+    report = json.loads(Path(paths["json"]).read_text(encoding="utf-8"))
+    assert report["trace_id"] == trace_id
+    assert report["clearwing"]["commit_sha"] == commit_sha
+    assert report["clearwing"]["start-time"] == "2026-08-26T12:00:00+00:00"
+    assert report["clearwing"]["end-time"] == "2026-08-26T12:05:00+00:00"
+    assert report["clearwing"]["version"]


### PR DESCRIPTION
## Summary

First PR in the SourceHunt investigation stack.

- Standardizes CVE evaluation invocation and output handling.
- Maintains the current evaluation ledger.
- Records the Clearwing version, commit and dirty state, run timing, and trace ID in JSON output.
- Keeps potential-lifecycle serialization out of this layer.

## Validation

- Focused evaluation and provenance tests pass.
- Ruff passes on changed Python files.
- `git diff --check` passes.

## PR stack

1. **#168 — Evaluation harness and run provenance (this PR)**
2. #169 — Remove Semgrep from deep-agent tools
3. #170 — Structured tool-call diagnostics
4. #171 — Semantic navigation foundation
5. #172 — Durable potential lifecycle
6. #173 — Investigation policy and orchestration

Supersedes the relevant portion of #160.
