### PR TITLE
refactor(sourcehunt): remove Semgrep from deep-agent tools

### DIFF
--- a/clearwing/agent/tools/hunt/deep_agent.py
+++ b/clearwing/agent/tools/hunt/deep_agent.py
@@ -27,7 +27,6 @@ from pydantic import Field
 
 from clearwing.llm import NativeToolSpec, ToolInputModel
 
-from .discovery import build_semgrep_tool
 from .pool_query import build_pool_query_tools
 from .potentials import build_potential_tools
 from .reporting import build_reporting_tools
@@ -104,7 +103,7 @@ def _matches(name: str, tokens: list[str]) -> bool:
 
 
 
-def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:
+def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:  # noqa: C901
     """Build the deep agent tool set: execute, read_file, write_file,
     plus the shared reporting + findings-pool tools.
     """
@@ -255,8 +254,6 @@ def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:
 
     reporting_tools = build_reporting_tools(ctx)
 
-    semgrep_tool = build_semgrep_tool(ctx)
-
     callgraph_tools = (
         [
             NativeToolSpec(
@@ -328,7 +325,6 @@ def build_deep_agent_tools(ctx: HunterContext) -> list[NativeToolSpec]:
             schema=WriteFileInput.model_json_schema(),
             handler=write_file,
         ),
-        semgrep_tool,
         *reporting_tools,
         *build_potential_tools(ctx),
         *(build_pool_query_tools(ctx) if ctx.findings_pool is not None else []),

--- a/tests/test_deep_agent_tools.py
+++ b/tests/test_deep_agent_tools.py
@@ -39,6 +39,7 @@ def test_build_deep_agent_tools_set(ctx):
     tools = build_deep_agent_tools(ctx)
     names = {t.name for t in tools}
     assert "think" not in names
+    assert "semgrep_scan" not in names
     assert {"execute", "read_file", "write_file", "record_finding"} <= names
 
 


### PR DESCRIPTION
## Summary

Second PR in the SourceHunt investigation stack.

Removes Semgrep only from the deep-agent tool palette. The Semgrep sidecar, preprocessing hints, constrained workflow, and retro-hunt remain intact.

## Validation

- 83 focused deep-agent and hunter tests pass.
- Ruff passes.
- `git diff --check` passes.

## PR stack

1. #168 — Evaluation harness and run provenance
2. **#169 — Remove Semgrep from deep-agent tools (this PR)**
3. #170 — Structured tool-call diagnostics
4. #171 — Semantic navigation foundation
5. #172 — Durable potential lifecycle
6. #173 — Investigation policy and orchestration

Depends on #168. Supersedes the relevant portion of #160.
