### PR TITLE
feat(sourcehunt): add durable potential lifecycle

### DIFF
--- a/clearwing/agent/tools/hunt/potentials.py
+++ b/clearwing/agent/tools/hunt/potentials.py
@@ -1,4 +1,4 @@
-"""Investigation queue tools: flag_potential, get_potentials, dismiss_potential.
+"""Investigation queue tool: flag_potential.
 
 Lets the hunter bookmark suspicious lines without committing to a finding.
 The queue accumulates across file reads so cross-file asymmetries stay visible.
@@ -7,9 +7,11 @@ The queue accumulates across file reads so cross-file asymmetries stay visible.
 from __future__ import annotations
 
 import logging
+import re
 import uuid
+from typing import Literal
 
-from pydantic import Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from clearwing.llm import NativeToolSpec, ToolInputModel
 
@@ -18,119 +20,608 @@ from .sandbox import HunterContext
 logger = logging.getLogger(__name__)
 
 
+PotentialPriority = Literal["high", "medium", "low"]
+EvidenceStatus = Literal["unknown", "supported", "disproven"]
+PotentialImpact = Literal[
+    "memory_corruption",
+    "authorization_bypass",
+    "integrity_or_confidentiality",
+    "code_execution",
+    "resource_exhaustion",
+    "other",
+    "unknown",
+]
+PotentialNovelty = Literal["distinct", "related", "duplicate", "unknown"]
+PotentialAction = Literal["update", "reopen", "close"]
+
+_IMPACT_SCORES: dict[str, int] = {
+    "code_execution": 55,
+    "memory_corruption": 50,
+    "authorization_bypass": 50,
+    "integrity_or_confidentiality": 40,
+    "resource_exhaustion": 5,
+    "other": 10,
+    "unknown": 0,
+}
+_EVIDENCE_SCORES: dict[str, int] = {"supported": 8, "unknown": 0, "disproven": -20}
+_NOVELTY_SCORES: dict[str, int] = {"distinct": 8, "related": 2, "unknown": 0, "duplicate": -40}
+
+
+class PotentialVerification(BaseModel):
+    """Neutral evidence gaps that must be resolved before promotion."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    attacker_control: EvidenceStatus = "unknown"
+    reachability: EvidenceStatus = "unknown"
+    guard_behavior: EvidenceStatus = "unknown"
+    impact: EvidenceStatus = "unknown"
+
+
+class Potential(BaseModel):
+    """Durable investigation state, independent of conversation history."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    file: str
+    line: int
+    note: str
+    hypothesis: str
+    security_boundary: str = ""
+    security_invariant: str
+    priority: PotentialPriority
+    priority_score: int = 0
+    priority_reasons: list[str] = Field(default_factory=list)
+    impact_class: PotentialImpact = "unknown"
+    novelty: PotentialNovelty = "unknown"
+    status: Literal["open", "examined", "safe", "unresolved", "confirmed"] = "open"
+    attacker_inputs: list[str] = Field(default_factory=list)
+    required_relationships: list[str] = Field(default_factory=list)
+    observed_checks: list[str] = Field(default_factory=list)
+    missing_checks: list[str] = Field(default_factory=list)
+    verification: PotentialVerification = Field(default_factory=PotentialVerification)
+    observations: list[str] = Field(default_factory=list)
+    open_questions: list[str] = Field(default_factory=list)
+    disproof_conditions: list[str] = Field(default_factory=list)
+    deferred_reason: str = ""
+    missing_evidence: list[str] = Field(default_factory=list)
+
+
 class FlagPotentialInput(ToolInputModel):
-    file: str = Field(description="Repo-relative file path, e.g. 'src/parser/decode.c'.")
+    file: str = Field(description="Existing repository-relative source path.")
     line: int = Field(description="Line number of the suspicious call or expression.")
-    note: str = Field(
-        description=(
-            "What you observed at this line — one concrete sentence. "
-            "Example: 'calls memcpy with user-supplied length without bounds check, "
-            "unlike parse_header which validates len < buf_size at line 233.'"
-        )
-    )
+    note: str = Field(default="", description="Optional concrete source fact observed here.")
     hypothesis: str = Field(
-        description=(
-            "The vulnerability class this might indicate. "
-            "Example: 'CWE-120: stack buffer overflow — attacker-controlled length "
-            "passed directly to memcpy without validation.'"
-        )
+        description="Security property that may be violated and the resulting impact."
     )
-    priority: str = Field(
+    security_invariant: str = Field(
+        default="", description="Safety or authorization rule that must hold if the code is secure."
+    )
+    security_boundary: str = Field(
+        default="",
+        description="Public entry point, parser, verifier, state transition, or authorization decision.",
+    )
+    attacker_inputs: list[str] = Field(default_factory=list, max_length=6)
+    required_relationships: list[str] = Field(default_factory=list, max_length=6)
+    observed_checks: list[str] = Field(default_factory=list, max_length=6)
+    missing_checks: list[str] = Field(default_factory=list, max_length=6)
+    open_questions: list[str] = Field(
+        default_factory=list,
+        max_length=4,
+        description="Neutral unanswered questions needed to assess the hypothesis.",
+    )
+    disproof_conditions: list[str] = Field(
+        default_factory=list,
+        max_length=3,
+        description="Concrete source facts that would rule out the hypothesis.",
+    )
+    impact_class: PotentialImpact = Field(
+        default="unknown",
+        description=(
+            "Most plausible direct security impact. Classify recoverable allocation or "
+            "CPU pressure as resource_exhaustion, not memory_corruption."
+        ),
+    )
+    novelty: PotentialNovelty = Field(
+        default="unknown",
+        description="Whether this is distinct from, related to, or duplicates an existing lead.",
+    )
+    priority: PotentialPriority = Field(
         default="medium",
         description=(
-            "high — directly violates a security invariant; investigate next. "
-            "medium — suspicious asymmetry; investigate after high items. "
-            "low — minor code smell; investigate only if time permits."
+            "Initial hint retained for compatibility. The queue recomputes priority from "
+            "typed impact, verification evidence, invariant completeness, and novelty."
         ),
     )
 
 
-class DismissPotentialInput(ToolInputModel):
+class UpdatePotentialInput(ToolInputModel):
     potential_id: str = Field(description="ID returned by flag_potential.")
-    reason: str = Field(
+    action: PotentialAction = Field(
+        default="update",
         description=(
-            "Why this was ruled out — one sentence. "
-            "Example: 'update_iv is called two lines earlier at line 499, inside the same if-block.'"
-        )
+            "update an active lead, reopen a previously unresolved lead, or close an "
+            "active lead as unresolved. Use dismiss_potential for evidence-backed safe closure."
+        ),
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Required for reopen and close; explain the investigation-state transition.",
+    )
+    missing_evidence: list[str] | None = Field(default=None, max_length=4)
+    observation: str | None = Field(
+        default=None,
+        description="One new source-backed fact learned during verification.",
+    )
+    security_invariant: str | None = Field(default=None)
+    security_boundary: str | None = Field(default=None)
+    attacker_inputs: list[str] | None = Field(default=None, max_length=6)
+    required_relationships: list[str] | None = Field(default=None, max_length=6)
+    observed_checks: list[str] | None = Field(default=None, max_length=6)
+    missing_checks: list[str] | None = Field(default=None, max_length=6)
+    open_questions: list[str] | None = Field(default=None, max_length=4)
+    disproof_conditions: list[str] | None = Field(default=None, max_length=3)
+    impact_class: PotentialImpact | None = None
+    novelty: PotentialNovelty | None = None
+    attacker_control: EvidenceStatus | None = None
+    reachability: EvidenceStatus | None = None
+    guard_behavior: EvidenceStatus | None = Field(
+        default=None,
+        description="supported means source evidence supports the suspected missing/ineffective guard.",
+    )
+    impact: EvidenceStatus | None = None
+
+
+def _score_potential(potential: dict) -> tuple[int, list[str]]:
+    """Derive lead priority from impact, evidence, invariant strength, and novelty."""
+
+    impact_class = str(potential.get("impact_class", "unknown"))
+    score = _IMPACT_SCORES.get(impact_class, 0)
+    reasons = [f"impact={impact_class}:{score:+d}"]
+
+    verification = potential.get("verification") or {}
+    for field in ("attacker_control", "reachability", "guard_behavior", "impact"):
+        status = str(verification.get(field, "unknown"))
+        points = _EVIDENCE_SCORES.get(status, 0)
+        score += points
+        if points:
+            reasons.append(f"{field}={status}:{points:+d}")
+
+    map_points = 0
+    if potential.get("security_invariant"):
+        map_points += 4
+    if potential.get("required_relationships"):
+        map_points += 4
+    if potential.get("missing_checks"):
+        map_points += 4
+    score += map_points
+    if map_points:
+        reasons.append(f"invariant_map:{map_points:+d}")
+
+    novelty = str(potential.get("novelty", "unknown"))
+    novelty_points = _NOVELTY_SCORES.get(novelty, 0)
+    score += novelty_points
+    if novelty_points:
+        reasons.append(f"novelty={novelty}:{novelty_points:+d}")
+    return score, reasons
+
+
+def _refresh_priority(potential: dict) -> None:
+    score, reasons = _score_potential(potential)
+    potential["priority_score"] = score
+    potential["priority_reasons"] = reasons
+    potential["priority"] = "high" if score >= 55 else ("medium" if score >= 30 else "low")
+
+
+def _sort_potentials(potentials: list[dict]) -> None:
+    potentials.sort(key=lambda item: int(item.get("priority_score", 0)), reverse=True)
+
+
+def _normalized_words(value: object) -> set[str]:
+    return set(re.findall(r"[a-z0-9_]+", str(value).lower()))
+
+
+def _same_potential(existing: dict, candidate: dict) -> bool:
+    existing_file = str(existing.get("file", "")).removeprefix("/workspace/")
+    candidate_file = str(candidate.get("file", "")).removeprefix("/workspace/")
+    if existing_file != candidate_file:
+        return False
+    same_contract = bool(candidate.get("security_boundary")) and (
+        _normalized_words(existing.get("security_boundary"))
+        == _normalized_words(candidate.get("security_boundary"))
+        and _normalized_words(existing.get("security_invariant"))
+        == _normalized_words(candidate.get("security_invariant"))
+    )
+    if same_contract:
+        return True
+    if existing.get("line") != candidate.get("line"):
+        return False
+    return existing.get("impact_class") == candidate.get("impact_class")
+
+
+def _find_duplicate(ctx: HunterContext, candidate: dict) -> dict | None:
+    return next(
+        (
+            existing
+            for existing in [*ctx.potentials, *ctx.potential_history]
+            if _same_potential(existing, candidate)
+        ),
+        None,
     )
 
 
-def build_potential_tools(ctx: HunterContext) -> list[NativeToolSpec]:
+def _potential_error(code: str, message: str, **details: object) -> dict[str, object]:
+    return {"ok": False, "error": {"code": code, "message": message, **details}}
+
+
+def _resolve_update_target(
+    ctx: HunterContext,
+    potential_id: str,
+    action: PotentialAction,
+    reason: str | None,
+) -> tuple[dict | None, str | dict[str, object] | None, bool]:
+    active = next((item for item in ctx.potentials if item.get("id") == potential_id), None)
+    if action != "reopen":
+        if active is not None:
+            if action == "close" and not reason:
+                return None, _potential_error(
+                    "MISSING_TRANSITION_REASON",
+                    "Closing a potential requires a reason.",
+                    potential_id=potential_id,
+                    status=active.get("status", "open"),
+                ), False
+            return active, None, False
+        historical = next(
+            (item for item in ctx.potential_history if item.get("id") == potential_id),
+            None,
+        )
+        if historical is not None:
+            return None, _potential_error(
+                "POTENTIAL_NOT_ACTIVE",
+                "The potential is closed; reopen it before updating it.",
+                potential_id=potential_id,
+                status=historical.get("status", "unknown"),
+            ), False
+        return None, f"No potential found with id={potential_id}", False
+
+    if active is not None:
+        return None, _potential_error(
+            "INVALID_POTENTIAL_TRANSITION",
+            f"Potential [{potential_id}] is already active; update or close it.",
+            potential_id=potential_id,
+            status=active.get("status", "open"),
+        ), False
+    history_index = next(
+        (
+            index
+            for index, item in enumerate(ctx.potential_history)
+            if item.get("id") == potential_id
+        ),
+        None,
+    )
+    if history_index is None:
+        return None, f"No potential found with id={potential_id}", False
+    historical = ctx.potential_history[history_index]
+    if historical.get("status") != "unresolved":
+        return None, _potential_error(
+            "INVALID_POTENTIAL_TRANSITION",
+            "Only an unresolved potential may be reopened.",
+            potential_id=potential_id,
+            status=historical.get("status", "unknown"),
+        ), False
+    if not reason:
+        return None, _potential_error(
+            "MISSING_TRANSITION_REASON",
+            "Reopening a potential requires a reason.",
+            potential_id=potential_id,
+            status="unresolved",
+        ), False
+    potential = ctx.potential_history.pop(history_index)
+    potential.setdefault("reopen_events", []).append(
+        {
+            "reason": reason,
+            "previous_deferred_reason": potential.get("deferred_reason", ""),
+            "previous_missing_evidence": potential.get("missing_evidence", []),
+        }
+    )
+    potential["status"] = "examined"
+    potential["deferred_reason"] = ""
+    potential["missing_evidence"] = []
+    ctx.potentials.append(potential)
+    return potential, None, True
+
+
+def _apply_potential_updates(potential: dict, updates: dict[str, object]) -> None:
+    observation = updates.pop("observation", None)
+    if observation:
+        potential.setdefault("observations", []).append(observation)
+        potential["status"] = "examined"
+    for field, value in updates.items():
+        if value is not None:
+            potential[field] = value
+
+
+def _update_verification(
+    potential: dict,
+    *,
+    attacker_control: EvidenceStatus | None,
+    reachability: EvidenceStatus | None,
+    guard_behavior: EvidenceStatus | None,
+    impact: EvidenceStatus | None,
+) -> None:
+    verification = potential.setdefault("verification", {})
+    for field, value in (
+        ("attacker_control", attacker_control),
+        ("reachability", reachability),
+        ("guard_behavior", guard_behavior),
+        ("impact", impact),
+    ):
+        if value is not None:
+            verification[field] = value
+
+
+class DismissPotentialInput(ToolInputModel):
+    potential_id: str = Field(description="ID returned by flag_potential.")
+    resolution: str = Field(
+        description="One sentence explaining the source evidence that ruled out the lead."
+    )
+    disproof_condition: str = Field(
+        description="Exact previously recorded disproof condition satisfied by the evidence."
+    )
+    evidence: list[str] = Field(
+        min_length=1,
+        max_length=4,
+        description="Source citations such as path:line plus the fact established there.",
+    )
+
+
+class DeferPotentialInput(ToolInputModel):
+    potential_id: str = Field(description="ID returned by flag_potential.")
+    reason: str = Field(description="Why the lead remains unresolved after bounded verification.")
+    missing_evidence: list[str] = Field(
+        default_factory=list,
+        max_length=4,
+        description="Specific evidence a later verifier must obtain.",
+    )
+
+
+def _dismissal_validation_error(
+    potential: dict, disproof_condition: str, evidence: list[str]
+) -> str | None:
+    if disproof_condition not in (potential.get("disproof_conditions") or []):
+        return (
+            "disproof_condition must exactly match one recorded on the potential. "
+            "Defer it if evidence is inconclusive."
+        )
+    if not evidence or not all(":" in item for item in evidence):
+        return "cite at least one repository path and line as path:line."
+    return None
+
+
+def build_potential_tools(ctx: HunterContext) -> list[NativeToolSpec]:  # noqa: C901
 
     def flag_potential(
         file: str,
         line: int,
-        note: str,
         hypothesis: str,
-        priority: str = "medium",
+        note: str = "",
+        security_boundary: str = "",
+        security_invariant: str = "",
+        attacker_inputs: list[str] | None = None,
+        required_relationships: list[str] | None = None,
+        observed_checks: list[str] | None = None,
+        missing_checks: list[str] | None = None,
+        open_questions: list[str] | None = None,
+        disproof_conditions: list[str] | None = None,
+        priority: PotentialPriority = "medium",
+        impact_class: PotentialImpact = "unknown",
+        novelty: PotentialNovelty = "unknown",
+        **_: object,
+    ) -> str | dict[str, object]:
+        entry = Potential(
+            id=uuid.uuid4().hex[:8],
+            file=file,
+            line=line,
+            note=note or hypothesis,
+            hypothesis=hypothesis,
+            security_boundary=security_boundary,
+            security_invariant=security_invariant,
+            priority=priority,
+            impact_class=impact_class,
+            novelty=novelty,
+            attacker_inputs=attacker_inputs or [],
+            required_relationships=required_relationships or [],
+            observed_checks=observed_checks or [],
+            missing_checks=missing_checks or [],
+            open_questions=open_questions or [],
+            disproof_conditions=disproof_conditions or [],
+        )
+        potential = entry.model_dump(mode="json")
+        _refresh_priority(potential)
+        if duplicate := _find_duplicate(ctx, potential):
+            duplicate_id = str(duplicate.get("id", ""))
+            duplicate_status = str(duplicate.get("status", "open"))
+            return _potential_error(
+                "POTENTIAL_ALREADY_EXISTS",
+                (
+                    "A semantically equivalent potential already exists. Decide whether to "
+                    "update it, reopen it if unresolved, close it, or abandon this lead."
+                ),
+                potential_id=duplicate_id,
+                status=duplicate_status,
+                priority_score=duplicate.get("priority_score", 0),
+            )
+        ctx.potentials.append(potential)
+        _sort_potentials(ctx.potentials)
+        logger.info(
+            "FLAGGED %s:%d [%s score=%d] %s",
+            file,
+            line,
+            potential["priority"],
+            potential["priority_score"],
+            hypothesis[:120],
+        )
+        return (
+            f"Flagged {file}:{line} as potential [{entry.id}] "
+            f"({potential['priority']}, score={potential['priority_score']}). "
+            f"Queue: {len(ctx.potentials)} unresolved."
+        )
+
+    def update_potential(
+        potential_id: str,
+        action: PotentialAction = "update",
+        reason: str | None = None,
+        missing_evidence: list[str] | None = None,
+        observation: str | None = None,
+        security_boundary: str | None = None,
+        security_invariant: str | None = None,
+        attacker_inputs: list[str] | None = None,
+        required_relationships: list[str] | None = None,
+        observed_checks: list[str] | None = None,
+        missing_checks: list[str] | None = None,
+        open_questions: list[str] | None = None,
+        disproof_conditions: list[str] | None = None,
+        impact_class: PotentialImpact | None = None,
+        novelty: PotentialNovelty | None = None,
+        attacker_control: EvidenceStatus | None = None,
+        reachability: EvidenceStatus | None = None,
+        guard_behavior: EvidenceStatus | None = None,
+        impact: EvidenceStatus | None = None,
+        **_: object,
+    ) -> str | dict[str, object]:
+        potential, error, reopened = _resolve_update_target(
+            ctx, potential_id, action, reason
+        )
+        if error is not None:
+            return error
+        assert potential is not None
+        _apply_potential_updates(
+            potential,
+            {
+                "observation": observation,
+                "security_boundary": security_boundary,
+                "security_invariant": security_invariant,
+                "attacker_inputs": attacker_inputs,
+                "required_relationships": required_relationships,
+                "observed_checks": observed_checks,
+                "missing_checks": missing_checks,
+                "open_questions": open_questions,
+                "disproof_conditions": disproof_conditions,
+                "impact_class": impact_class,
+                "novelty": novelty,
+            },
+        )
+        _update_verification(
+            potential,
+            attacker_control=attacker_control,
+            reachability=reachability,
+            guard_behavior=guard_behavior,
+            impact=impact,
+        )
+        _refresh_priority(potential)
+        if action == "close":
+            ctx.potentials.remove(potential)
+            potential["status"] = "unresolved"
+            potential["deferred_reason"] = reason
+            potential["missing_evidence"] = missing_evidence or []
+            ctx.potential_history.append(potential)
+            return f"Closed potential [{potential_id}] as unresolved: {reason}"
+        _sort_potentials(ctx.potentials)
+        transition = "Reopened" if reopened else "Updated"
+        return (
+            f"{transition} potential [{potential_id}] "
+            f"({potential['priority']}, score={potential['priority_score']})."
+        )
+
+    def dismiss_potential(
+        potential_id: str,
+        resolution: str,
+        disproof_condition: str,
+        evidence: list[str],
         **_: object,
     ) -> str:
-        entry = {
-            "id": uuid.uuid4().hex[:8],
-            "file": file,
-            "line": line,
-            "note": note,
-            "hypothesis": hypothesis,
-            "priority": priority,
-            "status": "open",
-        }
-        ctx.potentials.append(entry)
-        open_count = sum(1 for p in ctx.potentials if p["status"] == "open")
-        logger.info("FLAGGED %s:%d [%s] %s", file, line, priority, note[:120])
-        return f"Flagged {file}:{line} as potential [{entry['id']}]. Queue: {open_count} open."
+        for index, potential in enumerate(ctx.potentials):
+            if potential.get("id") == potential_id:
+                if error := _dismissal_validation_error(
+                    potential, disproof_condition, evidence
+                ):
+                    return f"Potential [{potential_id}] not dismissed: {error}"
+                resolved = ctx.potentials.pop(index)
+                resolved.update(
+                    {
+                        "status": "safe",
+                        "resolution": resolution,
+                        "satisfied_disproof_condition": disproof_condition,
+                        "resolution_evidence": evidence,
+                    }
+                )
+                ctx.potential_history.append(resolved)
+                return f"Potential [{potential_id}] ruled out: {resolution}"
+        return f"No potential found with id={potential_id}"
 
-    def get_potentials(**_: object) -> list[dict]:
-        return [p for p in ctx.potentials if p["status"] == "open"]
-
-    def dismiss_potential(potential_id: str, reason: str, **_: object) -> str:
-        for p in ctx.potentials:
-            if p["id"] == potential_id:
-                p["status"] = "dismissed"
-                p["dismiss_reason"] = reason
-                return f"Dismissed [{potential_id}]: {reason}"
-        return f"No open potential with id={potential_id}"
+    def defer_potential(
+        potential_id: str,
+        reason: str,
+        missing_evidence: list[str] | None = None,
+        **_: object,
+    ) -> str:
+        for index, potential in enumerate(ctx.potentials):
+            if potential.get("id") != potential_id:
+                continue
+            resolved = ctx.potentials.pop(index)
+            resolved["status"] = "unresolved"
+            resolved["deferred_reason"] = reason
+            resolved["missing_evidence"] = missing_evidence or []
+            ctx.potential_history.append(resolved)
+            return f"Deferred potential [{potential_id}] as unresolved: {reason}"
+        return f"No potential found with id={potential_id}"
 
     return [
         NativeToolSpec(
             name="flag_potential",
             description=(
-                "Call this the moment you see something suspicious while reading code — "
-                "before moving on to the next file or function. "
-                "Adds the line to an investigation queue so cross-file asymmetries stay "
-                "visible even after you've read many more files. "
-                "Do NOT defer flagging until you have a complete trace — flag early, "
-                "then keep reading. A potential is not a finding: you are saying "
-                "'this is worth coming back to', not 'this is definitely a bug'. "
-                "Example trigger: you see a function call a core operation (encrypt, free, write) "
-                "without the setup call (set_iv, null-check, bounds-check) that peer callers use."
+                "Bookmark a concrete security hypothesis immediately, before extended "
+                "verification. Requires only file, line, and hypothesis. Flagging is not "
+                "a claim that the issue is confirmed. Add the invariant map when known: "
+                "boundary, attacker inputs, required relationships, observed checks, and "
+                "checks that appear missing. Classify the direct impact and novelty so the "
+                "queue can prioritize the lead without benchmark-specific knowledge."
             ),
             schema=FlagPotentialInput.model_json_schema(),
             handler=flag_potential,
         ),
         NativeToolSpec(
-            name="get_potentials",
+            name="update_potential",
             description=(
-                "Return all open potentials in the investigation queue. "
-                "Call this: (1) before deciding what file to read next — the queue "
-                "may already point at the right place; (2) after reading several files "
-                "to compare leads side by side for asymmetries; (3) before concluding "
-                "the hunt to make sure no flagged lead was left uninvestigated."
+                "Update an active potential, reopen an unresolved historical potential, or "
+                "close an active potential as unresolved. Complete its invariant map before "
+                "promotion. Reopening and closing require a reason. Use dismiss_potential—not "
+                "close—for a source-proven safe lead. Typed verification evidence recomputes "
+                "priority from impact, attacker control, reachability, guard behavior, impact "
+                "evidence, invariant completeness, and novelty."
             ),
-            schema={
-                "type": "object",
-                "properties": {},
-                "required": [],
-                "title": "GetPotentialsInput",
-            },
-            handler=get_potentials,
+            schema=UpdatePotentialInput.model_json_schema(),
+            handler=update_potential,
+        ),
+        NativeToolSpec(
+            name="defer_potential",
+            description=(
+                "Stop active verification while preserving an unresolved potential. "
+                "Use when the bounded sourcehunt budget is exhausted and later verification "
+                "must obtain specific missing evidence."
+            ),
+            schema=DeferPotentialInput.model_json_schema(),
+            handler=defer_potential,
         ),
         NativeToolSpec(
             name="dismiss_potential",
             description=(
-                "Remove a potential from the queue after ruling it out. "
-                "Call this when you have read enough context to confirm the suspicion "
-                "was a false positive. Requires a one-sentence reason so the decision "
-                "is traceable."
+                "Resolve a flagged potential as dismissed only after source evidence satisfies "
+                "one of its recorded disproof conditions. The dismissed lead remains in the "
+                "audit history. A validation check is sufficient disproof only when it dominates "
+                "every subsequent attacker-controlled mutation and every security-sensitive use "
+                "across all reachable states. Do not dismiss an inconclusive lead; defer it instead."
             ),
             schema=DismissPotentialInput.model_json_schema(),
             handler=dismiss_potential,

--- a/clearwing/agent/tools/hunt/reporting.py
+++ b/clearwing/agent/tools/hunt/reporting.py
@@ -15,12 +15,14 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import uuid
+from typing import Literal
 
 from pydantic import Field
 
 from clearwing.core.events import EventBus, EventType
-from clearwing.findings.types import TraceStep, VulnerabilityTrace
+from clearwing.findings.types import EvidenceLevel, Severity, TraceStep, VulnerabilityTrace
 from clearwing.llm import NativeToolSpec, ToolInputModel
 from clearwing.sourcehunt.instrumentation import stable_run_id
 from clearwing.sourcehunt.state import Finding
@@ -28,6 +30,80 @@ from clearwing.sourcehunt.state import Finding
 from .sandbox import HunterContext
 
 logger = logging.getLogger(__name__)
+
+FindingType = Literal[
+    "auth_bypass",
+    "authorization_bypass",
+    "buffer_overflow",
+    "code_injection",
+    "command_injection",
+    "crypto_weakness",
+    "cve_variant",
+    "denial_of_service",
+    "double_free",
+    "heap_overflow",
+    "info_leak",
+    "insecure_deserialization",
+    "integer_overflow",
+    "integer_underflow",
+    "logic_error",
+    "memory_safety",
+    "memory_safety_heap_overflow",
+    "nonce_reuse",
+    "oob",
+    "out_of_bounds_read",
+    "out_of_bounds_write",
+    "padding_oracle",
+    "parameter_validation",
+    "path_traversal",
+    "propagation_buffer_size",
+    "propagation_default",
+    "propagation_macro",
+    "propagation_sentinel",
+    "propagation_truncation",
+    "race_condition",
+    "signature_forgery",
+    "sql_injection",
+    "ssrf",
+    "stack_overflow",
+    "timing_side_channel",
+    "truncation",
+    "uaf",
+    "use_after_free",
+    "xss",
+    "xxe",
+    "other",
+]
+Confidence = Literal["high", "medium", "low"]
+
+_INVARIANT_MAP_FIELDS = (
+    "security_boundary",
+    "security_invariant",
+    "attacker_inputs",
+    "required_relationships",
+    "observed_checks",
+    "missing_checks",
+)
+
+
+def _tool_error(code: str, message: str) -> dict[str, object]:
+    return {"ok": False, "error": {"code": code, "message": message}}
+
+
+def _completed_invariant_potential(
+    ctx: HunterContext, file: str, potential_id: str = ""
+) -> dict | None:
+    """Return a same-file potential whose security-boundary map is complete."""
+    for potential in reversed(ctx.potentials):
+        if potential_id and potential.get("id") != potential_id:
+            continue
+        if str(potential.get("file", "")).removeprefix("/workspace/") != file.removeprefix(
+            "/workspace/"
+        ):
+            continue
+        if all(potential.get(field) for field in _INVARIANT_MAP_FIELDS):
+            return potential
+    return None
 
 
 class RecordTraceStepInput(ToolInputModel):
@@ -65,8 +141,8 @@ class CompatibilityTraceInput(ToolInputModel):
 class RecordFindingInput(ToolInputModel):
     file: str
     line_number: int
-    finding_type: str
-    severity: str
+    finding_type: FindingType
+    severity: Severity
     cwe: str = Field(
         default="",
         description=(
@@ -75,11 +151,15 @@ class RecordFindingInput(ToolInputModel):
         ),
     )
     description: str
+    potential_id: str = Field(
+        default="",
+        description="ID of the completed invariant-mapped potential being promoted.",
+    )
     code_snippet: str = ""
     crash_evidence: str = ""
     poc: str = ""
-    confidence: str = "medium"
-    evidence_level: str = "suspicion"
+    confidence: Confidence = "medium"
+    evidence_level: EvidenceLevel = "suspicion"
     crypto_protocol: str = ""
     algorithm: str = ""
     crypto_attack_class: str = ""
@@ -123,7 +203,10 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         # it would reject every trace step. Skip the guard in deep mode;
         # downstream validators independently re-verify the assembled trace.
         if ctx.agent_mode != "deep" and file not in ctx.files_read:
-            return f"ERROR: file '{file}' has not been read yet. Call read_source_file first."
+            return _tool_error(
+                "UNREAD_TRACE_SOURCE",
+                f"File '{file}' has not been read yet. Call read_source_file first.",
+            )
         step = TraceStep(
             file=file,
             line=line,
@@ -153,16 +236,7 @@ def build_reporting_tools(ctx: HunterContext) -> list:
             f" ({function})" if function else "",
             f" — {note[:120]}" if note else "",
         )
-        # Echo the full accumulated trace back into the conversation so the
-        # growing dataflow path stays part of the message sequence the model
-        # reasons over before calling record_finding.
-        lines = [f"Trace step {n} recorded. Trace so far ({n} step(s)):"]
-        for i, s in enumerate(ctx.trace_steps, 1):
-            loc = f"{s.file}:{s.line}"
-            fn = f" {s.function}()" if s.function else ""
-            note_str = f" — {s.note}" if s.note else ""
-            lines.append(f"  {i}. {loc}{fn}{note_str}")
-        return "\n".join(lines)
+        return f"Trace step {n} recorded."
 
     def record_finding(
         file: str,
@@ -170,6 +244,7 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         finding_type: str,
         severity: str,
         description: str,
+        potential_id: str = "",
         cwe: str = "",
         code_snippet: str = "",
         crash_evidence: str = "",
@@ -217,7 +292,10 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                 steps take precedence when present.
         """
         if isinstance(trace, str):
-            trace = json.loads(trace)
+            try:
+                trace = json.loads(trace)
+            except json.JSONDecodeError as exc:
+                return _tool_error("INVALID_TRACE_JSON", f"Invalid trace JSON ({exc}).")
         explicit_steps = trace.get("steps", []) if trace else []
         try:
             authoritative_steps = (
@@ -226,35 +304,61 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                 else [TraceStep(**step) for step in explicit_steps]
             )
             if not authoritative_steps:
-                return (
-                    "ERROR: record_finding requires at least one trace step. "
-                    "Call record_trace_step while reading the entry-to-sink path, "
-                    "or pass a compatibility trace."
+                return _tool_error(
+                    "MISSING_TRACE",
+                    "record_finding requires at least one trace step. Call "
+                    "record_trace_step while reading the entry-to-sink path, or "
+                    "pass a compatibility trace.",
+                )
+            notes = "\n".join(step.note for step in authoritative_steps)
+            missing_roles = [
+                role
+                for role in ("ENTRY", "SINK")
+                if re.search(rf"\b{role}\b", notes, re.IGNORECASE) is None
+            ]
+            if missing_roles:
+                return _tool_error(
+                    "INCOMPLETE_TRACE",
+                    "record_finding requires explicit ENTRY and SINK roles in trace "
+                    f"step notes; missing: {', '.join(missing_roles)}.",
                 )
             vuln_trace = VulnerabilityTrace(
                 steps=authoritative_steps,
                 summary=(trace or {}).get("summary", ""),
             )
         except Exception as exc:
-            return (
-                f"ERROR: invalid trace ({exc}). Each step needs at least "
-                "`file` and `line`; optional `function`, `code_snippet`, `note`."
+            return _tool_error(
+                "INVALID_TRACE",
+                f"Invalid trace ({exc}). Each step needs at least `file` and "
+                "`line`; optional `function`, `code_snippet`, `note`.",
             )
         trace_dict = vuln_trace.model_dump()
-        # Reset only after the authoritative steps are stored on the finding.
-        ctx.trace_steps.clear()
+
+        # Direct/legacy reporting callers may not use the potential queue. Once
+        # a hunt does use it, however, promotion must come from a same-file lead
+        # with an explicit security-contract map rather than a sink-only hunch.
+        promoted_potential = _completed_invariant_potential(ctx, file, potential_id)
+        if (ctx.require_invariant_map or ctx.potentials) and promoted_potential is None:
+            return _tool_error(
+                "INCOMPLETE_INVARIANT_MAP",
+                "Before record_finding, update a potential in this file with its security "
+                "boundary, security invariant, attacker inputs, required relationships, "
+                "observed checks, and missing checks. Pass potential_id when more than one "
+                "lead exists.",
+            )
 
         duplicate = next(
             (f for f in ctx.findings if f.file == file and f.line_number == line_number),
             None,
         )
         if duplicate is not None:
-            return (
+            return _tool_error(
+                "DUPLICATE_FINDING",
                 f"Finding at {file}:{line_number} was already recorded earlier "
                 f"in this session (finding_type={duplicate.finding_type!r}, "
                 f"severity={duplicate.severity!r}). Skipping this duplicate "
                 "call — if you have new information about a different issue, "
-                "record it at a different line instead of re-reporting this one."
+                "record it at a different line instead of re-reporting this one.",
             )
 
         stable_finding_id = stable_run_id(
@@ -300,6 +404,16 @@ def build_reporting_tools(ctx: HunterContext) -> list:
             extra=finding_metadata,
         )
         ctx.findings.append(finding)
+        if promoted_potential is not None:
+            ctx.potentials.remove(promoted_potential)
+            confirmed = dict(promoted_potential)
+            confirmed["status"] = "confirmed"
+            confirmed["finding_id"] = finding.id
+            ctx.potential_history.append(confirmed)
+        # Consume streamed trace evidence only after every validation and
+        # duplicate check succeeds. A rejected report must not destroy evidence
+        # intended for a later legitimate finding.
+        ctx.trace_steps.clear()
         EventBus().emit(
             EventType.FINDING_RECORDED,
             {
@@ -326,10 +440,9 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         NativeToolSpec(
             name="record_trace_step",
             description=(
-                "Record one step in a vulnerability trace. Call this AS YOU "
-                "READ CODE to build an incremental path from attacker input "
-                "to vulnerable sink. The code_snippet MUST be copied from a "
-                "prior read_source_file result."
+                "Record one source-backed step in a vulnerability trace from "
+                "attacker input to vulnerable sink. The code_snippet must be "
+                "copied from a prior source-reading tool result."
             ),
             schema=RecordTraceStepInput.model_json_schema(),
             handler=record_trace_step,

--- a/clearwing/agent/tools/hunt/sandbox.py
+++ b/clearwing/agent/tools/hunt/sandbox.py
@@ -51,8 +51,11 @@ class HunterContext:
     exploit_result: object | None = None  # ExploiterResult slot for exploit agent
     elaboration_result: object | None = None  # ElaborationResult slot for elaboration agent
     potentials: list[dict] = field(default_factory=list)  # investigation queue for flag_potential tool
+    potential_history: list[dict] = field(default_factory=list)  # resolved leads retained for audit
+    require_invariant_map: bool = False  # subsystem findings must promote a mapped potential
     callgraph: object | None = None  # CallGraph from preprocessor (avoiding circular import)
     subsystem: object | None = None  # SubsystemSpec; set for subsystem hunters only
+    llm: object | None = None  # AsyncLLMClient for sub-calls (threat context, etc.)
 
     def get_sandbox_for_variant(
         self,

--- a/clearwing/sourcehunt/reporter.py
+++ b/clearwing/sourcehunt/reporter.py
@@ -83,6 +83,7 @@ def write_sourcehunt_report(
     subsystem_stats: dict | None = None,
     pipeline_status: PipelineStatus | None = None,
     budget_summary: dict[str, Any] | None = None,
+    potentials: list[dict] | None = None,
     trace_id: str | None = None,
     run_started_at: str | None = None,
     run_ended_at: str | None = None,
@@ -155,6 +156,8 @@ def write_sourcehunt_report(
             }
         if budget_summary is not None:
             json_data["budget"] = budget_summary
+        if potentials:
+            json_data["potentials"] = potentials
         with open(json_path, "w", encoding="utf-8") as f:
             json.dump(json_data, f, indent=2, default=_json_default)
         paths["json"] = str(json_path)

--- a/tests/test_hunt_reporting_tools.py
+++ b/tests/test_hunt_reporting_tools.py
@@ -36,34 +36,106 @@ def _record_finding(tools, **overrides):
 
 def test_record_finding_requires_trace_step(tools):
     result = _record_finding(tools)
-    assert "requires at least one trace step" in result
+    assert result["error"]["code"] == "MISSING_TRACE"
 
 
 def test_record_finding_records_after_trace_step(tools, ctx):
-    tools["record_trace_step"](file="app.py", line=42, note="entry")
+    tools["record_trace_step"](
+        file="app.py", line=42, note="ENTRY/SINK: SQL reaches database execution"
+    )
     result = _record_finding(tools)
     assert "Finding recorded" in result
     assert len(ctx.findings) == 1
 
 
 def test_record_finding_rejects_exact_line_duplicate(tools, ctx):
-    tools["record_trace_step"](file="app.py", line=42, note="entry")
+    tools["record_trace_step"](file="app.py", line=42, note="ENTRY/SINK: first path")
     first = _record_finding(tools)
     assert "Finding recorded" in first
 
-    tools["record_trace_step"](file="app.py", line=42, note="entry again")
+    tools["record_trace_step"](file="app.py", line=42, note="ENTRY/SINK: entry again")
     second = _record_finding(tools, description="Differently worded but same bug.")
 
-    assert "already recorded" in second
+    assert second["error"]["code"] == "DUPLICATE_FINDING"
     assert len(ctx.findings) == 1  # the duplicate must NOT be appended
+    assert len(ctx.trace_steps) == 1  # rejected duplicate preserves accumulated evidence
 
 
 def test_record_finding_allows_different_lines(tools, ctx):
-    tools["record_trace_step"](file="app.py", line=42, note="entry")
+    tools["record_trace_step"](file="app.py", line=42, note="ENTRY/SINK: first path")
     _record_finding(tools, line_number=42)
 
-    tools["record_trace_step"](file="app.py", line=99, note="entry")
+    tools["record_trace_step"](file="app.py", line=99, note="ENTRY/SINK: second path")
     result = _record_finding(tools, line_number=99, description="A different bug entirely.")
 
     assert "Finding recorded" in result
     assert len(ctx.findings) == 2
+
+
+def test_record_finding_rejects_trace_without_entry_and_sink(tools, ctx):
+    tools["record_trace_step"](file="app.py", line=42, note="Relevant code")
+
+    result = _record_finding(tools)
+
+    assert result["error"]["code"] == "INCOMPLETE_TRACE"
+    assert len(ctx.findings) == 0
+    assert len(ctx.trace_steps) == 1
+
+
+def test_record_finding_requires_complete_invariant_map_for_flagged_lead(tools, ctx):
+    ctx.potentials.append(
+        {
+            "id": "lead-1",
+            "file": "app.py",
+            "line": 42,
+            "security_invariant": "Queries must keep user input out of SQL syntax.",
+        }
+    )
+    tools["record_trace_step"](
+        file="app.py", line=42, note="ENTRY/SINK: user input reaches SQL execution"
+    )
+
+    result = _record_finding(tools)
+
+    assert result["error"]["code"] == "INCOMPLETE_INVARIANT_MAP"
+    assert len(ctx.findings) == 0
+    assert len(ctx.trace_steps) == 1
+
+
+def test_record_finding_requires_mapped_potential_for_subsystem_hunt(tools, ctx):
+    ctx.require_invariant_map = True
+    tools["record_trace_step"](
+        file="app.py", line=42, note="ENTRY/SINK: user input reaches SQL execution"
+    )
+
+    result = _record_finding(tools)
+
+    assert result["error"]["code"] == "INCOMPLETE_INVARIANT_MAP"
+    assert len(ctx.findings) == 0
+
+
+def test_record_finding_accepts_complete_invariant_map(tools, ctx):
+    ctx.potentials.append(
+        {
+            "id": "lead-1",
+            "file": "app.py",
+            "line": 42,
+            "security_boundary": "database query execution",
+            "security_invariant": "Queries must keep user input out of SQL syntax.",
+            "attacker_inputs": ["user_id"],
+            "required_relationships": ["user_id must be passed as a bound parameter"],
+            "observed_checks": ["no parameter binding occurs"],
+            "missing_checks": ["no rejection or escaping before interpolation"],
+        }
+    )
+    tools["record_trace_step"](
+        file="app.py", line=42, note="ENTRY/SINK: user input reaches SQL execution"
+    )
+
+    result = _record_finding(tools)
+
+    assert "Finding recorded" in result
+    assert len(ctx.findings) == 1
+    assert ctx.potentials == []
+    assert ctx.potential_history[0]["status"] == "confirmed"
+    assert ctx.potential_history[0]["finding_id"] == ctx.findings[0].id

--- a/tests/test_potentials.py
+++ b/tests/test_potentials.py
@@ -1,0 +1,467 @@
+import jsonschema
+import pytest
+
+from clearwing.agent.tools.hunt.potentials import build_potential_tools
+from clearwing.agent.tools.hunt.sandbox import HunterContext
+
+
+def test_minimal_potential_can_be_enriched_incrementally(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+
+    tools["flag_potential"].invoke(
+        {
+            "file": "routers/private/hook_pre_receive.go",
+            "line": 62,
+            "hypothesis": "A read-only deploy key may reach a write-capable path.",
+            "priority": "high",
+        }
+    )
+    potential_id = ctx.potentials[0]["id"]
+
+    assert ctx.potentials[0]["security_invariant"] == ""
+    assert ctx.potentials[0]["open_questions"] == []
+    assert ctx.potentials[0]["note"] == ctx.potentials[0]["hypothesis"]
+
+    result = tools["update_potential"].invoke(
+        {
+            "potential_id": potential_id,
+            "observation": "The deploy-key ID is propagated into HookOptions.",
+            "security_invariant": "Read-only deploy keys must not authorize writes.",
+            "open_questions": ["Does proc-receive preserve the deploy-key mode?"],
+        }
+    )
+
+    assert "Updated" in result
+    assert ctx.potentials[0]["observations"] == [
+        "The deploy-key ID is propagated into HookOptions."
+    ]
+    assert ctx.potentials[0]["security_invariant"] == (
+        "Read-only deploy keys must not authorize writes."
+    )
+
+
+def test_defer_potential_preserves_missing_evidence(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/auth.go",
+            "line": 42,
+            "hypothesis": "A cached permission may cross resource boundaries.",
+        }
+    )
+    potential_id = ctx.potentials[0]["id"]
+
+    result = tools["defer_potential"].invoke(
+        {
+            "potential_id": potential_id,
+            "reason": "Dynamic reachability is not established.",
+            "missing_evidence": ["A request reaching both resources in one session"],
+        }
+    )
+
+    assert "Deferred potential" in result
+    assert ctx.potentials == []
+    assert ctx.potential_history[0]["status"] == "unresolved"
+    assert ctx.potential_history[0]["deferred_reason"] == (
+        "Dynamic reachability is not established."
+    )
+    assert ctx.potential_history[0]["missing_evidence"] == [
+        "A request reaching both resources in one session"
+    ]
+
+
+def test_dismiss_potential_preserves_auditable_ruled_out_lead(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+
+    result = tools["flag_potential"].invoke(
+        {
+            "file": "src/parser.c",
+            "line": 42,
+            "note": "length reaches memcpy",
+            "hypothesis": "CWE-787",
+            "security_invariant": "copy length must not exceed destination capacity",
+            "open_questions": ["Can an untrusted caller control the length?"],
+            "disproof_conditions": ["Every caller bounds the length before dispatch"],
+            "priority": "high",
+        }
+    )
+    potential_id = ctx.potentials[0]["id"]
+
+    assert "Queue: 1 unresolved" in result
+    assert ctx.potentials[0]["security_invariant"] == (
+        "copy length must not exceed destination capacity"
+    )
+    assert ctx.potentials[0]["verification"] == {
+        "attacker_control": "unknown",
+        "reachability": "unknown",
+        "guard_behavior": "unknown",
+        "impact": "unknown",
+    }
+
+    dismissed = tools["dismiss_potential"].invoke(
+        {
+            "potential_id": potential_id,
+            "resolution": "caller checks the length before dispatch",
+            "disproof_condition": "Every caller bounds the length before dispatch",
+            "evidence": ["src/caller.c:88 checks length <= sizeof(destination)"],
+        }
+    )
+
+    assert "ruled out" in dismissed
+    assert ctx.potentials == []
+    assert ctx.potential_history[0]["status"] == "safe"
+    assert ctx.potential_history[0]["resolution_evidence"] == [
+        "src/caller.c:88 checks length <= sizeof(destination)"
+    ]
+
+
+def test_dismissed_potential_cannot_be_dismissed_twice(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/parser.c",
+            "line": 42,
+            "note": "unclear bounds",
+            "hypothesis": "CWE-787",
+            "security_invariant": "copy length must be bounded",
+            "open_questions": ["Where is the length validated?"],
+            "disproof_conditions": ["All reachable callers validate the length"],
+        }
+    )
+    potential_id = ctx.potentials[0]["id"]
+    args = {
+        "potential_id": potential_id,
+        "resolution": "caller validates the length",
+        "disproof_condition": "All reachable callers validate the length",
+        "evidence": ["src/caller.c:88 validates the length"],
+    }
+
+    tools["dismiss_potential"].invoke(args)
+    result = tools["dismiss_potential"].invoke(args)
+
+    assert "No potential found" in result
+    assert ctx.potentials == []
+
+
+def test_potential_preserves_complete_security_invariant_map(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/verify.c",
+            "line": 90,
+            "hypothesis": "Digest metadata may not constrain verification.",
+            "security_boundary": "verify_signature",
+            "security_invariant": "Digest identity and length must agree.",
+            "attacker_inputs": ["signature", "digest", "digest length"],
+            "required_relationships": ["digest length matches digest OID"],
+            "observed_checks": ["signature integers are range checked"],
+            "missing_checks": ["no digest OID/length consistency check found"],
+        }
+    )
+
+    potential = ctx.potentials[0]
+    assert potential["security_boundary"] == "verify_signature"
+    assert potential["attacker_inputs"] == ["signature", "digest", "digest length"]
+    assert potential["required_relationships"] == ["digest length matches digest OID"]
+    assert potential["observed_checks"] == ["signature integers are range checked"]
+    assert potential["missing_checks"] == ["no digest OID/length consistency check found"]
+
+
+def test_dismissal_without_recorded_disproof_is_rejected(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/parser.c",
+            "line": 42,
+            "hypothesis": "length may exceed the destination",
+            "disproof_conditions": ["All callers validate the length"],
+        }
+    )
+
+    result = tools["dismiss_potential"].invoke(
+        {
+            "potential_id": ctx.potentials[0]["id"],
+            "resolution": "looks safe",
+            "disproof_condition": "No crash was observed",
+            "evidence": ["src/parser.c:42 looks safe"],
+        }
+    )
+
+    assert "not dismissed" in result
+    assert len(ctx.potentials) == 1
+    assert ctx.potential_history == []
+
+
+def test_dismiss_tool_requires_lifecycle_dominance_instructions(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+
+    description = tools["dismiss_potential"].description
+    assert "dominates every subsequent attacker-controlled mutation" in description
+    assert "every security-sensitive use" in description
+    assert "all reachable states" in description
+
+
+def test_malformed_potential_arguments_are_rejected_before_state_mutation(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+
+    with pytest.raises(jsonschema.ValidationError, match="is not one of"):
+        tools["flag_potential"].invoke(
+            {
+                "file": "this",
+                "line": 18,
+                "note": "this",
+                "hypothesis": "x",
+                "security_invariant": "authorization must remain scoped to the resource",
+                "open_questions": ["Is the input attacker controlled?"],
+                "disproof_conditions": ["The input is assigned by trusted server code"],
+                "priority": "0</parameter>\n</invoke>\n",
+            }
+        )
+
+    assert ctx.potentials == []
+
+
+def test_potentials_are_ranked_by_typed_impact_and_evidence(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/allocate.c",
+            "line": 10,
+            "hypothesis": "A large allocation may exhaust memory.",
+            "impact_class": "resource_exhaustion",
+            "novelty": "distinct",
+            "security_invariant": "Untrusted sizes must be bounded.",
+            "required_relationships": ["size <= configured limit"],
+            "missing_checks": ["No configured limit found"],
+        }
+    )
+    resource_id = ctx.potentials[0]["id"]
+    tools["update_potential"].invoke(
+        {
+            "potential_id": resource_id,
+            "attacker_control": "supported",
+            "reachability": "supported",
+            "guard_behavior": "supported",
+            "impact": "supported",
+        }
+    )
+
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/copy.c",
+            "line": 20,
+            "hypothesis": "A copy extent may exceed the live destination.",
+            "impact_class": "memory_corruption",
+            "novelty": "distinct",
+            "security_invariant": "Copy extent must fit the live destination.",
+            "required_relationships": ["copy_len <= destination_len"],
+            "missing_checks": ["No dominating extent check found"],
+        }
+    )
+
+    assert ctx.potentials[0]["file"] == "src/copy.c"
+    assert ctx.potentials[0]["priority_score"] > ctx.potentials[1]["priority_score"]
+    assert ctx.potentials[1]["id"] == resource_id
+
+
+def test_update_potential_recomputes_priority_from_verification_evidence(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/auth.c",
+            "line": 42,
+            "hypothesis": "Authorization may be scoped to the wrong resource.",
+            "impact_class": "authorization_bypass",
+        }
+    )
+    potential_id = ctx.potentials[0]["id"]
+    initial_score = ctx.potentials[0]["priority_score"]
+
+    tools["update_potential"].invoke(
+        {
+            "potential_id": potential_id,
+            "attacker_control": "supported",
+            "reachability": "supported",
+            "guard_behavior": "supported",
+            "impact": "supported",
+            "novelty": "distinct",
+        }
+    )
+
+    assert ctx.potentials[0]["priority_score"] == initial_score + 40
+    assert ctx.potentials[0]["priority"] == "high"
+
+
+def test_update_potential_reopens_an_unresolved_historical_lead(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/hash.c",
+            "line": 42,
+            "hypothesis": "Predictable hash state may enable collision flooding.",
+        }
+    )
+    potential_id = ctx.potentials[0]["id"]
+    tools["defer_potential"].invoke(
+        {
+            "potential_id": potential_id,
+            "reason": "Reachability is not established.",
+            "missing_evidence": ["A reachable weak-seed configuration"],
+        }
+    )
+
+    result = tools["update_potential"].invoke(
+        {
+            "potential_id": potential_id,
+            "action": "reopen",
+            "reason": "A supported configuration reaches the weak-seed path.",
+            "observation": "src/config.h:19 enables the fallback on the supported target.",
+            "reachability": "supported",
+        }
+    )
+
+    assert "Reopened" in result
+    assert ctx.potential_history == []
+    assert ctx.potentials[0]["id"] == potential_id
+    assert ctx.potentials[0]["status"] == "examined"
+    assert ctx.potentials[0]["verification"]["reachability"] == "supported"
+    assert ctx.potentials[0]["reopen_events"][0]["previous_deferred_reason"] == (
+        "Reachability is not established."
+    )
+
+
+def test_update_potential_closes_active_lead_as_unresolved(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/parser.c",
+            "line": 88,
+            "hypothesis": "A parser length may reach a copy unchecked.",
+        }
+    )
+    potential_id = ctx.potentials[0]["id"]
+
+    result = tools["update_potential"].invoke(
+        {
+            "potential_id": potential_id,
+            "action": "close",
+            "reason": "The remaining caller evidence is outside this bounded hunt.",
+            "missing_evidence": ["Caller validation at dispatch"],
+        }
+    )
+
+    assert "Closed potential" in result
+    assert ctx.potentials == []
+    assert ctx.potential_history[0]["status"] == "unresolved"
+    assert ctx.potential_history[0]["missing_evidence"] == [
+        "Caller validation at dispatch"
+    ]
+
+
+def test_flag_potential_returns_existing_active_duplicate(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+    args = {
+        "file": "src/jv.c",
+        "line": 1217,
+        "hypothesis": "A predictable hash seed permits colliding keys and quadratic lookup.",
+        "security_boundary": "Object construction from untrusted keys.",
+        "security_invariant": "Hash bucket distribution must resist attacker concentration.",
+    }
+    tools["flag_potential"].invoke(args)
+    potential_id = ctx.potentials[0]["id"]
+
+    duplicate = tools["flag_potential"].invoke(args)
+
+    assert duplicate["ok"] is False
+    assert duplicate["error"]["code"] == "POTENTIAL_ALREADY_EXISTS"
+    assert duplicate["error"]["potential_id"] == potential_id
+    assert duplicate["error"]["status"] == "open"
+    assert len(ctx.potentials) == 1
+
+
+def test_flag_potential_returns_existing_unresolved_duplicate(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+    args = {
+        "file": "src/jv.c",
+        "line": 1217,
+        "hypothesis": "A predictable hash seed permits colliding keys and quadratic lookup.",
+        "security_boundary": "Object construction from untrusted keys.",
+        "security_invariant": "Hash bucket distribution must resist attacker concentration.",
+    }
+    tools["flag_potential"].invoke(args)
+    potential_id = ctx.potentials[0]["id"]
+    tools["defer_potential"].invoke(
+        {"potential_id": potential_id, "reason": "Reachability remains unknown."}
+    )
+
+    duplicate = tools["flag_potential"].invoke(args)
+
+    assert duplicate["error"]["code"] == "POTENTIAL_ALREADY_EXISTS"
+    assert duplicate["error"]["potential_id"] == potential_id
+    assert duplicate["error"]["status"] == "unresolved"
+    assert ctx.potentials == []
+    assert len(ctx.potential_history) == 1
+
+
+def test_flag_potential_detects_paraphrased_historical_duplicate(tmp_path) -> None:
+    ctx = HunterContext(repo_path=str(tmp_path))
+    tools = {tool.name: tool for tool in build_potential_tools(ctx)}
+    tools["flag_potential"].invoke(
+        {
+            "file": "src/jv.c",
+            "line": 1217,
+            "hypothesis": (
+                "A predictable getpid and time hash seed lets attacker-chosen JSON keys "
+                "land in one bucket, making linear chain scans quadratic."
+            ),
+            "security_boundary": "Object construction from untrusted JSON keys.",
+            "security_invariant": "Hash distribution must be unpredictable to attackers.",
+            "attacker_inputs": ["JSON object keys"],
+            "required_relationships": ["seed remains unpredictable"],
+            "missing_checks": ["no bucket chain cap"],
+            "impact_class": "resource_exhaustion",
+        }
+    )
+    potential_id = ctx.potentials[0]["id"]
+    tools["defer_potential"].invoke(
+        {"potential_id": potential_id, "reason": "Practical reachability is unknown."}
+    )
+
+    duplicate = tools["flag_potential"].invoke(
+        {
+            "file": "src/jv.c",
+            "line": 1217,
+            "hypothesis": (
+                "Weak fallback hash seeding permits adversarial JSON keys to concentrate "
+                "in the same bucket and trigger quadratic object construction."
+            ),
+            "security_boundary": "Parsing attacker-controlled keys into an object.",
+            "security_invariant": (
+                "Bucket distribution must resist attacker concentration and long chains."
+            ),
+            "attacker_inputs": ["attacker-controlled JSON key strings"],
+            "required_relationships": ["hash seed cannot be predicted"],
+            "missing_checks": ["bucket chains have no length limit"],
+            "impact_class": "resource_exhaustion",
+        }
+    )
+
+    assert duplicate["error"]["code"] == "POTENTIAL_ALREADY_EXISTS"
+    assert duplicate["error"]["potential_id"] == potential_id
+    assert len(ctx.potential_history) == 1

--- a/tests/test_sourcehunt_potential_reporting.py
+++ b/tests/test_sourcehunt_potential_reporting.py
@@ -1,0 +1,74 @@
+import json
+from pathlib import Path
+
+from clearwing.sourcehunt.reporter import write_sourcehunt_report
+
+
+def test_json_report_preserves_unresolved_potentials(tmp_path) -> None:
+    potentials = [
+        {
+            "id": "lead-1",
+            "file": "src/parser.c",
+            "line": 42,
+            "note": "unchecked length",
+            "hypothesis": "CWE-787",
+            "priority": "high",
+        },
+    ]
+
+    paths = write_sourcehunt_report(
+        output_dir=str(tmp_path),
+        session_id="session",
+        repo_url="example/repo",
+        findings=[],
+        verified_findings=[],
+        spent_per_tier={"A": 0.0, "B": 0.0, "C": 0.0},
+        formats=["json"],
+        potentials=potentials,
+    )
+
+    report = json.loads(Path(paths["json"]).read_text(encoding="utf-8"))
+    assert report["potentials"] == potentials
+
+
+def test_json_report_omits_empty_potential_collection(tmp_path) -> None:
+    paths = write_sourcehunt_report(
+        output_dir=str(tmp_path),
+        session_id="session",
+        repo_url="example/repo",
+        findings=[],
+        verified_findings=[],
+        spent_per_tier={"A": 0.0, "B": 0.0, "C": 0.0},
+        formats=["json"],
+        potentials=[],
+    )
+
+    report = json.loads(Path(paths["json"]).read_text(encoding="utf-8"))
+    assert "potentials" not in report
+
+
+def test_json_report_includes_sourcehunt_trace_id(tmp_path, monkeypatch) -> None:
+    trace_id = "656901efba4302f09db3999290711fb0"
+    commit_sha = "a" * 40
+    monkeypatch.setenv("CLEARWING_COMMIT_SHA", commit_sha)
+    paths = write_sourcehunt_report(
+        output_dir=str(tmp_path),
+        session_id="session",
+        repo_url="example/repo",
+        findings=[],
+        verified_findings=[],
+        spent_per_tier={"A": 0.0, "B": 0.0, "C": 0.0},
+        formats=["json"],
+        trace_id=trace_id,
+        run_started_at="2026-08-26T12:00:00+00:00",
+        run_ended_at="2026-08-26T12:05:00+00:00",
+    )
+
+    report = json.loads(Path(paths["json"]).read_text(encoding="utf-8"))
+    assert report["trace_id"] == trace_id
+    assert report["clearwing"] == {
+        "version": "1.0.0",
+        "commit_sha": commit_sha,
+        "start-time": "2026-08-26T12:00:00+00:00",
+        "end-time": "2026-08-26T12:05:00+00:00",
+    }


### PR DESCRIPTION
## Summary

Fifth PR in the SourceHunt investigation stack.

- Models durable examined, unresolved, safe, and confirmed leads.
- Supports enrichment, reopening, deferral, dismissal, and confirmation.
- Returns structured duplicate and validation failures.
- Preserves trace evidence until finding validation succeeds.
- Serializes potential state in result artifacts.

## Validation

- 26 focused potential and reporting tests pass.
- Ruff passes.
- `git diff --check` passes.

## PR stack

1. #168 — Evaluation harness and run provenance
2. #169 — Remove Semgrep from deep-agent tools
3. #170 — Structured tool-call diagnostics
4. #171 — Semantic navigation foundation
5. **#172 — Durable potential lifecycle (this PR)**
6. #173 — Investigation policy and orchestration

Depends on #171. Supersedes the relevant portion of #160.
