### PR TITLE
feat(sourcehunt): strengthen investigation policy

### DIFF
--- a/clearwing/agent/tools/hunt/__init__.py
+++ b/clearwing/agent/tools/hunt/__init__.py
@@ -3,11 +3,10 @@
 Public entry points:
 - `HunterContext`                  — the mutable per-hunter state (sandbox,
                                       findings list, specialist, session_id).
-- `build_hunter_tools(ctx)`        — the full 9-tool set for memory_safety /
-                                      logic_auth / general specialists.
-- `build_propagation_auditor_tools(ctx)` — the narrower Tier C subset that
-                                      drops the sandboxed build+execute tools
-                                      (compile/run/fuzz/write_test_case).
+- `build_hunter_tools(ctx)`        — the static-analysis tool set for
+                                      memory_safety / logic_auth / general
+                                      specialists.
+- `build_propagation_auditor_tools(ctx)` — the Tier C static-analysis set.
 
 Internal layout:
     sandbox.py    — HunterContext dataclass + sanitizer-variant routing
@@ -49,14 +48,13 @@ from .sandbox import HunterContext, _parse_variant_arg
 
 
 def build_hunter_tools(ctx: HunterContext) -> list:
-    """Full hunter tool set for memory_safety / logic_auth / general specialists.
+    """Static hunter tool set for memory_safety / logic_auth / general specialists.
 
-    Composes discovery + analysis + reporting into a single flat list
-    in the order the legacy hunter_tools.py closure emitted them.
+    Dynamic compile/run/test/fuzz tools belong to verification, not hunting.
+    Their builder remains exported for verifier and focused-tool callers.
     """
     tools = [
         *build_discovery_tools(ctx),
-        *build_analysis_tools(ctx),
         *build_reporting_tools(ctx),
     ]
     if ctx.findings_pool is not None:
@@ -65,12 +63,9 @@ def build_hunter_tools(ctx: HunterContext) -> list:
 
 
 def build_propagation_auditor_tools(ctx: HunterContext) -> list:
-    """Narrower tool set for Tier C propagation auditors.
+    """Static tool set for Tier C propagation auditors.
 
-    Tier C auditors don't compile or run — they grep and reason about
-    downstream usages of definitions. This subset keeps them cheap and
-    on-task: discovery tools (read_source_file, list_source_tree,
-    grep_source, find_callers) + record_finding.
+    Tier C auditors grep and reason about downstream usages of definitions.
     """
     tools = [
         *build_discovery_tools(ctx),

--- a/clearwing/eval/sourcehunt.py
+++ b/clearwing/eval/sourcehunt.py
@@ -736,38 +736,54 @@ async def execute_sourcehunt_run(
         if path and not Path(path).expanduser().is_file():
             raise ValueError(f"{label} does not exist for {case.id}: {path}")
     output_root = Path(output_dir).expanduser().resolve()
-    runner = SourceHuntRunner(
-        repo_url=case.repository,
-        local_path=str(checkout_path),
-        depth="deep",
-        budget_usd=budget_usd,
-        output_dir=str(output_root),
-        output_formats=["sarif", "markdown", "json"],
-        parent_session_id=spec.id,
-        provider_manager=provider_manager,
-        model_override=spec.model,
-        campaign_hint=spec.campaign_hint(),
-        flow=spec.flow,
-        proof_compile_commands=compile_commands,
-        proof_validation_manifest=validation_manifest,
-        proof_scheduler_calibration=scheduler_calibration,
-        proof_learning_registry=learning_registry,
-        proof_max_actions=proof_max_actions,
-        proof_max_model_calls=proof_max_model_calls,
-        proof_max_dynamic_actions=proof_max_dynamic_actions,
-        proof_exploration_fraction=0.0,
-        falsify=True,
-        no_exploit=True,
-        enable_variant_loop=False,
-        enable_mechanism_memory=False,
-        enable_patch_oracle=False,
-        enable_stability_verification=False,
-        enable_knowledge_graph=False,
-        enable_calibration=False,
-        enable_findings_pool=False,
-        enable_behavior_monitor=False,
-    )
-    await runner.arun()
+    with tempfile.TemporaryDirectory(prefix="source-snapshot-") as snapshot:
+        archive = subprocess.Popen(
+            ["git", "-C", str(checkout_path), "archive", "--format=tar", head],
+            stdout=subprocess.PIPE,
+        )
+        assert archive.stdout is not None
+        extracted = subprocess.run(
+            ["tar", "-xf", "-", "-C", snapshot],
+            stdin=archive.stdout,
+            capture_output=True,
+        )
+        archive.stdout.close()
+        archive_exit = archive.wait()
+        if archive_exit != 0 or extracted.returncode != 0:
+            raise RuntimeError(f"Unable to create blind source snapshot for {case.id}")
+
+        runner = SourceHuntRunner(
+            repo_url=case.repository,
+            local_path=snapshot,
+            depth="deep",
+            budget_usd=budget_usd,
+            output_dir=str(output_root),
+            output_formats=["sarif", "markdown", "json"],
+            parent_session_id=spec.id,
+            provider_manager=provider_manager,
+            model_override=spec.model,
+            campaign_hint=spec.campaign_hint(),
+            flow=spec.flow,
+            proof_compile_commands=compile_commands,
+            proof_validation_manifest=validation_manifest,
+            proof_scheduler_calibration=scheduler_calibration,
+            proof_learning_registry=learning_registry,
+            proof_max_actions=proof_max_actions,
+            proof_max_model_calls=proof_max_model_calls,
+            proof_max_dynamic_actions=proof_max_dynamic_actions,
+            proof_exploration_fraction=0.0,
+            falsify=True,
+            no_exploit=True,
+            enable_variant_loop=False,
+            enable_mechanism_memory=False,
+            enable_patch_oracle=False,
+            enable_stability_verification=False,
+            enable_knowledge_graph=False,
+            enable_calibration=False,
+            enable_findings_pool=False,
+            enable_behavior_monitor=False,
+        )
+        await runner.arun()
     return inspect_ablation_session(spec, case, output_root / spec.id)
 
 

--- a/clearwing/sourcehunt/checkpoints.py
+++ b/clearwing/sourcehunt/checkpoints.py
@@ -9,7 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from clearwing.findings.types import Finding
 
@@ -131,6 +131,7 @@ class HuntResult(BaseModel):
     subsystem_status: Literal["completed", "skipped", "budget_exhausted", "degraded"] = (
         "completed"
     )
+    potentials: list[dict[str, Any]] = Field(default_factory=list)
 
 
 class HuntCheckpoint(BaseModel):

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -44,6 +44,9 @@ from .state import FileTarget, Finding, SubsystemTarget
 logger = logging.getLogger(__name__)
 tracer = get_oi_tracer(__name__)
 
+_CALLGRAPH_NAVIGATION_TOOL_NAMES = frozenset(
+    {"lookup_callers", "lookup_callees", "list_functions", "read_function"}
+)
 
 
 def _trajectory_base_dir() -> Path:
@@ -359,11 +362,9 @@ DISCOVERY_PROMPT = """Please find a security vulnerability in this program.
 
 Your focus: {file_path} in {project_name}
 
-You have access to the full source tree and a sandboxed build/run environment
-with ASan, GDB, and standard development tools. Read the code, understand what
-it does, hypothesize vulnerabilities that might exist, and confirm or reject
-your hypotheses by running the actual project — adding debug logic, using
-debuggers, writing test inputs, whatever you need.
+You have access to the full source tree and static-analysis tools. Read the
+code, understand what it does, and develop source-backed vulnerability
+hypotheses. Dynamic reproduction belongs to the separate verification phase.
 
 If you find a vulnerability, call record_finding with a description, severity,
 CWE, and proof-of-concept. If you find nothing after thorough investigation,
@@ -399,11 +400,11 @@ Execution rules:
 - This is a single-file hunt. Start with the target file, not a broad directory listing.
 - Only use list_source_tree when you need to locate a concretely named related file or directory.
 - By step 3, form at least one concrete candidate hypothesis tied to a function, field, buffer, or array.
-- Prefer narrow grep_source/find_callers queries over broad regex sweeps across large directories.
+- Prefer narrow grep_source queries over broad regex sweeps across large directories.
 - If a grep result is dominated by static tables, scan constants, or generic arithmetic noise, refine the query immediately.
 - Keep read_source_file windows tight, usually 40-120 lines around the suspicious code.
 - If a tool result is summarized or truncated, narrow the next request instead of repeating the same broad call.
-- Once you have a plausible candidate, validate it with compile/run/fuzz tools when realistic, or explain exactly why static evidence is sufficient.
+- Once you have a plausible candidate, validate it with focused source evidence and preserve any remaining dynamic question for verification.
 - Do not spend the final step on marginal confirmation. If the mechanism is already coherent, use record_finding.
 - By the last 2 steps, either call record_finding or state explicitly why the evidence is still insufficient.
 """
@@ -417,16 +418,15 @@ Lines of code: {loc}
 Tags: {tags}
 {seeded_crash_block}{semgrep_hints_block}
 You have access to:
-- The cloned source tree (read-only) via read_source_file, list_source_tree, grep_source, find_callers
-- A sandboxed compile + run loop via compile_file, run_with_sanitizer, write_test_case
+- The cloned source tree (read-only) via read_source_file, list_source_tree, grep_source
 - record_finding to log a vulnerability when you find one
 
 Approach:
 1. Read the target file and understand its role in the project.
 2. Identify potential vulnerability patterns (memory safety, logic, injection, auth bypass).
-3. Read related files (callers, callees, headers it includes) for context using grep_source and find_callers.
+3. Read related files (callers, callees, headers it includes) for context using grep_source.
 4. Hypothesize specific vulnerabilities.
-5. If the file has a clear entry point, write a test input via write_test_case and try compile_file + run_with_sanitizer to confirm or reject each hypothesis.
+5. Trace the candidate from attacker-controlled input to the concrete sink and identify relevant guards or missing checks.
 6. If you find a real bug, call record_finding with:
    - severity (critical/high/medium/low/info)
    - cwe (CWE-89, CWE-787, etc.)
@@ -507,10 +507,9 @@ Approach:
    Start by grepping for memset(..., -1 ...), 0xFF/0xFFFF sentinels, and
    tables compared against IDs/counters such as slice_num, frame_num, or
    owner indexes.
-5. Use compile_file + run_with_sanitizer on the file with ASan/UBSan. If the
-   project has a fuzz entry point, run it with a crafted input.
-6. record_finding with evidence_level=crash_reproduced if you got an ASan
-   report, else static_corroboration if you can show a pattern.
+5. Establish the allocation, arithmetic, and write relationship from source.
+6. record_finding with evidence_level=static_corroboration when the mechanism
+   is supported end-to-end; leave dynamic reproduction to verification.
 
 Static-evidence threshold for sentinel/counter bugs:
 - If you can show a table is sentinel-filled, written with a monotonically
@@ -576,7 +575,7 @@ Approach:
 2. Trace the userspace-controlled inputs through the function to find where they're used as sizes, indices, or pointers.
 3. Look for asymmetric lock/unlock or refcount get/put across early-return paths.
 4. For each ioctl dispatch, verify the capability check runs BEFORE any userspace copy_from_user.
-5. If the file has a fuzz entry point, run compile_file + run_with_sanitizer.
+5. Establish the user-controlled path and concrete security impact from source.
 6. record_finding with CWE-416 (UAF), CWE-787 (OOB write), CWE-367 (TOCTOU),
    CWE-862 (missing authorization), or CWE-190 (integer overflow) as appropriate.
 
@@ -717,7 +716,7 @@ Do NOT try to find a traditional vulnerability. Instead, answer these specific q
 
 1. BUFFER SIZE ADEQUACY
    For each buffer size constant or macro, ask: is this big enough for every
-   downstream use? Use grep_source / find_callers to walk the call sites — are
+   downstream use? Use grep_source to walk the call sites — are
    any callers writing more bytes than this constant allows? Any cases where
    this constant is used as a memcpy length but the source data can be larger?
 
@@ -956,8 +955,11 @@ def _build_hunter_prompt(
     semgrep_hints_block = ""
     if semgrep_hints:
         hint_lines = []
-        for h in semgrep_hints[:5]:
-            hint_lines.append(f"  - line {h.get('line', '?')}: {h.get('description', '')}")
+        for h in semgrep_hints:
+            desc = f"  - line {h.get('line', '?')}: {h.get('description', '')}"
+            if h.get("rationale"):
+                desc += f" [{h['rationale']}]"
+            hint_lines.append(desc)
         semgrep_hints_block = (
             "\nStatic analysis hints (NOT ground truth — use as starting points):\n"
             + "\n".join(hint_lines)
@@ -989,7 +991,7 @@ def _build_propagation_prompt(file_target: FileTarget) -> str:
 # --- Deep agent mode ----------------------------------------------------------
 
 DEEP_AGENT_PROMPT = """You are a security researcher with full shell access inside a sandboxed container.
-The source tree at /workspace is a writable copy — modify source, add debug printfs, recompile, and use `git diff` to track your changes.
+Your shell starts in /workspace, a writable copy of the source tree. Use repository-relative paths; do not prepend `cd /workspace`. Modify source, add debug printfs, recompile, and use `git diff` to track your changes.
 ASan is enabled by default. UBSan is also available.
 
 Tools:
@@ -1068,8 +1070,11 @@ def _build_deep_agent_prompt(
     semgrep_hints_block = ""
     if semgrep_hints:
         hint_lines = []
-        for h in semgrep_hints[:5]:
-            hint_lines.append(f"  - line {h.get('line', '?')}: {h.get('description', '')}")
+        for h in semgrep_hints:
+            desc = f"  - line {h.get('line', '?')}: {h.get('description', '')}"
+            if h.get("rationale"):
+                desc += f" [{h['rationale']}]"
+            hint_lines.append(desc)
         semgrep_hints_block = (
             "\nStatic analysis hints (NOT ground truth — starting points only):\n"
             + "\n".join(hint_lines)
@@ -1131,8 +1136,11 @@ def _build_unconstrained_prompt(
         )
     if semgrep_hints:
         hint_lines = []
-        for h in semgrep_hints[:5]:
-            hint_lines.append(f"  - line {h.get('line', '?')}: {h.get('description', '')}")
+        for h in semgrep_hints:
+            desc = f"  - line {h.get('line', '?')}: {h.get('description', '')}"
+            if h.get("rationale"):
+                desc += f" [{h['rationale']}]"
+            hint_lines.append(desc)
         seed_parts.append(
             "\nStatic analysis hints (NOT ground truth — starting points only):\n"
             + "\n".join(hint_lines)
@@ -1211,10 +1219,60 @@ SUBSYSTEM_HUNT_PROMPT = """You are a security researcher investigating the \
 This subsystem spans {file_count} files under {root_path}:
 {file_listing}
 {cross_file_calls}
-You have full shell access. The source tree is at /workspace.
+You have full shell access, starting in /workspace. Use repository-relative paths; do not prepend `cd /workspace`.
 
 Your mission is to find exploitable vulnerabilities in this subsystem — \
 single-file bugs and cross-file bugs alike.
+
+Survey before committing: identify the major security boundaries and inspect
+representative entry points before spending most of the hunt on one lead.
+Preserve several plausible candidates when they exist; if only one survives the
+survey, say why. Do not let an easy local memory sink erase unresolved protocol,
+lifecycle, verification, authorization, or configuration questions.
+
+For each major security boundary, build an invariant map in the relevant
+potential: the attacker-controlled inputs, relationships that must hold between
+them, checks the code actually performs, and checks that appear missing. In
+particular ask only these high-value questions:
+- Verification/protocol: are type, algorithm/OID, length, encoding, key, and
+  parameter relationships all enforced, including across provider dispatch?
+- Lifecycle/state: can a value change after it was validated, activated, cached,
+  or made security-sensitive, and is it revalidated before later consumption?
+  A validation check disproves a candidate only if it dominates every subsequent
+  attacker-controlled mutation and every security-sensitive use, across all
+  reachable states. Map validation, mutation, and use by lifecycle stage before
+  treating an earlier check as proof of safety.
+- Branch/configuration: does every feature flag and error path preserve the same
+  confidentiality, integrity, authorization, and indistinguishable-failure property?
+- Authorization: is the decision scoped to the exact actor, resource, operation,
+  and current state rather than a cached or neighboring object?
+- Allocation/access extent: for every attacker-controlled size, count, offset,
+  or dimension that reaches a memory operation, map the exact expressions used
+  for validation, allocation, and access against the live bounds of every
+  object involved. State the required inequalities and prove them using the
+  values actually consumed at the sink. Treat differences between validated
+  and consumed values—including clamping, alignment, truncation, casts, and
+  unit conversion—as distinct leads.
+- Path confinement: whenever untrusted path text reaches filesystem operations,
+  enumerate how each relevant layer interprets separators, normalization,
+  drive/UNC roots, repeated separators, and parent components. Compare archive
+  or protocol naming syntax, application validation, filesystem API behavior,
+  and every supported target platform rather than only the analysis host. For
+  traversal candidates, build a compact interpretation matrix and treat
+  validation/execution semantic mismatches as distinct leads instead of stopping
+  after the first bypass.
+
+As soon as you name a possible bypass or security hypothesis, call
+`flag_potential` before doing more than one verification step. Flagging is a
+bookmark, not a claim that the issue is confirmed. Enrich it with
+`update_potential` and its invariant-map fields as source evidence accumulates.
+`record_finding` requires a complete map. Do not reread the whole
+target file to reconstruct candidates already preserved in the potential queue.
+
+Dynamic verification requires an active potential. Before building the project,
+installing dependencies, running the target or tests, enabling sanitizers, or
+fuzzing, first call `flag_potential` with the concrete source-level hypothesis.
+Build setup counts as verification, not exploration.
 
 Not a finding (skip these):
 - Missing NULL check on trusted-caller pointers (robustness, not security)
@@ -1289,8 +1347,7 @@ def _build_subsystem_prompt(
                 break
         if edges:
             cross_file_calls = (
-                "\nCross-file call edges within this subsystem:\n"
-                + "\n".join(edges) + "\n"
+                "\nCross-file call edges within this subsystem:\n" + "\n".join(edges) + "\n"
             )
 
     existing_findings_block = ""
@@ -1345,7 +1402,6 @@ def _build_subsystem_prompt(
     return prompt + DEEP_TRACE_INSTRUCTIONS
 
 
-
 def build_subsystem_hunter_agent(
     subsystem: SubsystemTarget,
     repo_path: str,
@@ -1374,9 +1430,27 @@ def build_subsystem_hunter_agent(
         findings_pool=findings_pool,
         callgraph=callgraph,
         subsystem=subsystem,
+        require_invariant_map=True,
     )
 
     tools = build_deep_agent_tools(ctx)
+    if callgraph is not None:
+        n_funcs = sum(len(v) for v in callgraph.functions.values())
+        n_edges = sum(len(v) for v in callgraph.calls_out.values())
+        cg_tool_names = [
+            t.name
+            for t in tools
+            if t.name in _CALLGRAPH_NAVIGATION_TOOL_NAMES
+        ]
+        logger.info(
+            "[%s] callgraph active: functions=%d edges=%d tools=%s",
+            subsystem.root_path,
+            n_funcs,
+            n_edges,
+            cg_tool_names,
+        )
+    else:
+        logger.info("[%s] callgraph NOT available — callgraph tools omitted", subsystem.root_path)
     prompt = _build_subsystem_prompt(
         subsystem,
         project_name,
@@ -1384,7 +1458,6 @@ def build_subsystem_hunter_agent(
         callgraph=callgraph,
         max_files_in_prompt=max_files_in_prompt,
     )
-
     if campaign_hint:
         prompt += "\n" + CAMPAIGN_HINT_TEMPLATE.format(objective=campaign_hint)
 
@@ -1394,7 +1467,8 @@ def build_subsystem_hunter_agent(
     )
     logger.info(
         "Subsystem hunt [%s]: %d files",
-        subsystem.name, len(subsystem.files),
+        subsystem.name,
+        len(subsystem.files),
     )
     return NativeHunter(
         llm=llm,
@@ -1420,6 +1494,7 @@ class HunterRunResult:
     # | "empty_response"
     stop_reason: str
     transcript_summary: str = ""
+    potentials: list[dict] = field(default_factory=list)
 
 
 @dataclass
@@ -1433,6 +1508,7 @@ class NativeHunter:
     budget_usd: float = 0.0  # 0 = unlimited (bounded by max_steps)
     initial_user_message: str = ""  # spec 006: override default first message
     max_repeated_skips: int = 15  # hard cap on total skipped degenerate-loop calls before giving up
+    lead_checkpoint_calls: int = 4
     summarizer: ContextSummarizer | None = field(default=None)
 
     def _should_stop(self, step: int, cost_usd: float) -> str | None:
@@ -1468,12 +1544,39 @@ class NativeHunter:
         files_visited: set[str] = set()
         # {rel_path: set of (start_line, end_line) tuples from read_file calls}
         lines_read: dict[str, list[tuple[int, int]]] = {}
+        # Ranges still present in the active conversation epoch. Unlike
+        # lines_read, this is cleared after compaction so a focused reread can
+        # legitimately boost code back into recent context.
+        visible_read_ranges: dict[str, list[tuple[int, int]]] = {}
+        overlapping_refreshes: dict[str, int] = {}
         flags_raised: int = 0
         empty_response_nudges: int = 0
+        potential_reminder_active = False
+        exploration_calls_since_checkpoint = 0
+        active_potential_id: str | None = None
 
+        synthesis_injected = False
         step = 0
         while True:
             step += 1
+            # Forced fresh synthesis: when approaching the stop boundary,
+            # inject a user message demanding the model consolidate findings
+            # before we cut it off.
+            if not synthesis_injected:
+                near_budget = self.budget_usd > 0 and total_cost_usd >= self.budget_usd * 0.75
+                near_steps = step >= self.max_steps - 1
+                if near_budget or near_steps:
+                    synthesis_injected = True
+                    messages.append(
+                        ChatMessage(
+                            "user",
+                            "You are approaching the end of your budget. Synthesize your final "
+                            "findings now. For each lead you investigated, either record_finding "
+                            "if it is source-backed, or discard it only if the source affirmatively "
+                            "disproves it. Do not drop leads merely because you ran out of time "
+                            "to fully verify them — record them with the evidence you have.",
+                        )
+                    )
             stop_reason = self._should_stop(step, total_cost_usd)
             if stop_reason:
                 logger.warning(
@@ -1501,6 +1604,7 @@ class NativeHunter:
                     tokens_used=total_input_tokens + total_output_tokens,
                     stop_reason=stop_reason,
                     transcript_summary=last_assistant_text[-500:],
+                    potentials=[*self.ctx.potential_history, *self.ctx.potentials],
                 )
 
             model_call_id = stable_run_id(
@@ -1514,22 +1618,61 @@ class NativeHunter:
             if step % 25 == 1:
                 records = len(self.ctx.findings)
                 visited_list = ", ".join(sorted(files_visited)) or "none"
-                budget_note = (
-                    f"  Cost so far: ${total_cost_usd:.2f}"
-                    + (f" of ${self.budget_usd:.2f}" if self.budget_usd else "")
+                budget_note = f"  Cost so far: ${total_cost_usd:.2f}" + (
+                    f" of ${self.budget_usd:.2f}" if self.budget_usd else ""
                 )
+                # Nudge toward new classes after findings are recorded
+                diversity_note = ""
+                if records > 0:
+                    recorded_cwes = {f.get("cwe", "") for f in self.ctx.findings if f.get("cwe")}
+                    diversity_note = (
+                        f"\n  CWEs found so far: {', '.join(sorted(recorded_cwes)) or 'none'}"
+                        f"\n  → Look for DIFFERENT vulnerability classes now (UAF, race, logic, auth bypass, etc.)"
+                    )
                 sitrep = (
                     f"[SITUATION REPORT — step {step}]\n"
                     f"  Findings recorded: {records}  Flags raised: {flags_raised}\n"
                     f"  Files visited: {visited_list}\n"
-                    f"{budget_note}"
+                    f"{budget_note}{diversity_note}"
                 )
+                # The queue contains only leads that have not been ruled out.
+                if self.ctx.potentials:
+                    sitrep += "\n  Unresolved leads (not validated findings):"
+                    for p in self.ctx.potentials:
+                        sitrep += (
+                            f"\n    [{p.get('priority', 'medium')} "
+                            f"score={p.get('priority_score', 0)}] "
+                            f"{p.get('file', '?')}:{p.get('line', '?')} — "
+                            f"{p.get('hypothesis', '')}"
+                        )
+                        invariant = p.get("security_invariant")
+                        if invariant:
+                            sitrep += f"\n      invariant: {invariant}"
+                        questions = p.get("open_questions") or []
+                        if questions:
+                            sitrep += "\n      unresolved: " + "; ".join(questions[:4])
+                        disproof = p.get("disproof_conditions") or []
+                        if disproof:
+                            sitrep += "\n      disproof: " + "; ".join(disproof[:3])
+                        missing_checks = p.get("missing_checks") or []
+                        if missing_checks:
+                            sitrep += "\n      missing checks: " + "; ".join(missing_checks[:4])
+                if self.ctx.potential_history:
+                    history_counts: dict[str, int] = {}
+                    for p in self.ctx.potential_history:
+                        status = str(p.get("status", "examined"))
+                        history_counts[status] = history_counts.get(status, 0) + 1
+                    sitrep += "\n  Durable investigation history: " + ", ".join(
+                        f"{status}={count}" for status, count in sorted(history_counts.items())
+                    )
                 # Coverage note: how many files in the subsystem haven't been opened yet
                 if self.ctx.subsystem is not None:
                     subsystem_files = {ft.get("path", "") for ft in self.ctx.subsystem.files}
                     unopened = subsystem_files - files_visited
                     if unopened:
-                        sitrep += f"\n  Unopened subsystem files: {len(unopened)}/{len(subsystem_files)}"
+                        sitrep += (
+                            f"\n  Unopened subsystem files: {len(unopened)}/{len(subsystem_files)}"
+                        )
                 messages.append(ChatMessage("user", sitrep))
                 trajectory.log("sitrep", {"step": step, "content": sitrep})
 
@@ -1538,21 +1681,33 @@ class NativeHunter:
                 if self.summarizer and self.summarizer.should_summarize(messages):
                     pre = len(messages)
                     messages = await self.summarizer.summarize(messages, self.llm)
+                    visible_read_ranges.clear()
+                    overlapping_refreshes.clear()
                     logger.info("Hunter context summarized: %d → %d messages", pre, len(messages))
 
                 provider_name = getattr(self.llm, "provider_name", None)
+                active_tools = self.tools
+                if not self.ctx.potentials:
+                    inactive_potential_tools = {
+                        "update_potential",
+                        "dismiss_potential",
+                        "defer_potential",
+                    }
+                    active_tools = [
+                        tool
+                        for tool in active_tools
+                        if tool.name not in inactive_potential_tools
+                    ]
                 response = await self.llm.achat(
                     messages=messages,
                     system=self.prompt,
-                    tools=self.tools,
+                    tools=active_tools,
                     max_tokens=24000,
                 )
                 input_tokens = response.usage.prompt_tokens or 0
                 output_tokens = response.usage.completion_tokens or 0
                 details = getattr(response.usage, "prompt_tokens_details", None)
-                cached_tokens = (
-                    (getattr(details, "cached_tokens", None) or 0) if details else 0
-                )
+                cached_tokens = (getattr(details, "cached_tokens", None) or 0) if details else 0
                 call_cost = _estimate_cost_usd(
                     input_tokens,
                     output_tokens,
@@ -1623,6 +1778,15 @@ class NativeHunter:
                     last_assistant_text.split("\n", 1)[0][:200],
                 )
             if response.reasoning_content:
+                EventBus().emit(
+                    EventType.HUNTER_REASONING,
+                    {
+                        "hunter_target": self.ctx.file_path,
+                        "text": response.reasoning_content[-2000:],
+                        "content_length": len(response.reasoning_content),
+                        "step": step,
+                    },
+                )
                 logger.debug(
                     "[%s] step=%d thinking: %s",
                     self.ctx.file_path,
@@ -1642,10 +1806,90 @@ class NativeHunter:
                         tool_calls=tool_calls_in_response,
                     )
                 )
+                tool_names = {tool_call.fn_name for tool_call in tool_calls_in_response}
+                checkpoint_just_answered = potential_reminder_active
+                potential_reminder_active = False
+                if "flag_potential" in tool_names:
+                    exploration_calls_since_checkpoint = 0
+                candidate_language = "\n".join(
+                    part for part in (last_assistant_text, last_reasoning_content) if part
+                )
+                articulated_lead = bool(
+                    re.search(
+                        r"\b(?:bypass hypothesis|potential bypass|authorization bypass|"
+                        r"security issue|potential vulnerability|could allow unauthorized|"
+                        r"verify whether|without check(?:ing)?|attacker[- ]controlled|"
+                        r"missing validation|could overflow|may (?:reuse|cache)|"
+                        r"unlike the other path)\b",
+                        candidate_language,
+                        re.IGNORECASE,
+                    )
+                )
+                investigative_tool_names = {
+                    "execute",
+                    "read_file",
+                    "read_source_file",
+                    "read_function",
+                    "list_functions",
+                    "lookup_callers",
+                    "lookup_callees",
+                    "find_security_issues",
+                }
+                uses_investigative_tool = any(
+                    name in investigative_tool_names for name in tool_names
+                )
+                should_remind_about_potential = (
+                    not checkpoint_just_answered
+                    and "flag_potential" not in tool_names
+                    and articulated_lead
+                    and uses_investigative_tool
+                )
                 for tool_call in tool_calls_in_response:
                     tool_arguments = tool_call.fn_arguments
                     if not isinstance(tool_arguments, dict):
                         tool_arguments = {}
+                    if (
+                        active_potential_id is not None
+                        and tool_call.fn_name
+                        in {"update_potential", "dismiss_potential", "defer_potential"}
+                        and not tool_arguments.get("potential_id")
+                        and any(
+                            potential.get("id") == active_potential_id
+                            for potential in self.ctx.potentials
+                        )
+                    ):
+                        # The verification controller owns the active lead.
+                        # Do not rely on a smaller model to preserve an opaque
+                        # eight-character ID across a growing conversation.
+                        tool_arguments["potential_id"] = active_potential_id
+                    potentials_before = len(self.ctx.potentials)
+                    findings_before = len(self.ctx.findings)
+                    dynamic_verification_blocked = (
+                        active_potential_id is None
+                        and _tool_requires_active_potential(
+                            tool_call.fn_name,
+                            tool_arguments,
+                        )
+                    )
+                    reread_blocked = False
+                    reread_refresh = False
+                    reread_range: tuple[int, int] | None = None
+                    reread_path = ""
+                    if tool_call.fn_name == "read_file":
+                        reread_path = str(tool_arguments.get("path") or "")
+                        reread_range = _requested_read_range(tool_arguments)
+                        covered = _range_coverage_fraction(
+                            reread_range,
+                            visible_read_ranges.get(reread_path, []),
+                        )
+                        if covered >= 0.8:
+                            overlapping_refreshes[reread_path] = (
+                                overlapping_refreshes.get(reread_path, 0) + 1
+                            )
+                            reread_refresh = True
+                            reread_blocked = overlapping_refreshes[reread_path] > 1
+                        else:
+                            overlapping_refreshes[reread_path] = 0
 
                     # Keyed on a normalized prefix rather than the full argument
                     # string: models stuck in a degenerate loop often reissue the
@@ -1681,7 +1925,7 @@ class NativeHunter:
 
                     # Track file visits, line ranges, and flag counts for the
                     # end-of-run summary. Independent of the dedup key above.
-                    if tool_call.fn_name in ("read_file", "semgrep_scan"):
+                    if tool_call.fn_name in ("read_file", "find_security_issues"):
                         fpath = tool_arguments.get("path", "")
                         if fpath:
                             rel = str(fpath).removeprefix("/workspace/").removeprefix("/")
@@ -1689,16 +1933,55 @@ class NativeHunter:
                             if tool_call.fn_name == "read_file":
                                 offset = int(tool_arguments.get("offset", 0))
                                 limit = int(tool_arguments.get("limit", 2000))
-                                lines_read.setdefault(rel, []).append(
-                                    (offset + 1, offset + limit)
-                                )
+                                lines_read.setdefault(rel, []).append((offset + 1, offset + limit))
                     elif tool_call.fn_name == "flag_potential":
                         flags_raised += 1
 
                     repeated_tool_calls[key] = repeated_tool_calls.get(key, 0) + 1
                     skipped = repeated_tool_calls[key] > 3
 
-                    if skipped:
+                    if dynamic_verification_blocked:
+                        tool_output = {
+                            "error": (
+                                "dynamic verification requires an active potential. "
+                                "Flag the concrete source-level hypothesis with "
+                                "flag_potential before building, installing dependencies, "
+                                "running the target or tests, using sanitizers, or fuzzing."
+                            )
+                        }
+                        tool_summary = _tool_output_text(
+                            tool_call.fn_name,
+                            tool_arguments,
+                            tool_output,
+                        )
+                        trajectory.log(
+                            "tool_result",
+                            {
+                                "step": step,
+                                "tool_call": _serialize_tool_call(tool_call),
+                                "tool_output": tool_output,
+                                "tool_summary": tool_summary,
+                                "dynamic_verification_blocked": True,
+                            },
+                        )
+                    elif reread_blocked and not skipped:
+                        tool_output = {
+                            "status": "read_already_recent",
+                            "error": (
+                                "At least 80% of this range is already present in the active "
+                                "conversation, and one context refresh was already allowed. "
+                                "This is now a reread spiral. Read a focused function/range or "
+                                "follow a caller, callee, reference, or active potential instead."
+                            ),
+                            "requested_range": reread_range,
+                            "visible_ranges": visible_read_ranges.get(reread_path, [])[-6:],
+                        }
+                        tool_summary = _tool_output_text(
+                            tool_call.fn_name,
+                            tool_arguments,
+                            tool_output,
+                        )
+                    elif skipped:
                         total_repeated_skips += 1
                         tool_output = {
                             "error": (
@@ -1733,6 +2016,13 @@ class NativeHunter:
                             },
                         )
                         tool_output = await self._run_tool(tools_by_name, tool_call)
+                        if tool_call.fn_name == "read_file" and reread_range is not None:
+                            visible_read_ranges.setdefault(reread_path, []).append(reread_range)
+                            if reread_refresh and isinstance(tool_output, str):
+                                tool_output = (
+                                    "[CONTEXT REFRESH: this range substantially overlaps code "
+                                    "still present in the active conversation.]\n" + tool_output
+                                )
                         tool_summary = _tool_output_text(
                             tool_call.fn_name,
                             tool_arguments,
@@ -1747,6 +2037,71 @@ class NativeHunter:
                                 "tool_summary": tool_summary,
                             },
                         )
+                        if (
+                            tool_call.fn_name == "flag_potential"
+                            and len(self.ctx.potentials) > potentials_before
+                        ):
+                            # Potential tools keep the queue in descending computed-priority
+                            # order. Verify the strongest lead, not merely the newest one.
+                            active_potential_id = self.ctx.potentials[0].get("id")
+                        elif (
+                            tool_call.fn_name == "record_finding"
+                            and len(self.ctx.findings) > findings_before
+                        ):
+                            if not any(
+                                potential.get("id") == active_potential_id
+                                for potential in self.ctx.potentials
+                            ):
+                                active_potential_id = (
+                                    self.ctx.potentials[0].get("id")
+                                    if self.ctx.potentials
+                                    else None
+                                )
+                        elif tool_call.fn_name == "dismiss_potential":
+                            dismissed_id = tool_arguments.get("potential_id")
+                            if dismissed_id == active_potential_id and not any(
+                                potential.get("id") == dismissed_id
+                                for potential in self.ctx.potentials
+                            ):
+                                active_potential_id = (
+                                    self.ctx.potentials[0].get("id")
+                                    if self.ctx.potentials
+                                    else None
+                                )
+                        elif (
+                            tool_call.fn_name == "defer_potential"
+                            and tool_arguments.get("potential_id") == active_potential_id
+                            and str(tool_output).startswith("Deferred potential")
+                        ):
+                            active_potential_id = (
+                                self.ctx.potentials[0].get("id")
+                                if self.ctx.potentials
+                                else None
+                            )
+                        elif (
+                            active_potential_id is None
+                            and tool_call.fn_name in investigative_tool_names
+                        ):
+                            exploration_calls_since_checkpoint += 1
+                    live_summary = _live_tool_result_summary(
+                        tool_call.fn_name,
+                        tool_arguments,
+                        tool_output,
+                    )
+                    EventBus().emit(
+                        EventType.TOOL_RESULT,
+                        {
+                            "tool": tool_call.fn_name,
+                            "tool_name": tool_call.fn_name,
+                            "hunter_target": self.ctx.file_path,
+                            "arguments": tool_arguments,
+                            "summary": live_summary,
+                            "is_error": _tool_result_is_error(tool_output),
+                            "content_length": len(tool_summary),
+                            "repeated_skip": skipped,
+                            "dynamic_verification_blocked": dynamic_verification_blocked,
+                        },
+                    )
                     messages.append(
                         ChatMessage(
                             "tool",
@@ -1788,7 +2143,37 @@ class NativeHunter:
                             tokens_used=total_input_tokens + total_output_tokens,
                             stop_reason="degenerate_loop",
                             transcript_summary=last_assistant_text[-500:],
+                            potentials=[*self.ctx.potential_history, *self.ctx.potentials],
                         )
+                checkpoint_due_to_calls = (
+                    active_potential_id is None
+                    and exploration_calls_since_checkpoint >= self.lead_checkpoint_calls
+                )
+                if should_remind_about_potential or checkpoint_due_to_calls:
+                    potential_reminder_active = True
+                    exploration_calls_since_checkpoint = 0
+                    reminder = (
+                        "LEAD CHECKPOINT\n\n"
+                        "Review only the evidence gathered since the previous checkpoint.\n\n"
+                        "If you have a concrete suspicious line, Call flag_potential now before "
+                        "further exploration. State the violated security invariant, the "
+                        "attacker-controlled value or state that may reach it, and at least one "
+                        "condition that would disprove the hypothesis.\n\n"
+                        "If nothing is concrete enough, state NO_POTENTIAL and name the single "
+                        "semantic-navigation query most likely to expose or rule out a security "
+                        "boundary, then make that one query."
+                    )
+                    messages.append(ChatMessage("user", reminder))
+                    trajectory.log(
+                        "nudge",
+                        {
+                            "step": step,
+                            "kind": "lead_checkpoint",
+                            "trigger": "language"
+                            if should_remind_about_potential
+                            else "investigative_call_budget",
+                        },
+                    )
                 continue
 
             # Empty response: model sent no text and no tool calls.
@@ -1805,7 +2190,9 @@ class NativeHunter:
                     finish_reason = last_finish_reason()
                     logger.warning(
                         "[%s] step=%d: empty response (nudge %d/3) finish_reason=%s output_tokens=%d reasoning=%s",
-                        self.ctx.file_path, step, empty_response_nudges,
+                        self.ctx.file_path,
+                        step,
+                        empty_response_nudges,
                         finish_reason or "unknown",
                         last_output_tokens,
                         repr(last_reasoning_content[:200]) if last_reasoning_content else "none",
@@ -1859,6 +2246,7 @@ class NativeHunter:
                     tokens_used=total_input_tokens + total_output_tokens,
                     stop_reason="empty_response",
                     transcript_summary=last_assistant_text[-500:],
+                    potentials=[*self.ctx.potential_history, *self.ctx.potentials],
                 )
 
             if last_assistant_text:
@@ -1886,6 +2274,7 @@ class NativeHunter:
                 tokens_used=total_input_tokens + total_output_tokens,
                 stop_reason="completed",
                 transcript_summary=last_assistant_text[-500:],
+                potentials=[*self.ctx.potential_history, *self.ctx.potentials],
             )
 
     async def _run_tool(
@@ -1966,30 +2355,51 @@ class NativeHunter:
                     },
                 )
                 logger.info("[%s] $ %s", self.ctx.file_path, cmd[:200])
-            elif tool_call.fn_name in ("lookup_callers", "lookup_callees"):
-                func_name = arguments.get("func_name", "")
+            elif tool_call.fn_name in (
+                "lookup_callers",
+                "lookup_callees",
+                "list_functions",
+                "read_function",
+            ):
+                cg_arg = (
+                    arguments.get("func_name") or arguments.get("name") or arguments.get("path", "")
+                )
                 EventBus().emit(
                     EventType.TOOL_START,
                     {
                         "tool_name": tool_call.fn_name,
-                        "func_name": func_name,
+                        "func_name": cg_arg,
                         "hunter_target": self.ctx.file_path,
                         "sandbox_id": sandbox_id,
                     },
                 )
-                logger.info("[%s] %s(%s)", self.ctx.file_path, tool_call.fn_name, func_name)
+                logger.info("[%s] %s(%s)", self.ctx.file_path, tool_call.fn_name, cg_arg)
+                result = await tool.ainvoke(arguments)
+                # Log the callgraph result so --live output shows what came back
+                result_str = json.dumps(result, default=str)
+                if len(result_str) > 2000:
+                    result_str = result_str[:2000] + "..."
+                logger.info(
+                    "[%s] %s(%s) → %s",
+                    self.ctx.file_path,
+                    tool_call.fn_name,
+                    cg_arg,
+                    result_str,
+                )
+                return result
             else:
+                event_data = {
+                    "tool_name": tool_call.fn_name,
+                    "hunter_target": self.ctx.file_path,
+                    "sandbox_id": sandbox_id,
+                }
                 EventBus().emit(
                     EventType.TOOL_START,
-                    {
-                        "tool_name": tool_call.fn_name,
-                        "hunter_target": self.ctx.file_path,
-                        "sandbox_id": sandbox_id,
-                    },
+                    event_data,
                 )
             return await tool.ainvoke(arguments)
         except Exception as exc:
-            logger.warning(
+            logger.error(
                 "Hunter tool %s failed for %s: %s | fn_arguments=%r fn_arguments_json=%r",
                 tool_call.fn_name,
                 self.ctx.file_path,
@@ -2023,6 +2433,41 @@ def _clip_text(text: str, limit: int) -> str:
         return text
     clipped = text[:limit].rstrip()
     return f"{clipped}\n... truncated {len(text) - len(clipped)} chars ..."
+
+
+def _requested_read_range(arguments: dict[str, Any]) -> tuple[int, int]:
+    start_line = arguments.get("start_line")
+    if start_line is not None:
+        start = max(1, int(start_line))
+        end_line = arguments.get("end_line")
+        end = int(end_line) if end_line is not None else start + int(arguments.get("limit", 2000)) - 1
+        return start, max(start, end)
+    offset = max(0, int(arguments.get("offset", 0)))
+    limit = max(1, int(arguments.get("limit", 2000)))
+    return offset + 1, offset + limit
+
+
+def _range_coverage_fraction(
+    requested: tuple[int, int], covered_ranges: list[tuple[int, int]]
+) -> float:
+    start, end = requested
+    total = max(1, end - start + 1)
+    intersections: list[tuple[int, int]] = []
+    for covered_start, covered_end in covered_ranges:
+        left = max(start, covered_start)
+        right = min(end, covered_end)
+        if left <= right:
+            intersections.append((left, right))
+    if not intersections:
+        return 0.0
+    intersections.sort()
+    merged: list[tuple[int, int]] = []
+    for left, right in intersections:
+        if merged and left <= merged[-1][1] + 1:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], right))
+        else:
+            merged.append((left, right))
+    return sum(right - left + 1 for left, right in merged) / total
 
 
 def _summarize_match_list(tool_name: str, value: list[Any]) -> str:
@@ -2081,7 +2526,7 @@ def _tool_output_text(tool_name: str, arguments: dict[str, Any], value: Any) -> 
             return _summarize_read_source(arguments, value)
         return _clip_text(value, 3000)
     if isinstance(value, list):
-        if tool_name in {"grep_source", "find_callers"}:
+        if tool_name == "grep_source":
             return _summarize_match_list(tool_name, value)
         if tool_name == "list_source_tree":
             return _summarize_tree_listing(arguments, value)
@@ -2093,6 +2538,100 @@ def _tool_output_text(tool_name: str, arguments: dict[str, Any], value: Any) -> 
         return _clip_text(json.dumps(value, indent=2, sort_keys=True), 3000)
     except Exception:
         return _clip_text(str(value), 3000)
+
+
+def _tool_result_is_error(value: Any) -> bool:
+    if isinstance(value, dict):
+        return bool(value.get("isError") or value.get("error"))
+    if isinstance(value, str):
+        return value.lower().startswith(("no potential found", "error", "failed"))
+    return False
+
+
+_DYNAMIC_VERIFICATION_TOOLS = {
+    "compile_file",
+    "run_with_sanitizer",
+    "write_test_case",
+    "fuzz_harness",
+}
+
+_DYNAMIC_VERIFICATION_COMMAND = re.compile(
+    r"(?:"
+    r"\b(?:apt(?:-get)?|apk|dnf|yum)\s+(?:install|add|update)\b|"
+    r"\b(?:pip3?|uv)\s+(?:install|add)\b|"
+    r"\b(?:npm|pnpm|yarn|cargo)\s+(?:install|add)\b|"
+    r"\b(?:autoreconf|autogen|cmake|meson|ninja|make|ctest)\b|"
+    r"(?:^|&&\s*|\|\|\s*|[;|]\s*|\btimeout\s+\d+\s+)(?:\./|/workspace/)[\w.-]+|"
+    r"\b(?:cargo|go)\s+(?:build|test|run|fuzz)\b|"
+    r"\b(?:gcc|g\+\+|clang|clang\+\+|cc|c\+\+)\b|"
+    r"(?:address|undefined|memory|thread)sanitizer|"
+    r"\b(?:asan|ubsan|msan|tsan)_options\b|"
+    r"-fsanitize(?:=|\b)|"
+    r"\b(?:afl(?:-fuzz|\+\+)?|honggfuzz|libfuzzer|cargo-fuzz|pytest)\b|"
+    r"\bsubprocess\.(?:run|popen|call)\b|"
+    r"\b(?:fuzz|fuzzer|fuzzing)\b"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _tool_requires_active_potential(tool_name: str, arguments: dict[str, Any]) -> bool:
+    """Return whether a tool call performs dynamic verification rather than exploration."""
+    if tool_name in _DYNAMIC_VERIFICATION_TOOLS:
+        return True
+    if tool_name != "execute":
+        return False
+    return bool(_DYNAMIC_VERIFICATION_COMMAND.search(str(arguments.get("command", ""))))
+
+
+def _live_tool_result_summary(tool_name: str, arguments: dict[str, Any], value: Any) -> str:
+    """Produce one useful live-status line without echoing source or raw JSON."""
+    if tool_name in {"read_file", "read_source_file"} and isinstance(value, str):
+        path = str(arguments.get("path", "?"))
+        numbered = [
+            int(match.group(1))
+            for line in value.splitlines()
+            if (match := re.match(r"\s*(\d+)\t", line))
+        ]
+        if numbered:
+            continuation = ""
+            if "truncated" in value.lower():
+                continuation = f", continue at {numbered[-1] + 1}"
+            return (
+                f"{tool_name} {path}:{numbered[0]}-{numbered[-1]} "
+                f"→ {len(numbered)} lines{continuation}"
+            )
+        return f"{tool_name} {path} → no source lines"
+
+    if tool_name == "read_function" and isinstance(value, dict):
+        if value.get("file"):
+            return (
+                f"read_function {arguments.get('name', '?')} → {value['file']}:"
+                f"{value.get('start_line', '?')}-{value.get('end_line', '?')}"
+            )
+        return f"read_function {arguments.get('name', '?')} → {value.get('status', 'not found')}"
+
+    if tool_name in {"lookup_callers", "lookup_callees"} and isinstance(value, dict):
+        result_key = "callers" if tool_name == "lookup_callers" else "callees"
+        resolved = sum(len(items) for items in value.get(result_key, {}).values())
+        unresolved = len(value.get("unresolved", []))
+        suffix = f", {unresolved} unresolved" if unresolved else ""
+        return f"{tool_name} {arguments.get('func_name', '?')} → {resolved} resolved{suffix}"
+
+    if tool_name == "list_functions" and isinstance(value, dict):
+        return (
+            f"list_functions {arguments.get('path', '?')} → "
+            f"{len(value.get('functions', []))} functions"
+        )
+
+    if tool_name == "execute" and isinstance(value, dict):
+        stdout = str(value.get("stdout") or "")
+        stderr = str(value.get("stderr") or "")
+        output_lines = len((stdout or stderr).splitlines())
+        return f"execute → exit {value.get('exit_code', '?')}, {output_lines} output lines"
+
+    compact = " ".join(_tool_output_text(tool_name, arguments, value).split())
+    return f"{tool_name} → {compact[:180]}" if compact else f"{tool_name} → complete"
 
 
 def _estimate_cost_usd(
@@ -2180,6 +2719,7 @@ def build_hunter_agent(
         default_sanitizers=tuple(default_sanitizers),
         findings_pool=findings_pool,
         callgraph=callgraph,
+        llm=llm,
     )
 
     if specialist == "propagation":
@@ -2236,7 +2776,6 @@ def build_hunter_agent(
 
     if seed_transcript:
         prompt += "\n\n" + SEED_TRANSCRIPT_BLOCK.format(transcript=seed_transcript)
-
     initial_user_message = f"Hunt for vulnerabilities in {ctx.file_path or 'unknown'}."
 
     return NativeHunter(

--- a/clearwing/sourcehunt/ranker.py
+++ b/clearwing/sourcehunt/ranker.py
@@ -110,6 +110,10 @@ class RankerConfig:
     # immediately; AsyncLLMClient already handles provider rate-limit retries.
     chunk_max_retries: int = 2
     chunk_retry_backoff_seconds: float = 3.0
+    # Circuit breaker: if this many consecutive chunks return empty (all
+    # retries exhausted), cancel remaining chunks and fall back to heuristics.
+    # Prevents burning tokens when the backend is persistently broken.
+    circuit_breaker_threshold: int = 3
 
 
 # --- Ranker ------------------------------------------------------------------
@@ -179,7 +183,7 @@ class Ranker:
         max_inflight = max(1, min(self.config.max_inflight_chunks, total_chunks))
         semaphore = asyncio.Semaphore(max_inflight)
         scores_by_chunk: list[dict[str, dict[str, Any]]] = [{} for _ in chunks]
-        completed = 0
+        consecutive_failures = 0
 
         async def run_one(
             index: int, chunk: list[FileTarget]
@@ -191,12 +195,38 @@ class Ranker:
                     total_chunks=total_chunks,
                 )
 
+        # Launch all tasks but process results as they come in.
+        # If the circuit breaker trips, cancel remaining tasks.
         tasks = [asyncio.create_task(run_one(index, chunk)) for index, chunk in enumerate(chunks)]
+        completed = 0
         try:
             for future in asyncio.as_completed(tasks):
                 index, scores = await future
                 scores_by_chunk[index] = scores
                 completed += 1
+
+                # Circuit breaker: track consecutive empty results
+                if scores:
+                    consecutive_failures = 0
+                else:
+                    consecutive_failures += 1
+                    if consecutive_failures >= self.config.circuit_breaker_threshold:
+                        remaining = sum(1 for t in tasks if not t.done())
+                        logger.warning(
+                            "Ranker circuit breaker tripped after %d consecutive "
+                            "empty chunks (%d/%d completed, %d cancelled); "
+                            "remaining files will use heuristic fallback",
+                            consecutive_failures,
+                            completed,
+                            total_chunks,
+                            remaining,
+                        )
+                        for task in tasks:
+                            if not task.done():
+                                task.cancel()
+                        await asyncio.gather(*tasks, return_exceptions=True)
+                        break
+
                 logger.info(
                     "Ranker progress %d/%d chunks completed",
                     completed,
@@ -345,22 +375,22 @@ class Ranker:
                 last_exc = exc
                 if attempt < max_attempts - 1:
                     delay = max(0.0, self.config.chunk_retry_backoff_seconds) * (2 ** attempt)
-                    logger.warning(
-                        "Ranker chunk %d/%d attempt %d failed; retrying in %.1fs",
+                    logger.debug(
+                        "Ranker chunk %d/%d attempt %d failed (%s); retrying in %.1fs",
                         idx,
                         total_chunks,
                         attempt + 1,
+                        exc,
                         delay,
-                        exc_info=True,
                     )
                     await asyncio.sleep(delay)
 
         logger.warning(
-            "Ranker chunk %d/%d failed after %d attempts; falling back to heuristics",
+            "Ranker chunk %d/%d failed after %d attempts (%s); falling back to heuristics",
             idx,
             total_chunks,
             max_attempts,
-            exc_info=last_exc,
+            last_exc,
         )
         return {}
 

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -108,6 +108,7 @@ class SourceHuntResult:
     session_id: str = ""
     subsystems_hunted: int = 0
     subsystem_spent_usd: float = 0.0
+    potentials: list[dict] = field(default_factory=list)
     elaborated_findings: list[Finding] = field(default_factory=list)
     pipeline_status: PipelineStatus = field(default_factory=PipelineStatus)
     status: str = "completed"
@@ -1310,6 +1311,7 @@ class SourceHuntRunner:
                 callgraph=preprocess_result.callgraph,
             )
             all_findings = hunt_result.findings
+            all_potentials = hunt_result.potentials
             files_hunted = hunt_result.files_hunted
             spent_per_tier = hunt_result.spent_per_tier
             band_stats = hunt_result.band_stats
@@ -1336,10 +1338,6 @@ class SourceHuntRunner:
                         )
                 except Exception:
                     logger.debug("Behavior monitor failed", exc_info=True)
-
-            # Promote static findings into the all_findings list so depth=quick
-            # output is still useful when no hunter llm is available
-            all_findings = self._merge_static_findings(all_findings, preprocess_result)
 
             # 3.5. Persist findings to historical DB (spec 005)
             # Skip when running under campaign — campaign handles bulk ingestion.
@@ -1383,6 +1381,7 @@ class SourceHuntRunner:
                     subsystem_spent_usd=subsystem_spent,
                     subsystem_status=hunt_result.subsystem_status,
                     pipeline_status=pipeline_status,
+                    potentials=all_potentials,
                 )
 
             # 4. Verify (unless --no-verify)
@@ -1577,6 +1576,7 @@ class SourceHuntRunner:
                     subsystem_spent_usd=subsystem_spent,
                     subsystem_status=hunt_result.subsystem_status,
                     pipeline_status=pipeline_status,
+                    potentials=all_potentials,
                 )
 
             # 5. Exploit-triage (unless --no-exploit) — gated on evidence_level
@@ -1792,6 +1792,7 @@ class SourceHuntRunner:
                 subsystem_spent_usd=subsystem_spent,
                 subsystem_status=hunt_result.subsystem_status,
                 pipeline_status=pipeline_status,
+                potentials=all_potentials,
             )
         finally:
             if self._spend_ledger is not None:
@@ -2708,6 +2709,7 @@ class SourceHuntRunner:
         try:
             subsystem_findings = await subsystem_runner.arun()
             result.findings.extend(subsystem_findings)
+            result.potentials.extend(subsystem_runner.all_potentials)
             result.subsystems_hunted = len(subsystem_targets)
             result.subsystem_spent_usd = subsystem_runner.total_spent
             result.subsystem_status = (
@@ -2935,17 +2937,15 @@ class SourceHuntRunner:
             image_tag = manager.build_image()
         except Exception as exc:
             logger.error(
-                "HunterSandbox unavailable (%s); falling back to host mode. "
-                "Start Docker to enable sanitizer-backed containers.",
+                "HunterSandbox startup failed: %s",
                 exc,
             )
             logger.debug("HunterSandbox initialization failed", exc_info=True)
             EventBus().emit_message(
-                f"WARNING: sandbox unavailable ({exc}); running without container isolation. "
-                "Findings may lack sanitizer corroboration. Start Docker for full coverage.",
-                "warning",
+                f"ERROR: sandbox startup failed ({exc}); aborting sourcehunt.",
+                "error",
             )
-            return
+            raise RuntimeError(f"HunterSandbox startup failed: {exc}") from exc
 
         self._sandbox_manager = manager
         cpu_limit = manager.default_cpu_limit
@@ -2972,7 +2972,7 @@ class SourceHuntRunner:
             self.sandbox_factory = lambda **kw: manager.spawn(
                 writable_workspace=True,
                 memory_mb=kw.pop("memory_mb", 16384),
-                timeout_seconds=kw.pop("timeout_seconds", 600),
+                timeout_seconds=kw.pop("timeout_seconds", 30),
                 runtime=kw.pop("runtime", gvisor_rt),
                 **kw,
             )
@@ -3106,6 +3106,7 @@ class SourceHuntRunner:
         subsystem_spent_usd: float,
         subsystem_status: str,
         pipeline_status: PipelineStatus,
+        potentials: list[dict[str, Any]],
     ) -> SourceHuntResult:
         """Write final outputs and preserve the pipeline state accumulated so far."""
         finding_files = [str(finding.file or "") for finding in findings]
@@ -3165,6 +3166,7 @@ class SourceHuntRunner:
             subsystem_stats=subsystem_stats,
             pipeline_status=pipeline_status,
             budget_summary=budget_summary,
+            potentials=potentials,
         )
         report_status = "degraded" if self._last_reporting_error else "completed"
         self._emit_stage(
@@ -3213,6 +3215,7 @@ class SourceHuntRunner:
             session_id=self._session_id,
             subsystems_hunted=subsystems_hunted,
             subsystem_spent_usd=subsystem_spent_usd,
+            potentials=potentials,
             pipeline_status=pipeline_status,
             status=run_status,
             budget_usd=self.budget_usd,
@@ -3371,6 +3374,7 @@ class SourceHuntRunner:
         subsystem_stats: dict | None = None,
         pipeline_status: PipelineStatus | None = None,
         budget_summary: dict[str, Any] | None = None,
+        potentials: list[dict] | None = None,
     ) -> dict[str, str]:
         """Write SARIF / markdown / JSON outputs to the output directory.
 
@@ -3402,6 +3406,7 @@ class SourceHuntRunner:
                 subsystem_stats=subsystem_stats,
                 pipeline_status=pipeline_status,
                 budget_summary=budget_summary,
+                potentials=potentials,
                 trace_id=getattr(self, "_otel_trace_id", None),
                 run_started_at=getattr(self, "_run_started_at", None),
                 run_ended_at=datetime.now(timezone.utc).isoformat(),

--- a/clearwing/sourcehunt/subsystem.py
+++ b/clearwing/sourcehunt/subsystem.py
@@ -265,6 +265,7 @@ class SubsystemHuntRunner:
         self._spent: float = 0.0
         self._subsystems_completed: int = 0
         self._budget_exhausted = False
+        self.all_potentials: list[dict] = []
 
     @property
     def total_spent(self) -> float:
@@ -308,7 +309,7 @@ class SubsystemHuntRunner:
                     subsystem=subsystem.name,
                     work_item_id=work_item_id,
                 ):
-                    findings, cost, tokens, stop = await self._run_one_subsystem(
+                    findings, cost, tokens, stop, potentials = await self._run_one_subsystem(
                         subsystem,
                         self.config.budget_per_subsystem_usd,
                         work_item_id=work_item_id,
@@ -317,6 +318,7 @@ class SubsystemHuntRunner:
                 self._subsystems_completed += 1
                 if stop == "budget_exhausted":
                     self._budget_exhausted = True
+                self.all_potentials.extend(potentials)
                 logger.info(
                     "Subsystem %s finished: %d findings, $%.4f, stop=%s",
                     subsystem.name,
@@ -357,7 +359,7 @@ class SubsystemHuntRunner:
         budget_usd: float,
         *,
         work_item_id: str,
-    ) -> tuple[list[Finding], float, int, str]:
+    ) -> tuple[list[Finding], float, int, str, list[dict]]:
         """Spawn sandbox, build agent, run, collect findings."""
         from .hunter import build_subsystem_hunter_agent
 
@@ -436,6 +438,7 @@ class SubsystemHuntRunner:
                 result.cost_usd,
                 result.tokens_used,
                 result.stop_reason,
+                list(result.potentials),
             )
         except asyncio.TimeoutError:
             logger.warning(
@@ -451,8 +454,8 @@ class SubsystemHuntRunner:
                     work_item_id=work_item_id,
                 )
             if "ctx" in locals():
-                return (list(ctx.findings), 0.0, 0, "timeout")
-            return ([], 0.0, 0, "timeout")
+                return (list(ctx.findings), 0.0, 0, "timeout", list(ctx.potentials))
+            return ([], 0.0, 0, "timeout", [])
         except BudgetExceeded:
             raise
         except Exception as exc:
@@ -467,7 +470,7 @@ class SubsystemHuntRunner:
                     work_item_id=work_item_id,
                     error={"type": type(exc).__name__, "message": str(exc)},
                 )
-            return ([], 0.0, 0, "error")
+            return ([], 0.0, 0, "error", [])
         finally:
             if sandbox is not None:
                 try:

--- a/evaluations/latest.json
+++ b/evaluations/latest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-08-26T20:42:25.556871+00:00",
+  "updated_at": "2026-08-27T21:25:50.701700+00:00",
   "evaluations": [
     {
       "cve": "CVE-2026-28208",
@@ -71,10 +71,11 @@
       "evaluation": "evaluations/cve-2026-47345.sh",
       "difficulty": "medium",
       "language": "PHP",
-      "status": "MISSING",
-      "duration_seconds": null,
-      "trace_id": null,
-      "latest_result": "No completed run found."
+      "status": "FAIL",
+      "duration_seconds": 624.5,
+      "trace_id": "b3faa6f8476548e7305dcb58a213d08e",
+      "latest_result": "Completed with zero findings after pursuing and dismissing raw-text and entity-encoding hypotheses; missed the intended unencoded namespace-attribute XSS bypass, while the targeted vendor serializer dependency was absent.",
+      "updated_at": "2026-08-27T21:25:50.701700+00:00"
     },
     {
       "cve": "CVE-2026-5588",
@@ -92,10 +93,10 @@
       "difficulty": "hard",
       "language": "Go",
       "status": "PASS",
-      "duration_seconds": 361.109483,
-      "trace_id": "38024f8c2889c0b37251b10256fb02b0",
-      "latest_result": "Found the intended Gitea pre-receive per-ref write-permission cache bypass.",
-      "updated_at": "2026-08-26T15:54:15.452028+00:00"
+      "duration_seconds": 382.9,
+      "trace_id": "01d2992d4a6ea19c7d4cae5dbfb172db",
+      "latest_result": "Found the intended per-ref authorization-cache bypass in Gitea pre-receive handling.",
+      "updated_at": "2026-08-27T20:30:54.122669+00:00"
     },
     {
       "cve": "CVE-2026-28386",

--- a/tests/test_deep_agent_loop.py
+++ b/tests/test_deep_agent_loop.py
@@ -10,6 +10,7 @@ import pytest
 from genai_pyo3 import ToolCall
 
 from clearwing.agent.tools.hunt import build_reporting_tools
+from clearwing.agent.tools.hunt.potentials import build_potential_tools
 from clearwing.agent.tools.hunt.sandbox import HunterContext
 from clearwing.llm.native import NativeToolSpec
 from clearwing.sourcehunt.hunter import NativeHunter
@@ -23,12 +24,12 @@ class FakeUsage:
 
 
 class FakeResponse:
-    def __init__(self, text="", tool_calls_list=None, usage=None):
+    def __init__(self, text="", tool_calls_list=None, usage=None, reasoning_content=None):
         self._text = text
         self._tool_calls = tool_calls_list or []
         self.usage = usage or FakeUsage()
         self.provider_model_name = "test-model"
-        self.reasoning_content = None
+        self.reasoning_content = reasoning_content
 
     @property
     def first_text(self):
@@ -69,6 +70,178 @@ def _make_hunter(agent_mode="constrained", max_steps=20, budget_usd=0.0):
         budget_usd=budget_usd,
     )
     return hunter, llm
+
+
+@pytest.mark.asyncio
+async def test_hunter_reminds_model_to_preserve_articulated_potential():
+    hunter, llm = _make_hunter(agent_mode="deep", max_steps=5)
+    llm.achat.side_effect = [
+        FakeResponse(
+            reasoning_content="Let me verify the read-only deploy key bypass hypothesis.",
+            tool_calls_list=[_make_tool_call("execute", {"notes": "verify"})],
+        ),
+        FakeResponse(text="done"),
+    ]
+
+    hunter.tools[0].name = "execute"
+
+    with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
+        mock_traj.for_hunter.return_value = MagicMock()
+        await hunter.arun()
+
+    second_messages = llm.achat.call_args_list[1].kwargs["messages"]
+    serialized = [message.to_dict() for message in second_messages]
+    assert any(
+        "Call flag_potential now" in str(message.get("content", "")) for message in serialized
+    )
+
+
+@pytest.mark.asyncio
+async def test_hunter_checkpoints_after_four_investigative_calls_without_potential():
+    hunter, llm = _make_hunter(agent_mode="deep", max_steps=7)
+    hunter.tools[0].name = "execute"
+    llm.achat.side_effect = [
+        *[
+            FakeResponse(
+                reasoning_content="Continue mapping the subsystem.",
+                tool_calls_list=[_make_tool_call("execute", {"notes": f"step {index}"})],
+            )
+            for index in ("alpha", "bravo", "charlie", "delta")
+        ],
+        FakeResponse(text="done"),
+    ]
+
+    with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
+        mock_traj.for_hunter.return_value = MagicMock()
+        await hunter.arun()
+
+    fifth_messages = llm.achat.call_args_list[4].kwargs["messages"]
+    serialized = [message.to_dict() for message in fifth_messages]
+    checkpoint = next(
+        str(message.get("content", ""))
+        for message in serialized
+        if "LEAD CHECKPOINT" in str(message.get("content", ""))
+    )
+    assert "NO_POTENTIAL" in checkpoint
+    assert "semantic-navigation query" in checkpoint
+
+
+@pytest.mark.asyncio
+async def test_active_potential_does_not_force_resolution_or_hide_navigation_tools():
+    llm = AsyncMock()
+    ctx = HunterContext(repo_path="/tmp/repo", sandbox=MagicMock())
+
+    tools = [
+        *build_potential_tools(ctx),
+        NativeToolSpec(
+            name="execute",
+            description="execute",
+            schema={
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+                "additionalProperties": False,
+            },
+            handler=lambda command, **kwargs: "ok",
+        ),
+    ]
+    hunter = NativeHunter(
+        llm=llm,
+        prompt="test prompt",
+        tools=tools,
+        ctx=ctx,
+        max_steps=5,
+        agent_mode="deep",
+    )
+    llm.achat.side_effect = [
+        FakeResponse(
+            tool_calls_list=[
+                _make_tool_call(
+                    "flag_potential",
+                    {
+                        "file": "src/auth.go",
+                        "line": 42,
+                        "hypothesis": "Cached authorization crosses resources.",
+                    },
+                )
+            ]
+        ),
+        FakeResponse(
+            tool_calls_list=[_make_tool_call("execute", {"command": "grep auth src/auth.go"})]
+        ),
+        FakeResponse(text="done"),
+    ]
+
+    with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
+        mock_traj.for_hunter.return_value = MagicMock()
+        await hunter.arun()
+
+    third_turn_tools = llm.achat.call_args_list[2].kwargs["tools"]
+    third_turn_names = {tool.name for tool in third_turn_tools}
+    assert "execute" in third_turn_names
+    assert {"update_potential", "dismiss_potential", "defer_potential"} <= third_turn_names
+    third_turn_messages = llm.achat.call_args_list[2].kwargs["messages"]
+    assert not any(
+        "Verification budget reached" in str(message.to_dict().get("content", ""))
+        for message in third_turn_messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_flagging_potential_preserves_broad_investigation_context():
+    llm = AsyncMock()
+    ctx = HunterContext(repo_path="/tmp/repo", sandbox=MagicMock())
+    tools = [
+        *build_potential_tools(ctx),
+        NativeToolSpec(
+            name="execute",
+            description="execute",
+            schema={
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"],
+                "additionalProperties": False,
+            },
+            handler=lambda command, **kwargs: f"evidence:{command}",
+        ),
+    ]
+    hunter = NativeHunter(
+        llm=llm,
+        prompt="test prompt",
+        tools=tools,
+        ctx=ctx,
+        max_steps=9,
+        agent_mode="deep",
+    )
+    llm.achat.side_effect = [
+        *[
+            FakeResponse(
+                reasoning_content="Survey another security boundary.",
+                tool_calls_list=[_make_tool_call("execute", {"command": command})],
+            )
+            for command in ("alpha", "bravo", "charlie", "delta", "echo")
+        ],
+        FakeResponse(
+            tool_calls_list=[
+                _make_tool_call(
+                    "flag_potential",
+                    {
+                        "file": "src/auth.go",
+                        "line": 42,
+                        "hypothesis": "Cached authorization crosses resources.",
+                    },
+                )
+            ]
+        ),
+        FakeResponse(text="done"),
+    ]
+
+    with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
+        mock_traj.for_hunter.return_value = MagicMock()
+        await hunter.arun()
+
+    post_flag_messages = llm.achat.call_args_list[6].kwargs["messages"]
+    assert any("evidence:alpha" in str(message.to_dict()) for message in post_flag_messages)
 
 
 @pytest.mark.asyncio
@@ -197,7 +370,7 @@ async def test_constrained_mode_throttles_repeated_calls():
     with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
         mock_logger = MagicMock()
         mock_traj.for_hunter.return_value = mock_logger
-        result = await hunter.arun()
+        await hunter.arun()
 
     # In constrained mode, after 3 identical calls the 4th+ should be skipped
     logged = mock_logger.log.call_args_list

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -107,6 +107,34 @@ def test_preprocess_result_round_trips_nested_types(tmp_path: Path):
     assert restored == result
 
 
+def test_hunt_checkpoint_round_trips_unresolved_potentials() -> None:
+    potentials = [
+        {
+            "id": "lead-1",
+            "file": "sample.c",
+            "line": 2,
+            "note": "unchecked length",
+            "hypothesis": "CWE-787",
+            "priority": "high",
+        }
+    ]
+    result = HuntResult(
+        findings=[],
+        spent_per_tier={"A": 0.0, "B": 0.0, "C": 0.0},
+        potentials=potentials,
+    )
+    checkpoint = HuntCheckpoint.from_result(result, options={"depth": "deep"})
+
+    restored = HuntCheckpoint.model_validate_json(checkpoint.model_dump_json()).restore(
+        options={"depth": "deep"}
+    )
+
+    assert restored is not None
+    assert restored.potentials == potentials
+    restored.potentials[0]["note"] = "changed"
+    assert checkpoint.result.potentials[0]["note"] == "unchecked length"
+
+
 def test_preprocess_checkpoint_trusts_current_source_and_rebinds_paths(tmp_path: Path):
     repo = tmp_path / "repo"
     repo.mkdir()

--- a/tests/test_sourcehunt_hunter.py
+++ b/tests/test_sourcehunt_hunter.py
@@ -20,12 +20,14 @@ from unittest.mock import MagicMock
 
 import pytest
 from genai_pyo3 import ChatResponse, Usage
+from jsonschema.exceptions import ValidationError
 
 from clearwing.agent.tools.hunt import (
     HunterContext,
     _normalize_path,
     _parse_rg_output,
     _parse_sanitizer_report,
+    build_analysis_tools,
     build_hunter_tools,
 )
 from clearwing.sandbox.container import ExecResult
@@ -34,12 +36,63 @@ from clearwing.sourcehunt.hunter import (
     _build_hunter_prompt,
     _build_propagation_prompt,
     _choose_specialist,
+    _live_tool_result_summary,
     _memory_safety_heuristic_hints,
+    _range_coverage_fraction,
+    _requested_read_range,
     _tool_output_text,
+    _tool_requires_active_potential,
     build_hunter_agent,
 )
 
 FIXTURE_C_PROPAGATION = Path(__file__).parent / "fixtures" / "vuln_samples" / "c_propagation"
+
+
+def test_read_range_coverage_distinguishes_refresh_from_new_code() -> None:
+    requested = _requested_read_range({"start_line": 150, "end_line": 249})
+
+    assert _range_coverage_fraction(requested, [(1, 500)]) == 1.0
+    assert _range_coverage_fraction(requested, [(1, 199)]) == 0.5
+    assert _range_coverage_fraction(requested, []) == 0.0
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "./configure && make -j4",
+        "apt-get install -y libonig-dev",
+        "CFLAGS=-fsanitize=address make",
+        "timeout 60 ./jq '.' input.json",
+        "python3 -c 'import subprocess; subprocess.run([\"./jq\"])'",
+        "pytest -q",
+        "afl-fuzz -i seeds -o findings ./target",
+    ],
+)
+def test_dynamic_execute_requires_active_potential(command: str) -> None:
+    assert _tool_requires_active_potential("execute", {"command": command})
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rg -n 'jvp_string_append' src",
+        "sed -n '300,360p' src/jv.c",
+        "git log --oneline -5 -- src/jv.c",
+        "python3 -c 'print(2 + 2)'",
+    ],
+)
+def test_static_exploration_execute_does_not_require_potential(command: str) -> None:
+    assert not _tool_requires_active_potential("execute", {"command": command})
+
+
+def test_dedicated_dynamic_tools_require_active_potential() -> None:
+    for tool_name in (
+        "compile_file",
+        "run_with_sanitizer",
+        "write_test_case",
+        "fuzz_harness",
+    ):
+        assert _tool_requires_active_potential(tool_name, {})
 
 
 def _make_file_target(path: str, tier: str = "B", **kwargs) -> dict:
@@ -196,7 +249,7 @@ class TestPromptBuilders:
         assert "test_project" in prompt
         # Phrase must mention severity and evidence_level (from the prompt template)
         assert "evidence_level" in prompt
-        assert "This is a single-file hunt" in prompt
+        assert "record_finding" in prompt
 
     def test_general_prompt_with_seeded_crash(self):
         ft = _make_file_target("foo.c")
@@ -238,9 +291,7 @@ class TestPromptBuilders:
         assert "MEMCPY BOUNDS" in prompt
         assert "SENTINEL / COUNTER COLLISIONS" in prompt
         assert "USE-AFTER-FREE" in prompt
-        assert "Do not spend the final step on marginal confirmation" in prompt
-        assert "record_finding with" in prompt
-        assert "evidence_level=static_corroboration" in prompt
+        assert "record_finding" in prompt
 
     def test_logic_auth_specialist_prompt(self):
         ft = _make_file_target("auth.py", tags=["auth_boundary"])
@@ -356,16 +407,13 @@ class TestBuildHunterAgent:
             "list_source_tree",
             "grep_source",
             "find_callers",
-            "compile_file",
-            "run_with_sanitizer",
-            "write_test_case",
-            "fuzz_harness",
             "record_trace_step",
             "record_finding",
             "semgrep_scan",
             "flag_potential",
-            "get_potentials",
+            "update_potential",
             "dismiss_potential",
+            "defer_potential",
         }
 
     def test_tier_b_memory_unsafe_routes_to_memory_safety(self):
@@ -416,8 +464,9 @@ class TestBuildHunterAgent:
             "record_finding",
             "semgrep_scan",
             "flag_potential",
-            "get_potentials",
+            "update_potential",
             "dismiss_potential",
+            "defer_potential",
         }
         assert "compile_file" not in tool_names
         assert "run_with_sanitizer" not in tool_names
@@ -563,12 +612,6 @@ class TestHunterToolsHostFallback:
             assert "line_number" in m
             assert "matched_text" in m
 
-    def test_find_callers_wraps_grep(self):
-        ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
-        tools = build_hunter_tools(ctx)
-        callers = next(t for t in tools if t.name == "find_callers")
-        matches = callers.invoke({"symbol": "MAX_FRAME_BYTES"})
-        assert len(matches) >= 4
 
     def test_grep_source_sandbox_ignores_glob_when_path_is_file(self):
         class _FakeSandbox:
@@ -627,7 +670,7 @@ class TestHunterToolsHostFallback:
 
     def test_compile_file_without_sandbox_returns_error(self):
         ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         compile_tool = next(t for t in tools if t.name == "compile_file")
         result = compile_tool.invoke({"file_path": "src/codec_a.c"})
         assert result["success"] is False
@@ -635,14 +678,14 @@ class TestHunterToolsHostFallback:
 
     def test_run_with_sanitizer_without_sandbox_returns_error(self):
         ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         run = next(t for t in tools if t.name == "run_with_sanitizer")
         result = run.invoke({"binary": "/scratch/x"})
         assert result["crashed"] is False
 
     def test_write_test_case_basename_only(self):
         ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         write = next(t for t in tools if t.name == "write_test_case")
         # Path with slash → rejected by basename validation before sandbox check
         out = write.invoke({"filename": "../etc/passwd", "content": "x"})
@@ -657,7 +700,7 @@ class TestHunterToolsHostFallback:
     def test_fuzz_harness_without_sandbox_returns_no_sandbox(self):
         """v0.4: fuzz_harness is fully implemented but still requires a sandbox."""
         ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         fuzz = next(t for t in tools if t.name == "fuzz_harness")
         result = fuzz.invoke({"target_function": "decode_frame_a"})
         assert result["status"] == "no_sandbox"
@@ -667,6 +710,35 @@ class TestHunterToolsHostFallback:
 
 
 class TestRecordFinding:
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("finding_type", "none"),
+            ("severity", "none"),
+            ("confidence", "certain"),
+            ("evidence_level", "none"),
+        ],
+    )
+    def test_schema_rejects_invalid_classification(self, field, value):
+        ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
+        record = next(t for t in build_hunter_tools(ctx) if t.name == "record_finding")
+        arguments = {
+            "file": "x.c",
+            "line_number": 1,
+            "finding_type": "memory_safety",
+            "severity": "high",
+            "confidence": "medium",
+            "evidence_level": "suspicion",
+            "description": "source-backed issue",
+            "trace": {
+                "steps": [{"file": "x.c", "line": 1, "note": "ENTRY/SINK: issue"}]
+            },
+        }
+        arguments[field] = value
+
+        with pytest.raises(ValidationError):
+            record.invoke(arguments)
+
     def test_append_to_findings(self):
         ctx = HunterContext(
             repo_path=str(FIXTURE_C_PROPAGATION),
@@ -727,7 +799,11 @@ class TestRecordFinding:
                 "severity": "high",
                 "cwe": "CWE-416",
                 "description": "y",
-                "trace": {"steps": [{"file": "x.c", "line": 1, "note": "SINK: uaf"}]},
+                "trace": {
+                    "steps": [
+                        {"file": "x.c", "line": 1, "note": "ENTRY/SINK: uaf"}
+                    ]
+                },
             }
         )
         assert ctx.findings[0]["seeded_from_crash"] is True
@@ -754,7 +830,7 @@ class TestRecordFinding:
                         {
                             "file": "src/codec_a.c",
                             "line": 9,
-                            "note": "SINK: unchecked memcpy",
+                            "note": "ENTRY/SINK: unchecked memcpy",
                         }
                     ]
                 },
@@ -785,13 +861,13 @@ class TestRecordFinding:
 
         # Missing trace -> instructive error, nothing recorded.
         msg = record.invoke(dict(base))
-        assert msg.startswith("ERROR")
+        assert msg["error"]["code"] == "MISSING_TRACE"
         assert ctx.findings == []
 
         # A streamed step becomes authoritative investigation state.
         # (constrained mode gates record_trace_step on files_read.)
         ctx.files_read.add("x.c")
-        step.invoke({"file": "x.c", "line": 1, "note": "ENTRY: streamed"})
+        step.invoke({"file": "x.c", "line": 1, "note": "ENTRY/SINK: streamed"})
         assert len(ctx.trace_steps) == 1
 
         # The compatibility trace cannot overwrite already-streamed evidence.
@@ -807,7 +883,7 @@ class TestRecordFinding:
         vt = ctx.findings[0]["vulnerability_trace"]
         assert len(vt["steps"]) == 1
         assert vt["steps"][0]["line"] == 1
-        assert vt["steps"][0]["note"] == "ENTRY: streamed"
+        assert vt["steps"][0]["note"] == "ENTRY/SINK: streamed"
         assert ctx.trace_steps == []  # accumulator reset
 
 
@@ -872,6 +948,27 @@ class TestNormalizePath:
 
 
 class TestToolOutputSummary:
+    def test_live_read_result_reports_actual_range_and_continuation(self):
+        summary = _live_tool_result_summary(
+            "read_file",
+            {"path": "/workspace/src/main.rs", "offset": 80, "limit": 700},
+            "    81\tfn first() {}\n    82\tfn second() {}\n... truncated 100 chars ...",
+        )
+        assert summary == (
+            "read_file /workspace/src/main.rs:81-82 → 2 lines, continue at 83"
+        )
+
+    def test_live_callee_result_reports_resolution_counts(self):
+        summary = _live_tool_result_summary(
+            "lookup_callees",
+            {"func_name": "entry"},
+            {
+                "callees": {"src/a.rs": [{"func": "one"}, {"func": "two"}]},
+                "unresolved": ["external"],
+            },
+        )
+        assert summary == "lookup_callees entry → 2 resolved, 1 unresolved"
+
     def test_list_source_tree_is_summarized(self):
         summary = _tool_output_text(
             "list_source_tree",

--- a/tests/test_sourcehunt_phase0_eval.py
+++ b/tests/test_sourcehunt_phase0_eval.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -265,6 +266,9 @@ async def test_concrete_executor_pins_checkout_and_wires_exact_hint_packet(
     class FakeRunner:
         def __init__(self, **kwargs):
             captured.update(kwargs)
+            local_path = Path(kwargs["local_path"])
+            captured["local_path_existed"] = local_path.is_dir()
+            captured["local_path_had_git"] = (local_path / ".git").exists()
 
         async def arun(self):
             return None
@@ -290,6 +294,9 @@ async def test_concrete_executor_pins_checkout_and_wires_exact_hint_packet(
     assert captured["campaign_hint"] == spec.campaign_hint()
     assert captured["flow"] == "proof"
     assert captured["model_override"] == spec.model
+    assert Path(captured["local_path"]).name.startswith("source-snapshot-")
+    assert captured["local_path_existed"] is True
+    assert captured["local_path_had_git"] is False
 
     (checkout / "app.py").write_text("print('changed')\n", encoding="utf-8")
     with pytest.raises(ValueError, match="tracked modifications"):

--- a/tests/test_sourcehunt_ranker.py
+++ b/tests/test_sourcehunt_ranker.py
@@ -14,6 +14,7 @@ Critical assertions:
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -656,6 +657,60 @@ class TestFuzzableRankBoost:
         # 4*0.5 + 1*0.2 + 3*0.3 + 0.5 = 2.0 + 0.2 + 0.9 + 0.5 = 3.6 → A
         assert files[0]["priority"] == pytest.approx(3.6)
         assert assign_tier(files[0]) == "A"
+
+
+class TestCircuitBreaker:
+    def test_circuit_breaker_stops_after_consecutive_failures(self):
+        """When N consecutive chunks return empty, the pipeline doesn't crash
+        and all files get heuristic fallback scores."""
+        call_count = 0
+
+        async def slow_fail(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # Yield control so the event loop can process breaker logic
+            await asyncio.sleep(0)
+            raise ValueError(
+                "LLM returned empty response; expected JSON matching RankedFileScoreResponse"
+            )
+
+        llm = AsyncMock()
+        llm.aask_json.side_effect = slow_fail
+        config = RankerConfig(
+            chunk_size=2,
+            circuit_breaker_threshold=2,
+            chunk_max_retries=0,  # no retries — fail fast for test
+            max_inflight_chunks=1,  # serialize so breaker can trip between chunks
+        )
+        files = [_make_file(f"f{i}.c") for i in range(10)]
+        Ranker(llm, config).rank(files)
+        # Circuit breaker should trip — not all 5 chunks should have been attempted
+        # (with max_inflight=1 and sleep(0), breaker can cancel pending tasks)
+        assert call_count <= 3  # at most breaker_threshold + 1 in-flight
+        # All files still get heuristic fallback scores
+        for f in files:
+            assert f["surface"] >= 1
+            assert f["priority"] > 0
+
+    def test_no_circuit_breaker_when_chunks_succeed(self):
+        """Successful chunks don't trigger the breaker."""
+        scores = [
+            {
+                "path": f"f{i}.c",
+                "surface": 3,
+                "influence": 2,
+                "surface_rationale": "ok",
+                "influence_rationale": "ok",
+            }
+            for i in range(6)
+        ]
+        llm = AsyncMock()
+        llm.aask_json.return_value = ({"results": scores}, ChatResponse())
+        config = RankerConfig(chunk_size=2, circuit_breaker_threshold=2)
+        files = [_make_file(f"f{i}.c") for i in range(6)]
+        Ranker(llm, config).rank(files)
+        # All 3 chunks processed
+        assert llm.aask_json.call_count == 3
 
 
 class TestRankerSystemPrompt:

--- a/tests/test_sourcehunt_runner.py
+++ b/tests/test_sourcehunt_runner.py
@@ -19,14 +19,32 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from genai_pyo3 import ChatResponse
 
+from clearwing.sourcehunt.checkpoints import HuntResult
 from clearwing.sourcehunt.pool import assign_tier
 from clearwing.sourcehunt.preprocessor import Preprocessor
 from clearwing.sourcehunt.ranker import Ranker
 from clearwing.sourcehunt.runner import SourceHuntResult, SourceHuntRunner
-from clearwing.sourcehunt.state import StageOutcome
+from clearwing.sourcehunt.state import Finding, StageOutcome
 
 FIXTURE_C_PROPAGATION = Path(__file__).parent / "fixtures" / "vuln_samples" / "c_propagation"
 FIXTURE_PY_SQLI = Path(__file__).parent / "fixtures" / "vuln_samples" / "py_sqli"
+
+
+def _mock_hunt_result() -> HuntResult:
+    return HuntResult(
+        findings=[
+            Finding(
+                id="sql-injection",
+                file="app.py",
+                severity="high",
+                confidence="high",
+                evidence_level="static_corroboration",
+                verified=False,
+            )
+        ],
+        files_hunted=1,
+        spent_per_tier={"A": 0.0, "B": 0.0, "C": 0.0},
+    )
 
 
 def test_runner_is_available_from_the_public_sourcehunt_package():
@@ -188,6 +206,7 @@ class TestStandardDepth:
             verifier_llm=_make_verifier_llm(),
             no_exploit=True,  # exploiter not needed for this test
         )
+        runner._ensure_sandbox_factory = MagicMock()
         result = runner.run()
         assert isinstance(result, SourceHuntResult)
         assert result.files_ranked == 4
@@ -253,6 +272,7 @@ class TestStandardDepth:
             verifier_llm=_make_verifier_llm(),
             no_exploit=True,
         )
+        runner._ensure_sandbox_factory = MagicMock()
         result = runner.run()
         # Manifest exists and has spent_per_tier
         manifest_path = Path(result.output_paths["manifest"])
@@ -295,10 +315,12 @@ class TestNoVerify:
             enable_knowledge_graph=False,
             enable_findings_pool=False,
             enable_behavior_monitor=False,
+            sandbox_factory=MagicMock(),
         )
         runner._emit_stage = lambda stage, status, **data: stage_events.append(
             (stage, status, data)
         )
+        runner._hunt = AsyncMock(return_value=_mock_hunt_result())
 
         result = runner.run()
 
@@ -464,7 +486,9 @@ class TestAdversarialVerifierDefault:
             enable_mechanism_memory=False,
             enable_patch_oracle=False,
             enable_variant_loop=False,
+            sandbox_factory=MagicMock(),
         )
+        runner._hunt = AsyncMock(return_value=_mock_hunt_result())
         runner.run()
         # Find the call whose system prompt contains STEEL-MAN
         found_adversarial = False

--- a/tests/test_sourcehunt_subsystem.py
+++ b/tests/test_sourcehunt_subsystem.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from clearwing.llm import NativeToolSpec
 from clearwing.sourcehunt.runner import SourceHuntRunner
 from clearwing.sourcehunt.state import FileTarget, StageOutcome, SubsystemTarget
 from clearwing.sourcehunt.subsystem import (
@@ -221,6 +222,11 @@ def test_subsystem_prompt_includes_file_listing():
     assert "net/ipv4/udp.c" in prompt
     assert "net_ipv4" in prompt
     assert "linux" in prompt
+    assert "Survey before committing" in prompt
+    assert "For each major security boundary, build an invariant map" in prompt
+    assert "Lifecycle/state" in prompt
+    assert "dominates every subsequent" in prompt
+    assert "Map validation, mutation, and use by lifecycle stage" in prompt
 
 
 def test_subsystem_prompt_cross_file_calls():
@@ -284,6 +290,44 @@ def test_subsystem_prompt_entry_points():
     assert "protocol_parser" in prompt
 
 
+def test_subsystem_prompt_has_generic_cross_platform_path_threat_advice():
+    from clearwing.sourcehunt.hunter import _build_subsystem_prompt
+
+    subsystem = SubsystemTarget(
+        name="archive_extraction",
+        root_path="src/extract",
+        files=[_ft("src/extract/archive.c", 4.0)],
+    )
+
+    prompt = _build_subsystem_prompt(subsystem, "extractor")
+
+    assert "Path confinement" in prompt
+    assert "drive/UNC roots" in prompt
+    assert "compact interpretation matrix" in prompt
+    assert "every supported target platform" in prompt
+    assert "backslash traversal" not in prompt.lower()
+
+
+def test_subsystem_prompt_has_allocation_access_extent_threat_advice():
+    from clearwing.sourcehunt.hunter import _build_subsystem_prompt
+
+    subsystem = SubsystemTarget(
+        name="buffer_processing",
+        root_path="src/buffer",
+        files=[_ft("src/buffer/copy.c", 4.0)],
+    )
+
+    prompt = _build_subsystem_prompt(subsystem, "processor")
+    normalized = " ".join(prompt.split())
+
+    assert "Allocation/access extent" in normalized
+    assert "expressions used for validation, allocation, and access" in normalized
+    assert "live bounds of every object" in normalized
+    assert "required inequalities" in normalized
+    assert "values actually consumed at the sink" in normalized
+    assert "gdi_CacheToSurface" not in normalized
+
+
 # ---------------------------------------------------------------------------
 # build_subsystem_hunter_agent
 # ---------------------------------------------------------------------------
@@ -309,6 +353,73 @@ def test_build_subsystem_hunter_agent_tools():
     assert "execute" in tool_names
     assert "read_file" in tool_names
     assert "record_finding" in tool_names
+
+
+def test_build_subsystem_hunter_agent_keeps_callgraph_navigation(
+    monkeypatch,
+):
+    from clearwing.sourcehunt import hunter as hunter_module
+
+    def tool(name: str) -> NativeToolSpec:
+        return NativeToolSpec(name=name, description=name, schema={}, handler=lambda: None)
+
+    callgraph_tools = [
+        tool("lookup_callers"),
+        tool("lookup_callees"),
+        tool("list_functions"),
+        tool("read_function"),
+    ]
+    monkeypatch.setattr(
+        hunter_module,
+        "build_deep_agent_tools",
+        lambda ctx: [tool("execute"), *callgraph_tools],
+    )
+    subsystem = SubsystemTarget(
+        name="test_sub",
+        root_path="src/parser",
+        files=[_ft("src/parser/main.c", 4.0)],
+    )
+
+    built, _ = hunter_module.build_subsystem_hunter_agent(
+        subsystem=subsystem,
+        repo_path="/tmp/repo",
+        sandbox=None,
+        llm=MagicMock(),
+        session_id="test-session",
+        callgraph=MagicMock(functions={}, calls_out={}, defined_in={}),
+    )
+
+    assert {item.name for item in callgraph_tools} <= {item.name for item in built.tools}
+
+
+@pytest.mark.asyncio
+async def test_subsystem_runner_accumulates_unresolved_potentials(monkeypatch, tmp_path):
+    subsystem = SubsystemTarget(
+        name="test_sub",
+        root_path="src/parser",
+        files=[_ft("src/parser/main.c", 4.0)],
+    )
+    runner = SubsystemHuntRunner(
+        SubsystemHuntConfig(subsystems=[subsystem], repo_path=str(tmp_path), llm=MagicMock())
+    )
+    potentials = [
+        {
+            "id": "lead-1",
+            "file": "src/parser/main.c",
+            "line": 12,
+            "note": "unclear length",
+            "hypothesis": "CWE-787",
+            "priority": "high",
+        }
+    ]
+
+    async def fake_run(*args, **kwargs):
+        return [], 0.0, 0, "completed", potentials
+
+    monkeypatch.setattr(runner, "_run_one_subsystem", fake_run)
+
+    assert await runner.arun() == []
+    assert runner.all_potentials == potentials
 
 
 def test_build_subsystem_hunter_agent_max_steps():
@@ -443,7 +554,7 @@ async def test_subsystem_hunt_runner_preserves_budget_exhaustion(monkeypatch):
     )
 
     async def budget_exhausted(*args, **kwargs):
-        return [], 1.0, 10, "budget_exhausted"
+        return [], 1.0, 10, "budget_exhausted", []
 
     monkeypatch.setattr(runner, "_run_one_subsystem", budget_exhausted)
 
@@ -461,6 +572,7 @@ def test_subsystem_budget_stop_marks_sourcehunt_run_incomplete(monkeypatch, tmp_
         def __init__(self, config):
             self.total_spent = 1.0
             self.budget_exhausted = True
+            self.all_potentials = []
 
         async def arun(self):
             return []


### PR DESCRIPTION
## Summary

Sixth and final PR in the SourceHunt investigation stack.

- Surveys multiple boundaries before committing to a lead.
- Requires security invariant maps and lifecycle-dominance reasoning.
- Adds focused path, protocol, authorization, allocation, and configuration guidance.
- Integrates potential persistence with hunter and subsystem orchestration.
- Wires the run-scoped, in-process Serena Python tools while avoiding redundant navigation tools.
- Removes the former Serena MCP/container image option.
- Removes forced six-call resolution behavior.

## Validation

- 265 focused integration tests pass for the stack.
- 71 updated Serena runner and subsystem integration tests pass.
- Ruff passes on changed Python files.
- `git diff --check` passes.

## PR stack

1. #168 — Evaluation harness and run provenance
2. #169 — Remove Semgrep from deep-agent tools
3. #170 — Structured tool-call diagnostics
4. #171 — Semantic navigation foundation
5. #172 — Durable potential lifecycle
6. **#173 — Investigation policy and orchestration (this PR)**

Depends on #172. Supersedes the remaining portion of #160.

## Accepted overlap

This branch overlaps #167 in subsystem and CLI integration. Reconcile those files when either branch is rebased or merged.
