### PR TITLE
fix(tests): update dynamic-verification tests for #173 gated investigation policy

### DIFF
--- a/tests/test_sandbox_msan_variants.py
+++ b/tests/test_sandbox_msan_variants.py
@@ -19,7 +19,7 @@ import pytest
 from clearwing.agent.tools.hunt import (
     HunterContext,
     _parse_variant_arg,
-    build_hunter_tools,
+    build_analysis_tools,
 )
 from clearwing.sandbox.builders import (
     INCOMPATIBLE_SANITIZER_PAIRS,
@@ -462,7 +462,7 @@ class TestCompileFileVariantDispatch:
             sandbox=primary,
             sandbox_manager=manager,
         )
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         compile_tool = next(t for t in tools if t.name == "compile_file")
         result = compile_tool.invoke(
             {
@@ -483,7 +483,7 @@ class TestCompileFileVariantDispatch:
             repo_path="/tmp/repo",
             sandbox=primary,
         )
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         compile_tool = next(t for t in tools if t.name == "compile_file")
         compile_tool.invoke({"file_path": "src/foo.c"})
         primary.exec.assert_called_once()
@@ -503,7 +503,7 @@ class TestRunWithSanitizerVariantDispatch:
             sandbox=primary,
             sandbox_manager=manager,
         )
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         run_tool = next(t for t in tools if t.name == "run_with_sanitizer")
         result = run_tool.invoke(
             {
@@ -527,7 +527,7 @@ class TestRunWithSanitizerVariantDispatch:
             sandbox_manager=manager,
             default_sanitizers=("asan", "ubsan"),
         )
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         run_tool = next(t for t in tools if t.name == "run_with_sanitizer")
         run_tool.invoke(
             {

--- a/tests/test_sandbox_writable_workspace.py
+++ b/tests/test_sandbox_writable_workspace.py
@@ -170,7 +170,7 @@ class TestSourceHuntSandboxCpuWiring:
         manager.spawn.assert_called_once_with(
             writable_workspace=True,
             memory_mb=16384,
-            timeout_seconds=600,
+            timeout_seconds=30,
             runtime=None,
         )
 

--- a/tests/test_sourcehunt_fuzz_harness_tool.py
+++ b/tests/test_sourcehunt_fuzz_harness_tool.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock
 from clearwing.agent.tools.hunt import (
     HunterContext,
     _default_libfuzzer_template,
-    build_hunter_tools,
+    build_analysis_tools,
 )
 from clearwing.sandbox.container import ExecResult
 
@@ -104,7 +104,7 @@ class TestLibFuzzerTemplate:
 class TestFuzzHarnessNoSandbox:
     def test_returns_error_without_sandbox(self):
         ctx = HunterContext(repo_path="/tmp")
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         fuzz = next(t for t in tools if t.name == "fuzz_harness")
         result = fuzz.invoke(
             {
@@ -118,7 +118,7 @@ class TestFuzzHarnessNoSandbox:
 class TestFuzzHarnessMissingInput:
     def test_no_target_and_no_source_is_error(self):
         ctx = HunterContext(repo_path="/tmp", sandbox=_FakeSandbox([]))
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         fuzz = next(t for t in tools if t.name == "fuzz_harness")
         result = fuzz.invoke({"target_function": "", "harness_source": ""})
         assert result["status"] == "error"
@@ -137,7 +137,7 @@ class TestFuzzHarnessTemplateMode:
             ]
         )
         ctx = HunterContext(repo_path="/tmp", sandbox=fake)
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         fuzz = next(t for t in tools if t.name == "fuzz_harness")
         result = fuzz.invoke(
             {
@@ -166,7 +166,7 @@ class TestFuzzHarnessTemplateMode:
             ]
         )
         ctx = HunterContext(repo_path="/tmp", sandbox=fake)
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         fuzz = next(t for t in tools if t.name == "fuzz_harness")
         result = fuzz.invoke(
             {
@@ -186,7 +186,7 @@ class TestFuzzHarnessTemplateMode:
             ]
         )
         ctx = HunterContext(repo_path="/tmp", sandbox=fake)
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         fuzz = next(t for t in tools if t.name == "fuzz_harness")
         result = fuzz.invoke({"target_function": "decode"})
         assert result["status"] == "compile_failed"
@@ -215,7 +215,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *D, size_t S) {
             ]
         )
         ctx = HunterContext(repo_path="/tmp", sandbox=fake)
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         fuzz = next(t for t in tools if t.name == "fuzz_harness")
         result = fuzz.invoke(
             {
@@ -243,7 +243,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *D, size_t S) { return 0; }
             ]
         )
         ctx = HunterContext(repo_path="/tmp", sandbox=fake)
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         fuzz = next(t for t in tools if t.name == "fuzz_harness")
         fuzz.invoke(
             {
@@ -275,7 +275,7 @@ class TestFuzzHarnessVariantDispatch:
             sandbox=primary,
             sandbox_manager=manager,
         )
-        tools = build_hunter_tools(ctx)
+        tools = build_analysis_tools(ctx)
         fuzz = next(t for t in tools if t.name == "fuzz_harness")
         result = fuzz.invoke(
             {

--- a/tests/test_unconstrained_prompt.py
+++ b/tests/test_unconstrained_prompt.py
@@ -142,7 +142,7 @@ class TestBuildHunterAgentPromptMode:
         assert "execute" in tool_names
         assert hunter.max_steps == 500
 
-    def test_unconstrained_constrained_uses_discovery_prompt_with_9_tools(self):
+    def test_unconstrained_constrained_uses_static_discovery_tools(self):
         llm = MagicMock()
         ft = _make_file_target(tags=["memory_unsafe"])
         hunter, ctx = build_hunter_agent(
@@ -159,7 +159,12 @@ class TestBuildHunterAgentPromptMode:
         assert ctx.specialist == "unconstrained"
         tool_names = {t.name for t in hunter.tools}
         assert "read_source_file" in tool_names
-        assert "compile_file" in tool_names
+        # Dynamic verification (compile/run/fuzz) is gated behind the
+        # investigation policy: a constrained hunter gets only static-analysis
+        # tools plus the potential lifecycle, and must flag_potential before
+        # earning dynamic tools in the separate verification phase.
+        assert "compile_file" not in tool_names
+        assert "flag_potential" in tool_names
         assert hunter.max_steps == 20
 
     def test_specialist_mode_uses_specialist_prompt(self):


### PR DESCRIPTION
`main` currently ships **14 failing tests**. They are not a regression in behavior — they're tests that #173 ("feat(sourcehunt): strengthen investigation policy") left un-updated when it changed the hunter's tool wiring. This PR aligns the tests with the accepted #173 behavior. **Test-only; no production code changed.**

## What #173 changed (and we accept)

- The dynamic verification tools — `compile_file`, `run_with_sanitizer`, `write_test_case`, `fuzz_harness` — were moved out of `build_hunter_tools` and gated behind `flag_potential`. Hunting now uses a static-analysis tool set; dynamic reproduction belongs to the separate verification phase (the tools still live in `build_analysis_tools`, used by the verifier).
- The deep-mode sandbox factory's default spawn timeout changed from `600s` to `30s` (callers still override per-spawn).

## Fixes

| Test file | Failing | Fix |
|---|---|---|
| `test_sourcehunt_fuzz_harness_tool.py` | 8 | build the tools via `build_analysis_tools` (which owns `fuzz_harness`) instead of `build_hunter_tools` |
| `test_sandbox_msan_variants.py` | 4 | same — `compile_file`/`run_with_sanitizer` now come from `build_analysis_tools` |
| `test_unconstrained_prompt.py` | 1 | a constrained hunter no longer exposes `compile_file`; assert the static set + `flag_potential`, and that `compile_file` is gated out; renamed off the stale "9 tools" name |
| `test_sandbox_writable_workspace.py` | 1 | expect the new `30s` default spawn timeout |

## Verification

Full suite on this branch (`origin/main` + these test changes): **3064 passed, 1 skipped**.

## Note

Two observations worth a maintainer's eye (not fixed here):
- The `600s → 30s` sandbox spawn-timeout change was bundled into the policy commit without a note. It's harmless if the dynamic tools always pass an explicit timeout, but worth confirming that's intended.
- `test_unconstrained_prompt.py` carries pre-existing unused-import lint (F401) on `origin/main`, left untouched here to keep this change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShCktZJoeBkVa3kGj6BKVS