### PR TITLE
feat(sourcehunt): work-item-granular hunt resume in the checkpoint system (supersedes #143)

### DIFF
--- a/clearwing/llm/budget.py
+++ b/clearwing/llm/budget.py
@@ -137,6 +137,7 @@ class SpendLedger:
         default_max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS,
         manifest_filename: str = "manifest.json",
         endpoint: LLMEndpoint | None = None,
+        resume: bool = False,
     ) -> None:
         if not math.isfinite(limit_usd) or limit_usd < 0:
             raise BudgetConfigurationError("LLM budget must be a finite value >= 0")
@@ -195,15 +196,132 @@ class SpendLedger:
         self.ledger_path = session_dir / "spend-ledger.jsonl"
         self.manifest_path = session_dir / manifest_filename
         with self._lock:
+            if resume:
+                self._restore_history_locked()
             self._persist_event_locked(
                 {
-                    "event": "run_started",
+                    "event": "run_resumed" if resume else "run_started",
                     "session_id": self.session_id,
                     "budget_usd": self.limit_usd,
+                    "carried_forward_usd": self._spent_usd,
                     "timestamp": self._timestamp(),
                 }
             )
             self._persist_snapshot_locked()
+
+    def _restore_history_locked(self) -> None:
+        """Restore settled calls and conservatively close interrupted reservations.
+
+        Replays the existing spend ledger so a resumed session keeps its dollar
+        cap as a lifetime budget rather than starting fresh. A call that was
+        reserved but never settled (the process died mid-flight) is charged its
+        reservation — the safe assumption is that it did spend.
+        """
+        if not self.ledger_path.is_file():
+            raise BudgetConfigurationError(
+                f"Cannot resume session {self.session_id!r}: spend ledger is missing"
+            )
+        try:
+            lines = self.ledger_path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError) as exc:
+            raise BudgetConfigurationError(
+                f"Cannot resume session {self.session_id!r}: spend ledger is unreadable"
+            ) from exc
+
+        reservations: dict[str, dict[str, Any]] = {}
+        settlements: dict[str, dict[str, Any]] = {}
+        has_run_header = False
+        for index, line in enumerate(lines):
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError as exc:
+                if index == len(lines) - 1:
+                    break  # tolerate a torn final line from a crash mid-write
+                raise BudgetConfigurationError(
+                    f"Cannot resume session {self.session_id!r}: spend ledger is corrupt"
+                ) from exc
+            if not isinstance(event, dict):
+                continue
+            if event.get("event") in {"run_started", "run_resumed"}:
+                has_run_header = has_run_header or event.get("session_id") == self.session_id
+            call_id = str(event.get("call_id") or "")
+            if not call_id:
+                continue
+            if event.get("event") == "call_reserved":
+                reservations.setdefault(call_id, event)
+            elif event.get("event") == "call_settled":
+                settlements.setdefault(call_id, event)
+
+        if not has_run_header:
+            raise BudgetConfigurationError(
+                f"Cannot resume session {self.session_id!r}: spend ledger is corrupt"
+            )
+
+        for call_id in reservations.keys() | settlements.keys():
+            if call_id in settlements:
+                self._restore_settlement_locked(settlements[call_id])
+            else:
+                self._recover_reservation_locked(call_id, reservations[call_id])
+        if self.enforcing and self._spent_usd >= self.limit_usd - self._EPSILON:
+            self._exhausted = True
+            self._status = "budget_exhausted"
+
+    def _restore_settlement_locked(self, event: dict[str, Any]) -> None:
+        try:
+            cost = float(event["cost_usd"])
+            input_tokens = int(event.get("input_tokens", 0))
+            output_tokens = int(event.get("output_tokens", 0))
+            cached_tokens = int(event.get("cached_input_tokens", 0))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BudgetConfigurationError(
+                f"Cannot resume session {self.session_id!r}: spend ledger is corrupt"
+            ) from exc
+        if not math.isfinite(cost) or min(cost, input_tokens, output_tokens, cached_tokens) < 0:
+            raise BudgetConfigurationError(
+                f"Cannot resume session {self.session_id!r}: spend ledger is corrupt"
+            )
+        if not isinstance(event.get("metadata"), dict):
+            event = {**event, "metadata": {}}
+        self._records.append(event)
+        self._spent_usd += cost
+        self._input_tokens += input_tokens
+        self._output_tokens += output_tokens
+        self._cached_input_tokens += cached_tokens
+
+    def _recover_reservation_locked(self, call_id: str, reservation: dict[str, Any]) -> None:
+        try:
+            reserved_usd = float(reservation["reserved_usd"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BudgetConfigurationError(
+                f"Cannot resume session {self.session_id!r}: spend ledger is corrupt"
+            ) from exc
+        if not math.isfinite(reserved_usd) or reserved_usd < 0:
+            raise BudgetConfigurationError(
+                f"Cannot resume session {self.session_id!r}: spend ledger is corrupt"
+            )
+        charged = reserved_usd if reservation.get("budget_enforcing", reserved_usd > 0) else 0.0
+        event = {
+            "event": "call_settled",
+            "call_id": call_id,
+            "timestamp": self._timestamp(),
+            "stage": reservation.get("stage"),
+            "model": reservation.get("model"),
+            "provider": reservation.get("provider"),
+            "status": "recovered_ambiguous_failure",
+            "reserved_usd": reserved_usd,
+            "cost_usd": charged,
+            "cost_source": "reservation" if charged else "none",
+            "input_tokens": 0,
+            "cached_input_tokens": 0,
+            "output_tokens": 0,
+            "metadata": (
+                reservation["metadata"] if isinstance(reservation.get("metadata"), dict) else {}
+            ),
+            "error": "Process exited before spend settlement; charged on resume",
+        }
+        self._records.append(event)
+        self._spent_usd += charged
+        self._persist_event_locked(event)
 
     @property
     def enforcing(self) -> bool:
@@ -356,6 +474,7 @@ class SpendLedger:
                     "stage": stage,
                     "model": model,
                     "provider": provider,
+                    "budget_enforcing": self.enforcing,
                     "reserved_usd": reserved_usd,
                     "input_token_upper_bound": input_token_upper_bound,
                     "max_output_tokens": effective_max_tokens,

--- a/clearwing/sourcehunt/findings_pool.py
+++ b/clearwing/sourcehunt/findings_pool.py
@@ -192,6 +192,11 @@ class FindingsPool:
     async def add(self, finding: Finding) -> Finding:
         """Add a finding, classify primitive, run dedup, return updated finding."""
         async with self._lock:
+            # Idempotent on finding id: a resumed run re-adds findings carried in
+            # from cached hunter work, and must not double-count or re-classify them.
+            existing = self._findings.get(finding.get("id", ""))
+            if existing is not None:
+                return existing
             if not finding.get("primitive_type"):
                 finding.primitive_type = await self._classify_primitive(finding)
 

--- a/clearwing/sourcehunt/hunt_work_cache.py
+++ b/clearwing/sourcehunt/hunt_work_cache.py
@@ -1,0 +1,163 @@
+"""Incremental per-work-item cache for the source-hunt stage.
+
+The checkpoint system (:mod:`clearwing.sourcehunt.checkpoints`) resumes the
+legacy pipeline at *stage* granularity: a stage is restored only when it ran to
+completion. That leaves a gap — a hunt interrupted part way through (crash,
+Ctrl-C, budget kill) has no ``HuntCheckpoint`` yet, so the whole hunt re-runs
+and every already-finished file is hunted again.
+
+``HuntWorkCache`` fills that gap *inside* the checkpoint system rather than
+adding a second resume path. As each hunter work item (a file/band/attempt/
+context combination) completes, its :class:`TargetResult` is written
+write-once to ``<session>/hunt-work/<work_id>.json``. On a resumed run the
+:class:`~clearwing.sourcehunt.pool.HunterPool` looks each work item up by its
+deterministic id and reuses the completed result instead of re-running it, so
+only unfinished work runs again. Compatibility (same repo, same options,
+unchanged sources) is already enforced by the surrounding checkpoint stages —
+this cache only stores and returns immutable completed results, and treats
+anything missing, malformed, or not ``completed`` as absent so the work simply
+re-runs.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import tempfile
+from dataclasses import asdict, is_dataclass
+from pathlib import Path
+from typing import Any
+
+from clearwing.findings.types import Finding
+from clearwing.runners.parallel.executor import TargetResult
+
+_SCHEMA_VERSION = 1
+_WORK_ID = re.compile(r"^work-[a-f0-9]{16}$")
+
+
+class HuntWorkCache:
+    """A directory of immutable, completed per-work-item hunter results."""
+
+    def __init__(self, work_dir: str | Path):
+        self.work_dir = Path(work_dir)
+
+    def load(self, work_id: str) -> TargetResult | None:
+        """Return the cached completed result for *work_id*, or None.
+
+        Returns None for any id that is missing, malformed, schema-mismatched,
+        or not a ``completed`` result — the caller then re-runs the work.
+        """
+        if not _WORK_ID.fullmatch(work_id):
+            return None
+        payload = _read_json(self.work_dir / f"{work_id}.json")
+        if (
+            not isinstance(payload, dict)
+            or payload.get("schema_version") != _SCHEMA_VERSION
+            or payload.get("work_id") != work_id
+            or not isinstance(payload.get("result"), dict)
+        ):
+            return None
+        result = payload["result"]
+        allowed_fields = set(TargetResult.__dataclass_fields__)
+        if (
+            result.get("status") != "completed"
+            or not isinstance(result.get("findings"), list)
+            or not set(result).issubset(allowed_fields)
+            or not all(field in result for field in ("target", "status", "tier", "band"))
+        ):
+            return None
+        try:
+            findings = [_finding(item) for item in result["findings"]]
+            if any(finding is None for finding in findings):
+                return None
+            target_result = TargetResult(
+                **{
+                    key: value
+                    for key, value in result.items()
+                    if key in TargetResult.__dataclass_fields__ and key != "findings"
+                },
+                findings=[finding for finding in findings if finding is not None],
+            )
+            if (
+                target_result.status != "completed"
+                or target_result.tier not in {"A", "B", "C"}
+                or target_result.band not in {"fast", "standard", "deep"}
+                or not math.isfinite(float(target_result.cost_usd))
+                or target_result.cost_usd < 0
+                or target_result.tokens_used < 0
+            ):
+                return None
+            return target_result
+        except (TypeError, ValueError):
+            return None
+
+    def save(self, work_id: str, result: TargetResult) -> None:
+        """Persist a completed *result* under *work_id*, write-once.
+
+        Non-completed results and ids that already exist are ignored, so the
+        first successful result for a work item is authoritative and later
+        attempts never overwrite it.
+        """
+        if not _WORK_ID.fullmatch(work_id) or result.status != "completed":
+            return
+        if self.load(work_id) is not None:
+            return
+        _atomic_json(
+            self.work_dir / f"{work_id}.json",
+            {
+                "schema_version": _SCHEMA_VERSION,
+                "work_id": work_id,
+                "result": _json_value(result),
+            },
+        )
+
+
+def _finding(value: Any) -> Finding | None:
+    if not isinstance(value, dict) or not isinstance(value.get("id"), str) or not value["id"]:
+        return None
+    try:
+        return Finding(
+            **{key: item for key, item in value.items() if key in Finding.__dataclass_fields__}
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _json_value(value: Any) -> Any:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {key: _json_value(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(key): _json_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item) for item in value]
+    if isinstance(value, Path):
+        return str(value)
+    return value
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _atomic_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+__all__ = ["HuntWorkCache"]

--- a/clearwing/sourcehunt/pool.py
+++ b/clearwing/sourcehunt/pool.py
@@ -72,19 +72,35 @@ class WorkItem:
     seed_transcript: str | None = None
     entry_point: Any = None  # EntryPoint | None — spec 004
     seed_context: str | None = None  # spec 004 seed corpus
+    context_id: str = ""  # hash of per-file seeded-crash/static prompt inputs
 
-    def stable_identifier(self, run_id: str) -> str:
+    def stable_identifier(self, run_id: str, tier: str = "") -> str:
+        # The id must vary with everything that changes the hunt result, so the
+        # work cache never returns a result computed under different inputs.
         entry_point = self.entry_point
+        entry_point_id = (
+            {
+                "file": getattr(entry_point, "file_path", ""),
+                "function": getattr(entry_point, "function_name", ""),
+                "start": getattr(entry_point, "start_line", 0),
+                "end": getattr(entry_point, "end_line", 0),
+                "type": getattr(entry_point, "entry_type", ""),
+            }
+            if entry_point is not None
+            else None
+        )
         return stable_run_id(
             "work",
             {
                 "run_id": run_id,
                 "file": self.file_target.get("path", ""),
+                "tier": tier,
                 "band": self.band,
                 "attempt": self.attempt,
-                "entry_point": (
-                    getattr(entry_point, "function_name", "") if entry_point is not None else ""
-                ),
+                "entry_point": entry_point_id,
+                "seed_context": self.seed_context,
+                "seed_transcript": self.seed_transcript,
+                "context_id": self.context_id,
             },
         )
 
@@ -213,6 +229,7 @@ class HuntPoolConfig:
     findings_pool: Any = None  # FindingsPool | None — spec 005
     trajectory_root: str | Path | None = None
     instrumentation: Any = None  # SourceHuntInstrumentation | None
+    work_cache: Any = None  # HuntWorkCache | None — work-item-granular hunt resume
 
 
 def _format_seed_context(entries: list) -> str | None:
@@ -298,6 +315,14 @@ class HunterPool:
                 else []
             )
             seed_entries = self.config.seed_corpus_by_file.get(file_path, [])
+            # Fold the per-file prompt inputs (seeded crash + static hints) into
+            # the work-item id so cached results are never reused across a change
+            # in what the hunter was actually shown.
+            context = {
+                "seeded_crash": self.config.seeded_crashes_by_file.get(file_path),
+                "static_hints": self.config.semgrep_hints_by_file.get(file_path, []),
+            }
+            context_id = stable_run_id("context", context) if any(context.values()) else ""
 
             if entry_points:
                 for ep in entry_points:
@@ -315,6 +340,7 @@ class HunterPool:
                                 attempt=attempt,
                                 entry_point=ep,
                                 seed_context=seed_ctx,
+                                context_id=context_id,
                             )
                         )
             else:
@@ -326,6 +352,7 @@ class HunterPool:
                             band=band,
                             attempt=attempt,
                             seed_context=seed_ctx,
+                            context_id=context_id,
                         )
                     )
         return items
@@ -449,7 +476,7 @@ class HunterPool:
             else None
         )
         spent = 0.0
-        in_flight: dict[asyncio.Task[TargetResult], WorkItem] = {}
+        in_flight: dict[asyncio.Future[TargetResult], tuple[WorkItem, str, bool]] = {}
         item_iter = iter(work_items)
         promotion_queue: list[WorkItem] = []
 
@@ -466,20 +493,35 @@ class HunterPool:
             if wi is None:
                 return False
             band_cost = self.config.band_budget.for_band(wi.band)
-            work_item_id = wi.stable_identifier(self.config.session_id_prefix)
-            task = asyncio.create_task(
-                self._run_file_task(
-                    wi.file_target,
-                    cost_limit=band_cost,
-                    tier=tier,
-                    band=wi.band,
-                    seed_transcript=wi.seed_transcript,
-                    entry_point=wi.entry_point,
-                    seed_context=wi.seed_context,
-                    work_item_id=work_item_id,
+            work_item_id = wi.stable_identifier(self.config.session_id_prefix, tier)
+            cached = self.config.work_cache.load(work_item_id) if self.config.work_cache else None
+            if cached is not None and (
+                cached.target != wi.file_target.get("path", "")
+                or cached.tier != tier
+                or cached.band != wi.band
+            ):
+                logger.warning("Ignoring mismatched cached hunter work %s", work_item_id)
+                cached = None
+            if cached is not None:
+                logger.info("Reusing completed hunter work for %s", wi.file_target.get("path", ""))
+                task: asyncio.Future[TargetResult] = asyncio.get_running_loop().create_future()
+                task.set_result(cached)
+                from_cache = True
+            else:
+                task = asyncio.create_task(
+                    self._run_file_task(
+                        wi.file_target,
+                        cost_limit=band_cost,
+                        tier=tier,
+                        band=wi.band,
+                        seed_transcript=wi.seed_transcript,
+                        entry_point=wi.entry_point,
+                        seed_context=wi.seed_context,
+                        work_item_id=work_item_id,
+                    )
                 )
-            )
-            in_flight[task] = wi
+                from_cache = False
+            in_flight[task] = (wi, work_item_id, from_cache)
             return True
 
         for _ in range(max(1, self.config.max_parallel)):
@@ -499,7 +541,7 @@ class HunterPool:
                     timeout,
                     len(in_flight),
                 )
-                for task, wi in list(in_flight.items()):
+                for task, (wi, _work_item_id, _from_cache) in list(in_flight.items()):
                     task.cancel()
                     key = wi.file_target.get("path", "")
                     async with self._state_lock:
@@ -514,7 +556,7 @@ class HunterPool:
                 return spent
 
             for task in done:
-                wi = in_flight.pop(task)
+                wi, work_item_id, from_cache = in_flight.pop(task)
                 key = wi.file_target.get("path", "")
                 try:
                     result = await task
@@ -545,6 +587,17 @@ class HunterPool:
                         tier=tier,
                         band=wi.band,
                     )
+                if (
+                    result.status == "completed"
+                    and not from_cache
+                    and self.config.work_cache is not None
+                ):
+                    try:
+                        self.config.work_cache.save(work_item_id, result)
+                    except Exception:
+                        logger.warning(
+                            "Could not cache completed work %s", work_item_id, exc_info=True
+                        )
                 ep_suffix = f":{wi.entry_point.function_name}" if wi.entry_point else ""
                 async with self._state_lock:
                     self._results[f"{key}{ep_suffix}:{wi.band}:{wi.attempt}"] = result
@@ -625,6 +678,7 @@ class HunterPool:
                                 band=next_band,
                                 attempt=wi.attempt,
                                 seed_transcript=_extract_transcript(result),
+                                context_id=wi.context_id,
                             )
                         )
 

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -58,6 +58,7 @@ from .disclosure import (
 )
 from .exploiter import AgenticExploiter, Exploiter, apply_exploiter_result
 from .harness_generator import HarnessGenerator, HarnessGeneratorConfig, SeededCrash
+from .hunt_work_cache import HuntWorkCache
 from .instrumentation import SourceHuntInstrumentation, stable_run_id
 from .manifest import build_run_metadata
 from .mechanism_memory import (
@@ -252,6 +253,7 @@ class SourceHuntRunner:
         exploiter_llm: Any = None,
         sandbox_factory: Any = None,  # callable[[], SandboxContainer]
         parent_session_id: str | None = None,
+        resume_session_id: str | None = None,
         checkpoint: dict[str, Any] | str | None = None,
         checkpoint_path: str | Path | None = None,
         agent_mode: str = "auto",  # "auto" | "constrained" | "deep"
@@ -544,7 +546,18 @@ class SourceHuntRunner:
         self.sandbox_factory = sandbox_factory
         self._sandbox_manager: HunterSandbox | None = None
         self._preprocessor: Preprocessor | None = None
-        self._session_id = parent_session_id or f"sh-{uuid.uuid4().hex[:8]}"
+        # --resume reuses a prior session directory in place: same session id,
+        # so its checkpoint, spend ledger, findings pool, and hunt work cache
+        # are all continued rather than started fresh. It routes entirely through
+        # the checkpoint machinery below — there is no separate resume path.
+        if resume_session_id is not None:
+            if parent_session_id is not None:
+                raise ValueError("resume_session_id cannot be combined with parent_session_id")
+            session_dir = Path(self.output_dir) / resume_session_id
+            if not session_dir.is_dir():
+                raise ValueError(f"Sourcehunt session {resume_session_id!r} does not exist")
+        self._resuming = resume_session_id is not None
+        self._session_id = resume_session_id or parent_session_id or f"sh-{uuid.uuid4().hex[:8]}"
         self._checkpoint_path = (
             Path(checkpoint_path)
             if checkpoint_path is not None
@@ -787,6 +800,7 @@ class SourceHuntRunner:
                 manifest_filename=(
                     "spend-summary.json" if self._flow == "proof" else "manifest.json"
                 ),
+                resume=self._resuming,
             )
         return self._spend_ledger
 
@@ -2453,6 +2467,16 @@ class SourceHuntRunner:
                 files=stage_files,
                 symbols=hunt_symbols,
             )
+            # Work-item-granular hunt resume: when this run is checkpointed
+            # (always, once preprocessing has produced a checkpoint), memoize
+            # each completed hunter work item under the session directory. A
+            # resumed run reuses the finished work and re-runs only what was
+            # interrupted, instead of the coarse all-or-nothing HuntCheckpoint.
+            work_cache = (
+                HuntWorkCache(self._ensure_output_dir_layout() / "hunt-work")
+                if self._checkpoint is not None
+                else None
+            )
             pool = HunterPool(
                 HuntPoolConfig(
                     files=files,
@@ -2461,6 +2485,7 @@ class SourceHuntRunner:
                     sandbox_manager=self._sandbox_manager,
                     hunter_factory=None,
                     llm=hunter_llm,
+                    work_cache=work_cache,
                     max_parallel=self.max_parallel,
                     budget_usd=self.budget_usd,
                     tier_budget=self.tier_budget,

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -55,6 +55,15 @@ def add_parser(subparsers):
         choices=["preprocess", "rank", "hunt", "verify", "exploit"],
         help="Stop after the named stage completes (checkpoint is saved for resumption)",
     )
+    parser.add_argument(
+        "--resume",
+        metavar="SESSION_ID",
+        help=(
+            "Resume a prior legacy run in place by its session id (e.g. sh-535ed81b). "
+            "Reuses that session's checkpoint, spend ledger, and completed hunter work; "
+            "the repo and hunt options must match the original run"
+        ),
+    )
     parser.add_argument("--machine-fd", type=int, help=argparse.SUPPRESS)
     parser.add_argument(
         "--flow",
@@ -1160,6 +1169,7 @@ def handle(cli, args):
     runner = SourceHuntRunner(
         repo_url=args.repo,
         checkpoint=args.checkpoint,
+        resume_session_id=getattr(args, "resume", None),
         branch=args.branch,
         local_path=args.local_path,
         depth=args.depth,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -215,6 +215,28 @@ use a lowered 70% threshold with 100 runs.
   [--no-patch-oracle]           # skip patch-oracle truth test
 ```
 
+### Checkpointing & resume
+
+Every legacy run checkpoints its pipeline stages under
+`<output-dir>/<session>/`. Resume is a single system built on those
+checkpoints:
+
+```bash
+  [--checkpoint JSON]           # restore from a portable checkpoint blob
+  [--checkpoint-path PATH]      # where the checkpoint is saved
+  [--stop-after STAGE]          # stop after preprocess|rank|verify|exploit|hunt
+  [--resume SESSION_ID]         # resume a prior run in place (e.g. sh-535ed81b)
+```
+
+A completed stage restores whole. The **hunt** stage additionally memoizes
+each completed work item (file/band/attempt/context) under
+`<session>/hunt-work/`, so a run interrupted part way through resumes at
+work-item granularity — finished files are reused and only unfinished work
+re-runs. `--resume` continues the same session directory, including its spend
+ledger, so the dollar budget stays a lifetime cap across the resume. The repo
+and hunt options must match the original run; the model, endpoint, and
+credentials may change.
+
 ### `sourcehunt --nday` — N-day exploit pipeline
 
 ```bash

--- a/tests/test_sourcehunt_hunt_work_cache.py
+++ b/tests/test_sourcehunt_hunt_work_cache.py
@@ -1,0 +1,389 @@
+"""Work-item-granular hunt resume folded into the checkpoint architecture.
+
+Covers the ``HuntWorkCache`` store, its wiring into ``HunterPool`` (reuse
+completed work, save new work, ignore mismatched/corrupt entries), the
+idempotent findings-pool replay, the spend-ledger lifetime-budget resume, and
+the runner's ``--resume`` session validation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from clearwing.findings.types import Finding
+from clearwing.llm.budget import BudgetConfigurationError, SpendLedger
+from clearwing.runners.parallel.executor import TargetResult
+from clearwing.sourcehunt.entry_points import EntryPoint
+from clearwing.sourcehunt.findings_pool import FindingsPool
+from clearwing.sourcehunt.hunt_work_cache import HuntWorkCache
+from clearwing.sourcehunt.pool import HunterPool, HuntPoolConfig, WorkItem, _extract_transcript
+
+
+def _target(repo: Path, **overrides):
+    target = {
+        "path": "app.py",
+        "absolute_path": str(repo / "app.py"),
+        "surface": 4,
+        "influence": 4,
+        "reachability": 3,
+        "priority": 3.7,
+        "tier": "C",
+        "tags": ["attacker_reachable"],
+        "language": "python",
+        "loc": 1,
+        "surface_rationale": "ranked",
+        "influence_rationale": "ranked",
+        "reachability_rationale": "reachable",
+        "static_hint": 0,
+        "semgrep_hint": 0,
+        "taint_hits": 0,
+        "imports_by": 0,
+        "transitive_callers": 0,
+        "defines_constants": False,
+        "has_fuzz_entry_point": False,
+        "fuzz_harness_path": None,
+    }
+    target.update(overrides)
+    return target
+
+
+class _MemoryWorkCache:
+    """In-memory HuntWorkCache stand-in that records loads and saves."""
+
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+        self.loaded: list[str] = []
+        self.saved: list[tuple[str, TargetResult]] = []
+
+    def load(self, work_id):
+        self.loaded.append(work_id)
+        return self.values.get(work_id)
+
+    def save(self, work_id, result):
+        self.saved.append((work_id, result))
+        self.values[work_id] = result
+
+
+# --- HuntWorkCache store ----------------------------------------------------
+
+
+def test_completed_work_round_trips_and_corruption_is_a_cache_miss(tmp_path):
+    cache = HuntWorkCache(tmp_path / "hunt-work")
+    work_id = "work-" + "a" * 16
+    result = TargetResult(
+        target="app.py",
+        status="completed",
+        findings=[
+            Finding(
+                id="finding-1",
+                file="app.py",
+                line_number=1,
+                severity="high",
+                description="unsafe input",
+            )
+        ],
+        cost_usd=0.25,
+        tokens_used=20,
+        tier="A",
+        band="fast",
+    )
+    cache.save(work_id, result)
+
+    # A fresh cache over the same directory reads the persisted result back —
+    # this is exactly what a resumed process does.
+    restored = HuntWorkCache(tmp_path / "hunt-work").load(work_id)
+    assert restored is not None
+    assert restored.cost_usd == 0.25
+    assert isinstance(restored.findings[0], Finding)
+
+    # Zero-finding completed work is still cached (it is real, finished work).
+    zero_id = "work-" + "b" * 16
+    cache.save(zero_id, TargetResult(target="app.py", status="completed", findings=[], tier="A", band="fast"))
+    assert cache.load(zero_id) is not None
+
+    # A torn file is a cache miss, not a crash — the work simply re-runs.
+    (cache.work_dir / f"{work_id}.json").write_text('{"result":', encoding="utf-8")
+    assert cache.load(work_id) is None
+
+
+def test_only_completed_work_is_cached(tmp_path):
+    cache = HuntWorkCache(tmp_path / "hunt-work")
+    work_id = "work-" + "c" * 16
+    cache.save(work_id, TargetResult(target="app.py", status="error", findings=[], tier="A", band="fast"))
+    assert cache.load(work_id) is None
+    assert not (cache.work_dir / f"{work_id}.json").exists()
+    # A malformed id is never written or read.
+    assert cache.load("not-a-work-id") is None
+
+
+def test_save_is_write_once(tmp_path):
+    cache = HuntWorkCache(tmp_path / "hunt-work")
+    work_id = "work-" + "d" * 16
+    first = TargetResult(target="app.py", status="completed", findings=[], cost_usd=1.0, tier="A", band="fast")
+    second = TargetResult(target="app.py", status="completed", findings=[], cost_usd=9.0, tier="A", band="fast")
+    cache.save(work_id, first)
+    cache.save(work_id, second)  # ignored — first result is authoritative
+    assert cache.load(work_id).cost_usd == 1.0
+
+
+# --- HunterPool wiring ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cached_work_is_reused_and_promotions_follow_normal_path(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = _target(repo)
+    finding = Finding(
+        id="cached-finding",
+        file="app.py",
+        line_number=1,
+        severity="high",
+        description="cached bug",
+    )
+    base_result = TargetResult(
+        target="app.py",
+        status="completed",
+        findings=[finding],
+        cost_usd=1.0,
+        tier="A",
+        band="fast",
+        stop_reason="completed",
+    )
+    base = WorkItem(target, "fast")
+    promoted = WorkItem(target, "standard", seed_transcript=_extract_transcript(base_result))
+    work_cache = _MemoryWorkCache(
+        {
+            base.stable_identifier("sh-test", "A"): base_result,
+            promoted.stable_identifier("sh-test", "A"): TargetResult(
+                target="app.py", status="completed", findings=[], tier="A", band="standard"
+            ),
+        }
+    )
+    findings_pool = FindingsPool()
+    pool = HunterPool(
+        HuntPoolConfig(
+            files=[target],
+            repo_path=str(repo),
+            work_cache=work_cache,
+            findings_pool=findings_pool,
+            session_id_prefix="sh-test",
+            redundancy_override=1,
+            max_parallel=1,
+            starting_band="fast",
+            max_band="standard",
+        )
+    )
+    pool._run_file_task = AsyncMock(side_effect=AssertionError("cached work reran"))
+
+    findings = await pool.arun()
+
+    pool._run_file_task.assert_not_awaited()
+    assert [item.id for item in findings] == ["cached-finding"]
+    assert pool.promotion_counts == {"fast→standard": 1, "standard→deep": 0}
+    assert pool.total_spent == 1.0
+
+
+@pytest.mark.asyncio
+async def test_missing_work_runs_and_is_saved_even_with_zero_findings(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    target = _target(repo)
+    work_cache = _MemoryWorkCache()
+    pool = HunterPool(
+        HuntPoolConfig(
+            files=[target],
+            repo_path=str(repo),
+            work_cache=work_cache,
+            session_id_prefix="sh-test",
+            redundancy_override=1,
+            max_parallel=1,
+            starting_band="fast",
+            max_band="fast",
+        )
+    )
+    pool._run_file_task = AsyncMock(
+        return_value=TargetResult(
+            target="app.py", status="completed", findings=[], cost_usd=0.2, tier="A", band="fast"
+        )
+    )
+
+    assert await pool.arun() == []
+    pool._run_file_task.assert_awaited_once()
+    assert len(work_cache.saved) == 1
+    assert work_cache.saved[0][1].findings == []
+
+
+@pytest.mark.asyncio
+async def test_mismatched_cached_work_is_a_cache_miss(tmp_path):
+    target = _target(tmp_path)
+    item = WorkItem(target, "fast")
+    work_cache = _MemoryWorkCache(
+        {
+            item.stable_identifier("sh-test", "A"): TargetResult(
+                target="other.py", status="completed", findings=[], tier="A", band="fast"
+            )
+        }
+    )
+    pool = HunterPool(
+        HuntPoolConfig(
+            files=[target],
+            repo_path=str(tmp_path),
+            work_cache=work_cache,
+            session_id_prefix="sh-test",
+            redundancy_override=1,
+            max_parallel=1,
+            starting_band="fast",
+            max_band="fast",
+        )
+    )
+    pool._run_file_task = AsyncMock(
+        return_value=TargetResult(
+            target="app.py", status="completed", findings=[], tier="A", band="fast"
+        )
+    )
+
+    await pool.arun()
+
+    pool._run_file_task.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_findings_pool_add_is_idempotent(tmp_path):
+    path = tmp_path / "findings-pool.jsonl"
+    original = Finding(
+        id="cached-finding",
+        file="app.py",
+        line_number=1,
+        finding_type="command_injection",
+        severity="critical",
+        description="cached bug",
+    )
+    pool = FindingsPool(checkpoint_path=path)
+    await pool.add(original)
+    cluster_id = original.cluster_id
+
+    resumed = FindingsPool.from_checkpoint(path)
+    restored = await resumed.add(
+        Finding(
+            id="cached-finding",
+            file="app.py",
+            line_number=1,
+            finding_type="command_injection",
+            severity="critical",
+            description="cached bug",
+        )
+    )
+
+    assert resumed.count == 1
+    assert restored.cluster_id == cluster_id
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+# --- Work-item identity -----------------------------------------------------
+
+
+def test_work_ids_distinguish_overloaded_entry_points(tmp_path):
+    target = _target(tmp_path)
+    first = WorkItem(target, "fast", entry_point=EntryPoint("app.py", "parse", 1, 10, "parser", "first"))
+    second = WorkItem(target, "fast", entry_point=EntryPoint("app.py", "parse", 20, 30, "parser", "second"))
+    assert first.stable_identifier("sh-test", "A") != second.stable_identifier("sh-test", "A")
+
+
+def test_work_ids_vary_with_tier_and_context(tmp_path):
+    target = _target(tmp_path)
+    item = WorkItem(target, "fast")
+    assert item.stable_identifier("sh-test", "A") != item.stable_identifier("sh-test", "B")
+    with_context = WorkItem(target, "fast", context_id="ctx-1")
+    assert item.stable_identifier("sh-test", "A") != with_context.stable_identifier("sh-test", "A")
+
+
+# --- Spend ledger lifetime-budget resume ------------------------------------
+
+
+def _ledger(tmp_path: Path, session_id: str, *, resume: bool = False) -> SpendLedger:
+    return SpendLedger(
+        limit_usd=10.0,
+        session_id=session_id,
+        repo_url="repo",
+        output_dir=tmp_path,
+        input_price_per_million=0.0,
+        output_price_per_million=1_000_000.0,
+        resume=resume,
+    )
+
+
+def test_spend_resume_restores_settlements_and_ignores_a_truncated_tail(tmp_path):
+    ledger = _ledger(tmp_path, "settled")
+    reservation = ledger.reserve_call(
+        model="test",
+        provider="test",
+        stage="hunt",
+        input_token_upper_bound=0,
+        requested_max_output_tokens=2,
+        supports_output_limit=True,
+    )
+    ledger.settle_call(reservation, input_tokens=2, output_tokens=1)
+    ledger.finalize("failed")
+    with ledger.ledger_path.open("a", encoding="utf-8") as stream:
+        stream.write('{"event":')
+
+    resumed = _ledger(tmp_path, "settled", resume=True)
+    assert resumed.spent_usd == pytest.approx(1.0)
+    assert resumed.snapshot()["total_tokens"] == 3
+
+
+def test_spend_resume_charges_an_orphaned_reservation_only_once(tmp_path):
+    ledger = _ledger(tmp_path, "orphan")
+    reservation = ledger.reserve_call(
+        model="test",
+        provider="test",
+        stage="hunt",
+        input_token_upper_bound=0,
+        requested_max_output_tokens=2,
+        supports_output_limit=True,
+    )
+    first_resume = _ledger(tmp_path, "orphan", resume=True)
+    assert first_resume.spent_usd == pytest.approx(reservation.reserved_usd)
+    first_resume.finalize("failed")
+
+    second_resume = _ledger(tmp_path, "orphan", resume=True)
+    assert second_resume.spent_usd == pytest.approx(reservation.reserved_usd)
+
+
+def test_spend_resume_refuses_a_missing_or_corrupt_ledger(tmp_path):
+    with pytest.raises(BudgetConfigurationError, match="ledger is missing"):
+        _ledger(tmp_path, "missing", resume=True)
+
+    ledger = _ledger(tmp_path, "corrupt")
+    ledger.ledger_path.write_text("not-json\n{}\n", encoding="utf-8")
+    with pytest.raises(BudgetConfigurationError, match="ledger is corrupt"):
+        _ledger(tmp_path, "corrupt", resume=True)
+
+
+# --- Runner --resume validation ---------------------------------------------
+
+
+def test_runner_resume_requires_an_existing_session(tmp_path):
+    from clearwing.sourcehunt.runner import SourceHuntRunner
+
+    with pytest.raises(ValueError, match="does not exist"):
+        SourceHuntRunner(
+            repo_url="x", output_dir=str(tmp_path), resume_session_id="sh-nope"
+        )
+
+
+def test_runner_resume_conflicts_with_parent_session(tmp_path):
+    from clearwing.sourcehunt.runner import SourceHuntRunner
+
+    (Path(tmp_path) / "sh-a").mkdir()
+    with pytest.raises(ValueError, match="cannot be combined"):
+        SourceHuntRunner(
+            repo_url="x",
+            output_dir=str(tmp_path),
+            resume_session_id="sh-a",
+            parent_session_id="sh-b",
+        )


### PR DESCRIPTION
Folds the work-item memoization from **#143** *into* the existing checkpoint/resume architecture (#151–#164) instead of adding a second, parallel resume system. One resume path, finer resolution.

## Why

#143 was written before the checkpoint system landed, so it added its own resume mechanism (`resume.py`, a separate `--resume` with its own manifest/fingerprint/session-lock/rank-plan). That collided with the checkpoint stages already on `main` — two CLIs, two persistence models, two code paths. But the *idea* was valuable: the checkpoint system's `HuntCheckpoint` is all-or-nothing (restores only a fully-completed hunt), so a hunt interrupted part way re-runs every finished file.

This keeps the checkpoint system as the single resume path and gives just the **hunt stage** work-item resolution.

## What

- **`hunt_work_cache.py`** — `HuntWorkCache`, an incremental write-once per-work-item store (adapted from #143's validated `resume.py` load/save, dropping the manifest/fingerprint/rank-plan/session-lock — the checkpoint stages already validate compatibility and restore the rank plan). Anything missing/malformed/not-`completed` is a cache miss, so the work just re-runs.
- **`pool.py`** — `WorkItem.stable_identifier` folds in tier / entry-point identity / seed context / a per-file `context_id` so a cached result is never reused across changed inputs; `HunterPool` reuses a completed result (as a resolved future) or runs and saves it.
- **`findings_pool.py`** — `FindingsPool.add` is idempotent on finding id (cached findings aren't double-counted on resume).
- **`budget.py`** — `SpendLedger(resume=True)` replays the existing ledger so the dollar cap stays a **lifetime** budget across a resume; an interrupted reservation is charged once.
- **`runner.py` / CLI** — the hunt stage always memoizes under `<session>/hunt-work/`; **`--resume SESSION_ID`** continues a prior session directory in place, routing entirely through the existing checkpoint / ledger / findings-pool machinery. No parallel resume path.

A fully-completed hunt still restores whole (fast path, unchanged). Only an *interrupted* hunt uses the work-item cache.

## Not carried over from #143

Its separate `resume.py` (manifest/fingerprint/rank-plan/session-lock) and its standalone `--resume` machinery — all replaced by the checkpoint system. Subsystem hunts remain stage-granular (the per-file `HunterPool` is where the reuse win is).

## Testing

14 new tests in `tests/test_sourcehunt_hunt_work_cache.py` (store round-trip/corruption/write-once, pool reuse + promotion, missing-work-saved, mismatched-cache miss, idempotent findings replay, work-item identity, ledger lifetime-budget resume, `--resume` validation). Full affected suite (`sourcehunt`/`pool`/`checkpoint`/`budget`/`hunter`/`findings`/`runner`): **1230 passed**, ruff clean.

Supersedes #143 — suggest closing it in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShCktZJoeBkVa3kGj6BKVS