### PR TITLE
refactor(llm): stop sending output-token caps

### DIFF
--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -36,7 +36,6 @@ from pydantic import BaseModel, ConfigDict, RootModel
 from clearwing.observability.otel import get_oi_tracer
 
 from .budget import (
-    BudgetExceeded,
     BudgetReservation,
     SpendLedger,
     current_spend_metadata,
@@ -91,7 +90,6 @@ def _trace_genai_input(model: str, request: ChatRequest, options: ChatOptions) -
                 "options": {
                     "temperature": options.temperature,
                     "top_p": options.top_p,
-                    "max_tokens": options.max_tokens,
                     "reasoning_effort": options.reasoning_effort,
                     "response_json_mode": options.response_json_mode,
                     "response_json_spec": str(options.response_json_spec)
@@ -293,37 +291,6 @@ _REASONING_EFFORT_LOW_DEFAULT_PATTERNS: tuple[str, ...] = (
 # for names matching this list. Case-insensitive substring match on the model
 # name. Add new offenders here as they surface.
 _REASONING_CAPTURE_UNSUPPORTED_PATTERNS: tuple[str, ...] = ("gpt-5.3-codex-spark",)
-
-# Truncation-retry policy. Under a dollar budget the applied output cap is
-# known locally; a response whose completion_tokens reached that cap AND
-# carries no tool call was almost certainly cut off mid-generation
-# (provider finish_reason == "length"). genai-pyo3's ChatResponse does not
-# surface finish_reason, so we detect via the token count and retry ONCE with
-# a larger cap so reasoning models aren't robbed of the turn that would have
-# emitted their tool call. Bounded to a single escalation to avoid loops; the
-# affordability clamp in reserve_call still bounds total spend, and a
-# genuinely-exhausted budget raises BudgetExceeded which we swallow so the
-# truncated response is returned rather than looping.
-_TRUNCATION_RETRY_ESCALATION = 4
-_TRUNCATION_RETRY_CEILING = 65536
-
-
-def _looks_truncated(response: ChatResponse, applied_max_tokens: int | None) -> bool:
-    """True when *response* appears cut off at the output-token cap.
-
-    genai-pyo3's ChatResponse carries no finish_reason, so we use the reliable
-    proxy: a capped call whose completion_tokens reached the applied cap was
-    truncated. Returns False when no cap was applied (``applied_max_tokens is
-    None``) or usage is unavailable.
-    """
-    if applied_max_tokens is None:
-        return False
-    usage = getattr(response, "usage", None)
-    completion = getattr(usage, "completion_tokens", None) if usage is not None else None
-    if completion is None:
-        return False
-    return completion >= applied_max_tokens
-
 
 def _model_supports_reasoning_capture(model_name: str) -> bool:
     """False when *model_name* rejects reasoning-content capture (blacklist)."""
@@ -637,16 +604,13 @@ class AsyncLLMClient:
             self._anthropic_oauth_url = "https://api.anthropic.com/v1/messages"
 
         self.default_system = default_system
-        # Role-binding inference defaults: applied by achat/achat_stream when a
-        # call site passes temperature/max_tokens=None. A call that specifies
-        # either value wins; these only fill the gap, so no existing call site
-        # changes behavior.
+        # Role-binding inference defaults are resolved before each call.
         self.default_temperature = default_temperature
         self.default_max_tokens = default_max_tokens
         # Nucleus-sampling default (ChatOptions.top_p) and a per-attempt wall
         # clock. Both fill in only when a call passes None, mirroring the
-        # temperature/max_tokens defaults. `timeout_seconds` is enforced by the
-        # client (asyncio.wait_for), not a provider parameter.
+        # temperature default. `timeout_seconds` is enforced by the client
+        # (asyncio.wait_for), not a provider parameter.
         self.default_top_p = default_top_p
         self.timeout_seconds = default_timeout_seconds
         # How much conversation context this role should carry before the
@@ -672,12 +636,6 @@ class AsyncLLMClient:
         # every model except the blacklisted ones (see
         # _REASONING_CAPTURE_UNSUPPORTED_PATTERNS), which error if it's set.
         self.capture_reasoning_content = _model_supports_reasoning_capture(model_name)
-        # Some Responses-compatible gateways reject the standard
-        # `max_output_tokens` field.  Learn that once from an explicit HTTP
-        # 400 and omit the optional provider-side cap for the rest of this
-        # client session; the spend ledger still reserves against the caller's
-        # requested maximum before ChatOptions is built.
-        self._omit_max_tokens = False
         self.rate_limit_max_retries = max(0, rate_limit_max_retries)
         self.timeout_max_retries = max(0, timeout_max_retries)
         self.rate_limit_initial_backoff_seconds = max(0.1, rate_limit_initial_backoff_seconds)
@@ -861,7 +819,6 @@ class AsyncLLMClient:
         response_schema: type[BaseModel] | None = None,
         response_schema_name: str | None = None,
         response_schema_description: str | None = None,
-        _truncation_retry: int = 0,
         cache_prefix: bool = False,
         prompt_cache_key: str | None = None,
     ) -> ChatResponse:
@@ -897,17 +854,14 @@ class AsyncLLMClient:
             tools=tools,
             max_tokens=max_tokens,
         )
-        if reservation is not None and self._spend_ledger is not None:
-            if self._spend_ledger.enforcing:
-                max_tokens = reservation.max_output_tokens
-
         started = time.monotonic()
         dispatched = False
         try:
             options = ChatOptions(
                 temperature=temperature,
                 top_p=top_p,
-                max_tokens=None if self._omit_max_tokens else max_tokens,
+                # Output-token fields are deliberately never sent. Provider
+                # gateways disagree on their spelling and semantics.
                 capture_content=True,
                 capture_usage=True,
                 capture_tool_calls=True,
@@ -951,20 +905,6 @@ class AsyncLLMClient:
                         )
                         self.reasoning_effort = None
                         options = self._rebuild_options_without_reasoning(options)
-                        response = await self._with_retries(
-                            lambda: self._achat_with_provider_policy(client, request, options)
-                        )
-                    elif (
-                        options.max_tokens is not None
-                        and self._is_unsupported_max_output_tokens_error(exc)
-                    ):
-                        logger.warning(
-                            "Provider rejected max_output_tokens for model %r; retrying "
-                            "without it and disabling it for this session.",
-                            self.model_name,
-                        )
-                        self._omit_max_tokens = True
-                        options = self._rebuild_options_without_max_tokens(options)
                         response = await self._with_retries(
                             lambda: self._achat_with_provider_policy(client, request, options)
                         )
@@ -1014,43 +954,6 @@ class AsyncLLMClient:
             cached_tokens=cached_tokens,
         )
 
-        applied_cap = None if self._omit_max_tokens else max_tokens
-        # Only retry the truncation fingerprint: a capped turn that produced
-        # NEITHER a tool call NOR visible text (reasoning tokens consumed the
-        # whole cap before any output). A response carrying text is a real
-        # answer — e.g. a ranker emitting JSON at a tight cap — and must never
-        # be retried, or we'd regenerate valid output and risk over-spending.
-        has_output = bool(n_tool_calls) or bool(getattr(response, "first_text", None))
-        if _truncation_retry < 1 and not has_output and _looks_truncated(response, applied_cap):
-            escalated = min(applied_cap * _TRUNCATION_RETRY_ESCALATION, _TRUNCATION_RETRY_CEILING)
-            if escalated > applied_cap:
-                logger.warning(
-                    "LLM response for model=%s truncated at output cap "
-                    "(completion_tokens=%s >= max_tokens=%s) with no tool call "
-                    "or text; retrying once with max_tokens=%s.",
-                    self.model_name,
-                    completion_tokens,
-                    applied_cap,
-                    escalated,
-                )
-                try:
-                    return await self.achat(
-                        messages=messages,
-                        system=system,
-                        tools=tools,
-                        temperature=temperature,
-                        max_tokens=escalated,
-                        response_schema=response_schema,
-                        response_schema_name=response_schema_name,
-                        response_schema_description=response_schema_description,
-                        _truncation_retry=_truncation_retry + 1,
-                    )
-                except BudgetExceeded:
-                    logger.warning(
-                        "Truncation retry for model=%s could not be afforded "
-                        "(budget exhausted); returning the truncated response.",
-                        self.model_name,
-                    )
         return response
 
     async def achat_stream(
@@ -1063,7 +966,6 @@ class AsyncLLMClient:
         max_tokens: int | None = None,
         top_p: float | None = None,
         on_text_delta: Callable[[str], None] | None = None,
-        _truncation_retry: int = 0,
         cache_prefix: bool = False,
         prompt_cache_key: str | None = None,
     ) -> ChatResponse:
@@ -1110,17 +1012,12 @@ class AsyncLLMClient:
             tools=tools,
             max_tokens=max_tokens,
         )
-        if reservation is not None and self._spend_ledger is not None:
-            if self._spend_ledger.enforcing:
-                max_tokens = reservation.max_output_tokens
-
         started = time.monotonic()
         dispatched = False
         try:
             options = ChatOptions(
                 temperature=temperature,
                 top_p=top_p,
-                max_tokens=None if self._omit_max_tokens else max_tokens,
                 capture_content=True,
                 capture_usage=True,
                 capture_tool_calls=True,
@@ -1158,18 +1055,6 @@ class AsyncLLMClient:
                         )
                         self.reasoning_effort = None
                         options = self._rebuild_options_without_reasoning(options)
-                        response = await _consume(options)
-                    elif (
-                        options.max_tokens is not None
-                        and self._is_unsupported_max_output_tokens_error(exc)
-                    ):
-                        logger.warning(
-                            "Provider rejected max_output_tokens (streaming) for model "
-                            "%r; retrying without it and disabling it for this session.",
-                            self.model_name,
-                        )
-                        self._omit_max_tokens = True
-                        options = self._rebuild_options_without_max_tokens(options)
                         response = await _consume(options)
                     elif self._should_try_openai_http_fallback(exc) and (
                         not (self._spend_ledger is not None and self._spend_ledger.enforcing)
@@ -1235,39 +1120,6 @@ class AsyncLLMClient:
             cached_tokens=cached_tokens,
         )
 
-        applied_cap = None if self._omit_max_tokens else max_tokens
-        # Same fingerprint as achat: retry only a capped turn with no tool call
-        # AND no visible text; a text-bearing answer is never a truncation.
-        has_output = bool(n_tool_calls) or bool(getattr(response, "first_text", None))
-        if _truncation_retry < 1 and not has_output and _looks_truncated(response, applied_cap):
-            escalated = min(applied_cap * _TRUNCATION_RETRY_ESCALATION, _TRUNCATION_RETRY_CEILING)
-            if escalated > applied_cap:
-                logger.warning(
-                    "LLM stream for model=%s truncated at output cap "
-                    "(completion_tokens=%s >= max_tokens=%s) with no tool call "
-                    "or text; retrying once with max_tokens=%s.",
-                    self.model_name,
-                    completion_tokens,
-                    applied_cap,
-                    escalated,
-                )
-                try:
-                    return await self.achat_stream(
-                        messages=messages,
-                        system=system,
-                        tools=tools,
-                        temperature=temperature,
-                        max_tokens=escalated,
-                        on_text_delta=on_text_delta,
-                        _truncation_retry=_truncation_retry + 1,
-                    )
-                except BudgetExceeded:
-                    logger.warning(
-                        "Truncation retry (streaming) for model=%s could not be "
-                        "afforded (budget exhausted); returning the truncated "
-                        "response.",
-                        self.model_name,
-                    )
         return response
 
     def chat(self, **kwargs: Any) -> ChatResponse:
@@ -1336,10 +1188,11 @@ class AsyncLLMClient:
     def _codex_safe_params(
         self, temperature: float | None, max_tokens: int | None
     ) -> tuple[float | None, int | None]:
-        # The ChatGPT Codex (openai_codex) backend rejects `temperature` and
-        # `max_output_tokens`, so omit both for that provider.
+        # The ChatGPT Codex (openai_codex) backend rejects `temperature`.
+        # Output-token fields are omitted for every provider when ChatOptions
+        # is built; max_tokens remains an internal accounting hint here.
         if self.provider_name == "openai_codex":
-            return None, None
+            return None, max_tokens
         return temperature, max_tokens
 
     def _build_client(self, client_cls):
@@ -1592,8 +1445,9 @@ class AsyncLLMClient:
             body["temperature"] = options.temperature
         if options.top_p is not None:
             body["top_p"] = options.top_p
-        if options.max_tokens is not None:
-            body["max_tokens"] = options.max_tokens
+        # Output-token caps are intentionally absent even if this low-level
+        # fallback is handed an options object containing one. Keeping the
+        # omission here makes it a transport invariant.
         if options.stop_sequences:
             body["stop"] = list(options.stop_sequences)
         if options.seed is not None:
@@ -1993,31 +1847,12 @@ class AsyncLLMClient:
         return ChatOptions(
             temperature=options.temperature,
             top_p=options.top_p,
-            max_tokens=options.max_tokens,
             capture_content=options.capture_content,
             capture_usage=options.capture_usage,
             capture_tool_calls=options.capture_tool_calls,
             capture_reasoning_content=options.capture_reasoning_content,
             normalize_reasoning_content=options.normalize_reasoning_content,
             reasoning_effort=None,
-            prompt_cache_key=options.prompt_cache_key,
-            response_json_spec=options.response_json_spec,
-        )
-
-    @staticmethod
-    def _rebuild_options_without_max_tokens(options: ChatOptions) -> ChatOptions:
-        """Return a copy of *options* with ``max_tokens=None``."""
-
-        return ChatOptions(
-            temperature=options.temperature,
-            top_p=options.top_p,
-            max_tokens=None,
-            capture_content=options.capture_content,
-            capture_usage=options.capture_usage,
-            capture_tool_calls=options.capture_tool_calls,
-            capture_reasoning_content=options.capture_reasoning_content,
-            normalize_reasoning_content=options.normalize_reasoning_content,
-            reasoning_effort=options.reasoning_effort,
             prompt_cache_key=options.prompt_cache_key,
             response_json_spec=options.response_json_spec,
         )
@@ -2033,15 +1868,6 @@ class AsyncLLMClient:
         """
         text = str(exc).lower()
         if "reasoning_effort" not in text:
-            return False
-        return "400" in text or "unsupported" in text
-
-    @staticmethod
-    def _is_unsupported_max_output_tokens_error(exc: BaseException) -> bool:
-        """True for an explicit rejection of Responses' output-token cap."""
-
-        text = str(exc).lower()
-        if "max_output_tokens" not in text:
             return False
         return "400" in text or "unsupported" in text
 

--- a/clearwing/providers/manager.py
+++ b/clearwing/providers/manager.py
@@ -427,12 +427,12 @@ class ProviderManager:
               roles:                             # explicit bindings
                 reviewer:
                   model: qwen_a95b               # -> a models: name, or literal
-                  inference: {reasoning: xhigh, max_output_tokens: 32768}
+                  inference: {reasoning: xhigh}
                   constraints: {independent_model_family: true}
               overrides: {frontier: {reasoning: max}}   # legacy flat overrides
 
         Bindings are validated against model capabilities at load time — an
-        unsupported reasoning level or an over-ceiling output budget raises
+        unsupported inference setting raises
         :class:`clearwing.providers.binding.BindingValidationError` here,
         before any scan starts.
         """
@@ -871,8 +871,7 @@ class ProviderManager:
         # model family (a local Qwen that rejects the param is downgraded to
         # None). Unset reasoning keeps the client's "auto" per-model default.
         effort = effective_reasoning_effort(model, reasoning) if reasoning is not None else "auto"
-        # Inference budgets become client-level defaults: they fill a call's
-        # temperature/max_tokens only when the call site leaves them None.
+        # Inference settings become client-level defaults.
         temp = inference.temperature if inference else None
         max_out = inference.max_output_tokens if inference else None
         ctx_budget = inference.context_budget_tokens if inference else None

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -1703,7 +1703,6 @@ class NativeHunter:
                     messages=messages,
                     system=self.prompt,
                     tools=active_tools,
-                    max_tokens=24000,
                     # Prompt caching: mark the growing prefix cacheable so each
                     # turn re-reads system + tools + prior history from cache
                     # instead of paying full input price to re-send it. This is

--- a/clearwing/sourcehunt/ranker.py
+++ b/clearwing/sourcehunt/ranker.py
@@ -336,7 +336,6 @@ class Ranker:
                             user=user_msg,
                             schema_model=RankedFileScoreResponse,
                             schema_name="ranked_file_score_response",
-                            max_tokens=16000,
                         ),
                         timeout=self.config.llm_timeout_seconds,
                     )
@@ -346,7 +345,6 @@ class Ranker:
                         user=user_msg,
                         schema_model=RankedFileScoreResponse,
                         schema_name="ranked_file_score_response",
-                        max_tokens=16000,
                     )
                 elapsed = asyncio.get_running_loop().time() - started_at
                 logger.info(

--- a/clearwing/ui/commands/doctor.py
+++ b/clearwing/ui/commands/doctor.py
@@ -278,7 +278,6 @@ def _invoke_test_native(endpoint) -> DoctorCheck:
         resp = asyncio.run(
             client.achat(
                 messages=[ChatMessage("user", "Reply with exactly the word PONG.")],
-                max_tokens=16,
             )
         )
     except Exception as exc:

--- a/docs/model-roles.md
+++ b/docs/model-roles.md
@@ -49,8 +49,8 @@ task string  ->  role  ->  (tier, inference profile)  ->  concrete model
 - **`tier`** is a rung on a provider's ladder (`small` / `mid` / `large`).
   A provider only answers three questions, and every role resolves.
 - **`inference profile`** is the policy: `reasoning` budget (in
-  `AsyncLLMClient` vocabulary, `none` … `max`), `max_output_tokens`,
-  `temperature`, and (staged) `context_budget_tokens`, `tool_choice`,
+  `AsyncLLMClient` vocabulary, `none` … `max`), `temperature`, and (staged)
+  `context_budget_tokens`, `tool_choice`,
   `parallel_tool_calls`, `timeout_seconds`.
 
 Concrete model ids never appear in the role layer. That indirection is
@@ -183,13 +183,13 @@ model_roles:
   roles:
     researcher:
       model: flash
-      inference: { reasoning: high, max_output_tokens: 32768, temperature: 0.2 }
+      inference: { reasoning: high, temperature: 0.2 }
     builder:
       model: flash
-      inference: { reasoning: high, max_output_tokens: 24576, temperature: 0.1 }
+      inference: { reasoning: high, temperature: 0.1 }
     reviewer:
       model: a95b
-      inference: { reasoning: xhigh, max_output_tokens: 32768 }
+      inference: { reasoning: xhigh }
       constraints: { independent_model_family: true }
 ```
 
@@ -209,11 +209,11 @@ denylist the client uses (Qwen2 / Gemma / Llama / Mistral reject the
 parameter) and validates against that — it just never invents a ceiling
 it doesn't actually know.
 
-**Wired to the wire now:** `reasoning`, `max_output_tokens`, `temperature`,
-`top_p` (these become client-level defaults a call site can still
-override), `timeout_seconds` (a per-attempt wall clock enforced by the
-client), `context_budget_tokens` (see below), and `fallback:` availability
-failover (see below). **Schema + validation only:** `tool_choice` and
+**Provider request settings:** `reasoning`, `temperature`, and `top_p`.
+`timeout_seconds` is a per-attempt wall clock enforced by the client;
+`context_budget_tokens` controls local context management (see below); and
+`fallback:` controls availability failover (see below). **Schema + validation
+only:** `tool_choice` and
 `parallel_tool_calls` — the native `genai_pyo3` transport doesn't expose
 these yet, so they're carried and validated but not sent; they light up
 once the transport gains support. **Further step:** runtime call-failure
@@ -294,7 +294,7 @@ model_roles:
     network.investigate:            # a new named route
       role: researcher
       agent: { max_steps: 20 }
-      inference: { max_output_tokens: 12000 }   # trim output for this route only
+      inference: { temperature: 0.1 }
 ```
 
 `agent:` limits (`max_steps` / `max_tool_calls` / `max_retries`, positive

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -556,4 +556,3 @@ class TestInferenceWiring:
 
         opts = ChatOptions(top_p=0.8, reasoning_effort="high", max_tokens=1000)
         assert AsyncLLMClient._rebuild_options_without_reasoning(opts).top_p == 0.8
-        assert AsyncLLMClient._rebuild_options_without_max_tokens(opts).top_p == 0.8

--- a/tests/test_llm_openai_fallback.py
+++ b/tests/test_llm_openai_fallback.py
@@ -44,6 +44,9 @@ def test_openai_fallback_request_body_includes_system_tools_and_json_schema():
     assert body["tools"][0]["function"]["name"] == "lookup"
     assert body["reasoning_effort"] == "medium"
     assert body["response_format"]["type"] == "json_schema"
+    assert "max_tokens" not in body
+    assert "max_completion_tokens" not in body
+    assert "max_output_tokens" not in body
 
 
 def test_openai_fallback_parses_reasoning_content_usage_and_tool_calls():

--- a/tests/test_llm_spend_budget.py
+++ b/tests/test_llm_spend_budget.py
@@ -125,7 +125,7 @@ def test_reservations_are_atomic_across_concurrent_native_calls(tmp_path, monkey
 
     assert sum(isinstance(result, ChatResponse) for result in results) == 1
     assert sum(isinstance(result, BudgetExceeded) for result in results) == 7
-    assert observed_caps == [1]
+    assert observed_caps == [None]
     assert ledger.spent_usd == pytest.approx(1.0)
     assert ledger.remaining_usd == pytest.approx(0.0)
 
@@ -282,7 +282,7 @@ def test_streaming_calls_settle_against_the_same_ledger(tmp_path, monkeypatch):
 
     assert result is response
     assert deltas == ["ok"]
-    assert observed_caps == [1]
+    assert observed_caps == [None]
     assert ledger.spent_usd == pytest.approx(1.0)
 
 

--- a/tests/test_native_reasoning_effort.py
+++ b/tests/test_native_reasoning_effort.py
@@ -10,13 +10,10 @@ from unittest.mock import patch
 import pytest
 from genai_pyo3 import ChatResponse
 
-from clearwing.llm.budget import BudgetExceeded
 from clearwing.llm.native import (
     _REASONING_EFFORT_OVERRIDE_ALLOW,
     _REASONING_EFFORT_UNSUPPORTED_PATTERNS,
-    _TRUNCATION_RETRY_ESCALATION,
     AsyncLLMClient,
-    _looks_truncated,
 )
 
 
@@ -224,7 +221,7 @@ class TestTimeoutRetryPolicy:
 class TestRebuildOptionsWithoutReasoning:
     """Layer 2 helper: reconstruct ChatOptions with reasoning_effort dropped."""
 
-    def test_drops_reasoning_effort_preserves_everything_else(self):
+    def test_drops_reasoning_effort_without_reintroducing_output_cap(self):
         from genai_pyo3 import ChatOptions
 
         original = ChatOptions(
@@ -242,7 +239,7 @@ class TestRebuildOptionsWithoutReasoning:
 
         assert rebuilt.reasoning_effort is None
         assert rebuilt.temperature == 0.7
-        assert rebuilt.max_tokens == 2048
+        assert rebuilt.max_tokens is None
         assert rebuilt.capture_content is True
         assert rebuilt.capture_usage is True
         assert rebuilt.capture_tool_calls is True
@@ -406,144 +403,44 @@ class TestAchatStreamRetryOnUnsupportedReasoning:
         assert client.reasoning_effort is None
 
 
-class TestLooksTruncated:
-    """The truncation proxy: completion_tokens reached the applied cap."""
-
-    def test_at_cap_is_truncated(self):
-        resp = _FakeResponse(completion_tokens=4096)
-        assert _looks_truncated(resp, 4096) is True
-
-    def test_over_cap_is_truncated(self):
-        resp = _FakeResponse(completion_tokens=5000)
-        assert _looks_truncated(resp, 4096) is True
-
-    def test_under_cap_is_not_truncated(self):
-        resp = _FakeResponse(completion_tokens=100)
-        assert _looks_truncated(resp, 4096) is False
-
-    def test_no_cap_is_never_truncated(self):
-        resp = _FakeResponse(completion_tokens=999999)
-        assert _looks_truncated(resp, None) is False
-
-
-class TestAchatTruncationRetry:
-    """achat detects a capped, tool-call-less response and retries once."""
-
+class TestOutputTokenCapsAreNeverSent:
     def _make_client(self):
-        # No spend ledger → reservation is None and max_tokens flows straight
-        # from the caller, so we control the applied cap directly.
         return AsyncLLMClient(
-            model_name="deepseek-v4-flash",
-            provider_name="openai_compat",
+            model_name="gpt-5.6-sol",
+            provider_name="openai_resp",
             api_key="sk-test",
+            default_max_tokens=32768,
         )
 
-    def _run(self, client, fake_policy, *, max_tokens):
+    def test_non_streaming_omits_cap_even_when_caller_requests_one(self):
+        client = self._make_client()
+        observed: list[int | None] = []
+
+        async def fake_policy(self_, client_obj, request, options):
+            observed.append(options.max_tokens)
+            return _FakeResponse(completion_tokens=100, text="done")
+
         with (
             patch.object(AsyncLLMClient, "_achat_with_provider_policy", new=fake_policy),
             patch.object(AsyncLLMClient, "_build_client", new=lambda self, cls: object()),
         ):
-            return asyncio.run(
-                client.achat(messages=[], system=None, tools=None, max_tokens=max_tokens)
+            result = asyncio.run(
+                client.achat(messages=[], system=None, tools=None, max_tokens=4096)
             )
 
-    def test_retries_once_with_escalated_cap(self):
+        assert result.first_text == "done"
+        assert observed == [None]
+
+    def test_streaming_omits_default_cap(self):
         client = self._make_client()
-        caps: list = []
-
-        async def fake_policy(self_, client_obj, request, options):
-            caps.append(options.max_tokens)
-            if len(caps) == 1:
-                # Truncation fingerprint: at cap, no tool call, no text.
-                return _FakeResponse(completion_tokens=100, tool_calls=[], text="")
-            return _FakeResponse(completion_tokens=50, tool_calls=[], text="done")
-
-        result = self._run(client, fake_policy, max_tokens=100)
-
-        assert caps == [100, 100 * _TRUNCATION_RETRY_ESCALATION]
-        assert result.usage.completion_tokens == 50
-
-    def test_no_retry_when_text_present_even_at_cap(self):
-        """A text-bearing answer at the cap (e.g. ranker JSON on a tight budget)
-        is a real answer, not a truncation — must NOT retry."""
-        client = self._make_client()
-        caps: list = []
-
-        async def fake_policy(self_, client_obj, request, options):
-            caps.append(options.max_tokens)
-            return _FakeResponse(completion_tokens=100, tool_calls=[], text='{"results": []}')
-
-        result = self._run(client, fake_policy, max_tokens=100)
-
-        assert caps == [100]
-        assert result.first_text == '{"results": []}'
-
-    def test_no_retry_when_tool_calls_present(self):
-        client = self._make_client()
-        caps: list = []
-
-        async def fake_policy(self_, client_obj, request, options):
-            caps.append(options.max_tokens)
-            # At cap, but a tool call means the turn did useful work.
-            return _FakeResponse(completion_tokens=100, tool_calls=[object()])
-
-        result = self._run(client, fake_policy, max_tokens=100)
-
-        assert caps == [100]
-        assert result.tool_calls
-
-    def test_no_retry_when_under_cap(self):
-        client = self._make_client()
-        caps: list = []
-
-        async def fake_policy(self_, client_obj, request, options):
-            caps.append(options.max_tokens)
-            return _FakeResponse(completion_tokens=50, tool_calls=[])
-
-        self._run(client, fake_policy, max_tokens=100)
-
-        assert caps == [100]
-
-    def test_only_one_retry_even_if_still_truncated(self):
-        client = self._make_client()
-        caps: list = []
-
-        async def fake_policy(self_, client_obj, request, options):
-            caps.append(options.max_tokens)
-            # Always truncated at whatever cap was applied → would loop forever
-            # if the single-retry guard were missing.
-            return _FakeResponse(completion_tokens=options.max_tokens, tool_calls=[], text="")
-
-        self._run(client, fake_policy, max_tokens=100)
-
-        assert caps == [100, 100 * _TRUNCATION_RETRY_ESCALATION]
-
-    def test_budget_exceeded_on_retry_returns_truncated_response(self):
-        client = self._make_client()
-        caps: list = []
-        first = _FakeResponse(completion_tokens=100, tool_calls=[], text="")
-
-        async def fake_policy(self_, client_obj, request, options):
-            caps.append(options.max_tokens)
-            if len(caps) == 1:
-                return first
-            raise BudgetExceeded("no budget for the escalated retry")
-
-        result = self._run(client, fake_policy, max_tokens=100)
-
-        assert caps == [100, 100 * _TRUNCATION_RETRY_ESCALATION]
-        assert result is first
-
-    def test_streaming_retries_once_with_escalated_cap(self):
-        client = self._make_client()
-        caps: list = []
+        observed: list[int | None] = []
 
         class FakeEvent:
-            content = None
+            content = "done"
             end = object()
 
         async def fake_stream(model_name, request, options):
-            caps.append(options.max_tokens)
+            observed.append(options.max_tokens)
 
             async def gen():
                 yield FakeEvent()
@@ -551,17 +448,15 @@ class TestAchatTruncationRetry:
             return gen()
 
         fake_client = type("FakeClient", (), {"astream_chat": staticmethod(fake_stream)})()
-        responses = [
-            _FakeResponse(completion_tokens=100, tool_calls=[], text=""),  # truncated
-            _FakeResponse(completion_tokens=50, tool_calls=[], text="ok"),  # under cap
-        ]
-
-        def fake_from_end(self_, end):
-            return responses.pop(0)
+        response = _FakeResponse(completion_tokens=100, text="done")
 
         with (
             patch.object(AsyncLLMClient, "_build_client", new=lambda self, cls: fake_client),
-            patch.object(AsyncLLMClient, "_chat_response_from_stream_end", new=fake_from_end),
+            patch.object(
+                AsyncLLMClient,
+                "_chat_response_from_stream_end",
+                new=lambda self, end: response,
+            ),
         ):
             result = asyncio.run(
                 client.achat_stream(
@@ -569,9 +464,8 @@ class TestAchatTruncationRetry:
                     system=None,
                     tools=None,
                     on_text_delta=lambda chunk: None,
-                    max_tokens=100,
                 )
             )
 
-        assert caps == [100, 100 * _TRUNCATION_RETRY_ESCALATION]
-        assert result.usage.completion_tokens == 50
+        assert result is response
+        assert observed == [None]


### PR DESCRIPTION
Stack 1/7 on #181.

Provider requests now omit max_tokens, max_completion_tokens, and max_output_tokens across the native genai transport and direct OpenAI HTTP fallback. This removes the parameter-rejection retry and cap-based truncation retry paths, and removes ad hoc caps from production call sites.

Validation: Ruff passed; 173 focused provider, budget, binding, and ranker tests passed; the full 1,000-test SourceHunt suite passed at the stack tip.