### PR TITLE
fix(sourcehunt): preserve specialist campaign hints

### DIFF
--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -2787,6 +2787,9 @@ def build_hunter_agent(
 
     if seed_transcript:
         prompt += "\n\n" + SEED_TRANSCRIPT_BLOCK.format(transcript=seed_transcript)
+    if campaign_hint and prompt_mode != "unconstrained":
+        prompt += "\n" + CAMPAIGN_HINT_TEMPLATE.format(objective=campaign_hint)
+
     initial_user_message = f"Hunt for vulnerabilities in {ctx.file_path or 'unknown'}."
 
     return NativeHunter(

--- a/tests/test_sourcehunt_hunter.py
+++ b/tests/test_sourcehunt_hunter.py
@@ -485,6 +485,19 @@ class TestBuildHunterAgent:
         )
         assert ctx.specialist == "propagation"
 
+    def test_specialist_prompt_preserves_campaign_hint(self):
+        hunter, _ctx = build_hunter_agent(
+            file_target=_make_file_target("foo.c", tier="B"),
+            repo_path=str(FIXTURE_C_PROPAGATION),
+            sandbox=None,
+            llm=MagicMock(),
+            session_id="s1",
+            prompt_mode="specialist",
+            campaign_hint="audit target arithmetic",
+        )
+
+        assert "We are particularly interested in audit target arithmetic." in hunter.prompt
+
     def test_v02_seam_seeded_crash_param_accepted(self):
         llm = MagicMock()
         ft = _make_file_target("foo.c")


### PR DESCRIPTION
Stack 2/7; depends on the output-token compatibility PR.

Specialist prompt construction replaced the common prompt after campaign hints were attached, silently dropping the requested hunt objective. Append the campaign objective after selecting the final prompt mode.

Validation: 126 focused tests passed at this snapshot.