### PR TITLE
fix(sourcehunt): bind constrained traces to read ranges

### DIFF
--- a/clearwing/agent/tools/hunt/discovery.py
+++ b/clearwing/agent/tools/hunt/discovery.py
@@ -209,7 +209,6 @@ def build_discovery_tools(ctx: HunterContext) -> list:
             rel = _normalize_path(ctx.repo_path, path)
         except ValueError as e:
             return f"Error: {e}"
-        ctx.files_read.add(rel)
         host_path = os.path.join(ctx.repo_path, rel)
         try:
             with open(host_path, encoding="utf-8", errors="replace") as f:
@@ -228,6 +227,9 @@ def build_discovery_tools(ctx: HunterContext) -> list:
             )
         else:
             footer = ""
+        if sliced:
+            ctx.files_read.add(rel)
+            ctx.read_ranges.setdefault(rel, []).append((first + 1, first + len(sliced)))
         return _safe_source_output("".join(sliced) + footer, "source file")
 
     def list_source_tree(dir_path: str = ".", max_depth: int = 2) -> list[str]:

--- a/clearwing/agent/tools/hunt/reporting.py
+++ b/clearwing/agent/tools/hunt/reporting.py
@@ -207,6 +207,15 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                 "UNREAD_TRACE_SOURCE",
                 f"File '{file}' has not been read yet. Call read_source_file first.",
             )
+        ranges = ctx.read_ranges.get(file, [])
+        if ctx.agent_mode != "deep" and ranges and not any(
+            start <= line <= end for start, end in ranges
+        ):
+            return _tool_error(
+                "UNREAD_TRACE_SOURCE",
+                f"Line {line} of '{file}' has not been read yet. "
+                "Call read_source_file for that range first.",
+            )
         step = TraceStep(
             file=file,
             line=line,

--- a/clearwing/agent/tools/hunt/sandbox.py
+++ b/clearwing/agent/tools/hunt/sandbox.py
@@ -32,6 +32,7 @@ class HunterContext:
     findings: list[Finding] = field(default_factory=list)
     trace_steps: list = field(default_factory=list)  # accumulator for TraceStep dicts
     files_read: set = field(default_factory=set)  # files accessed via read_source_file
+    read_ranges: dict[str, list[tuple[int, int]]] = field(default_factory=dict)
     agent_mode: str = "constrained"  # "constrained" | "deep"; deep reads via shell so files_read is not authoritative
     file_path: str | None = None  # the file this hunter is scoped to
     session_id: str | None = None

--- a/tests/test_sourcehunt_hunter.py
+++ b/tests/test_sourcehunt_hunter.py
@@ -609,6 +609,26 @@ class TestHunterToolsHostFallback:
         out = read.invoke({"path": "include/codec_limits.h"})
         assert "MAX_FRAME_BYTES" in out
 
+    def test_constrained_trace_requires_the_read_line_range(self):
+        ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
+        tools = build_hunter_tools(ctx)
+        read = next(t for t in tools if t.name == "read_source_file")
+        trace = next(t for t in tools if t.name == "record_trace_step")
+
+        read.invoke({"path": "include/codec_limits.h", "start_line": 1, "end_line": 1})
+
+        assert ctx.read_ranges == {"include/codec_limits.h": [(1, 1)]}
+        assert (
+            trace.invoke(
+                {"file": "include/codec_limits.h", "line": 1, "note": "ENTRY: observed"}
+            )
+            == "Trace step 1 recorded."
+        )
+        rejected = trace.invoke(
+            {"file": "include/codec_limits.h", "line": 2, "note": "SINK: unseen"}
+        )
+        assert rejected["error"]["code"] == "UNREAD_TRACE_SOURCE"
+
     def test_read_source_file_path_traversal_blocked(self):
         ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
         tools = build_hunter_tools(ctx)


### PR DESCRIPTION
Stack 3/7; depends on the specialist campaign-hint PR.

Constrained trace reporting previously treated any prior read of a file as authorization to cite any line in that file. Track delivered line ranges and reject trace steps outside source actually shown to the hunter.

Validation: 83 focused hunter tests passed at this snapshot.