### PR TITLE
fix(sourcehunt): pass callgraphs to per-file hunters

### DIFF
--- a/clearwing/sourcehunt/pool.py
+++ b/clearwing/sourcehunt/pool.py
@@ -230,6 +230,7 @@ class HuntPoolConfig:
     trajectory_root: str | Path | None = None
     instrumentation: Any = None  # SourceHuntInstrumentation | None
     work_cache: Any = None  # HuntWorkCache | None — work-item-granular hunt resume
+    callgraph: Any = None
 
 
 def _format_seed_context(entries: list) -> str | None:
@@ -897,6 +898,7 @@ class HunterPool:
             entry_point=entry_point,
             seed_context=seed_context,
             findings_pool=self.config.findings_pool,
+            callgraph=self.config.callgraph,
         )
         self._configure_hunter_context(result, work_item_id)
         return result

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -2505,6 +2505,7 @@ class SourceHuntRunner:
                     findings_pool=findings_pool,
                     trajectory_root=Path(self.output_dir) / self._session_id / "trajectories",
                     instrumentation=self._instrumentation,
+                    callgraph=callgraph,
                 )
             )
             try:

--- a/tests/test_sourcehunt_pool_budget.py
+++ b/tests/test_sourcehunt_pool_budget.py
@@ -7,7 +7,7 @@ so we can exercise the budget math without any LLM or sandbox calls.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -124,6 +124,23 @@ class TestTierAssignmentOnInit:
         assert files[1]["tier"] == "B"
         assert files[2]["tier"] == "C"
         assert files[3]["tier"] == "B"  # critical regression — must be B not C
+
+
+def test_default_hunter_factory_receives_callgraph():
+    callgraph = object()
+    config = HuntPoolConfig(
+        files=[_ft("target.c", 5, 5)],
+        repo_path="/tmp/repo",
+        llm=MagicMock(),
+        callgraph=callgraph,
+    )
+    pool = HunterPool(config)
+    factory = MagicMock(return_value=(MagicMock(), MagicMock()))
+
+    with patch("clearwing.sourcehunt.pool._DEFAULT_HUNTER_FACTORY", factory):
+        pool._build_hunter_for_file(config.files[0], sandbox=None)
+
+    assert factory.call_args.kwargs["callgraph"] is callgraph
 
 
 # --- Within-tier priority ordering -----------------------------------------


### PR DESCRIPTION
Stack 4/7; depends on the read-range provenance PR.

The runner built a callgraph but did not pass it through HunterPool to per-file hunter construction, leaving semantic navigation tools without their intended graph. Wire the existing callgraph through the pool configuration.

Validation: 11 focused pool tests passed at this snapshot.