### PR TITLE
fix(sourcehunt): contain hunter sandbox startup failures

### DIFF
--- a/clearwing/sourcehunt/pool.py
+++ b/clearwing/sourcehunt/pool.py
@@ -799,7 +799,7 @@ class HunterPool:
                 sandbox = await asyncio.to_thread(self.config.sandbox_factory)
             except Exception as e:
                 logger.error("sandbox_factory failed for %s: %s", file_target.get("path"), e)
-                raise SystemExit(1) from e
+                raise RuntimeError(f"sandbox startup failed: {e}") from e
 
         try:
             hunter, ctx = self._build_hunter_for_file(

--- a/tests/test_sourcehunt_pool_budget.py
+++ b/tests/test_sourcehunt_pool_budget.py
@@ -6,6 +6,7 @@ so we can exercise the budget math without any LLM or sandbox calls.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
@@ -141,6 +142,21 @@ def test_default_hunter_factory_receives_callgraph():
         pool._build_hunter_for_file(config.files[0], sandbox=None)
 
     assert factory.call_args.kwargs["callgraph"] is callgraph
+
+
+def test_sandbox_startup_failure_does_not_exit_process():
+    def fail_sandbox():
+        raise RuntimeError("daemon unavailable")
+
+    config = HuntPoolConfig(
+        files=[_ft("target.c", 5, 5)],
+        repo_path="/tmp/repo",
+        sandbox_factory=fail_sandbox,
+    )
+    pool = HunterPool(config)
+
+    with pytest.raises(RuntimeError, match="sandbox startup failed: daemon unavailable"):
+        asyncio.run(pool._run_one_hunter(config.files[0], cost_limit=1.0))
 
 
 # --- Within-tier priority ordering -----------------------------------------


### PR DESCRIPTION
Stack 5/7; depends on the callgraph-wiring PR.

A single sandbox spawn failure escaped the per-target task and could abort the entire hunter pool. Convert startup failure into a normal failed target result so sibling work and partial findings remain available.

Validation: 12 focused pool tests passed at this snapshot.