### PR TITLE
feat(sourcehunt): add independent sandbox verification

### DIFF
--- a/clearwing/agent/tools/hunt/__init__.py
+++ b/clearwing/agent/tools/hunt/__init__.py
@@ -7,6 +7,8 @@ Public entry points:
                                       memory_safety / logic_auth / general
                                       specialists.
 - `build_propagation_auditor_tools(ctx)` — the Tier C static-analysis set.
+- `build_verification_tools(ctx)`      — sandbox tools used only by the
+                                      independent verification phase.
 
 Internal layout:
     sandbox.py    — HunterContext dataclass + sanitizer-variant routing
@@ -45,6 +47,7 @@ from .discovery import (
 from .pool_query import build_pool_query_tools
 from .reporting import build_reporting_tools
 from .sandbox import HunterContext, _parse_variant_arg
+from .verification import build_verification_workspace_tools
 
 
 def build_hunter_tools(ctx: HunterContext) -> list:
@@ -76,12 +79,23 @@ def build_propagation_auditor_tools(ctx: HunterContext) -> list:
     return tools
 
 
+def build_verification_tools(ctx: HunterContext) -> list:
+    """Build the sandbox tool set for independent dynamic verification.
+
+    The verifier gets the same three primitives a human needs to inspect,
+    instrument, build, and run a real checkout. Keeping this palette minimal
+    avoids duplicating compile/fuzz helper schemas in every verification turn.
+    """
+    return build_verification_workspace_tools(ctx)
+
+
 __all__ = [
     # Public API
     "HunterContext",
     "build_deep_agent_tools",
     "build_hunter_tools",
     "build_propagation_auditor_tools",
+    "build_verification_tools",
     # Per-domain builders (for callers that want a narrower tool set)
     "build_discovery_tools",
     "build_semgrep_tool",

--- a/clearwing/agent/tools/hunt/verification.py
+++ b/clearwing/agent/tools/hunt/verification.py
@@ -1,0 +1,173 @@
+"""Small, bounded workspace tool palette for independent verification."""
+
+from __future__ import annotations
+
+import hashlib
+import shlex
+from pathlib import PurePosixPath
+
+from pydantic import Field
+
+from clearwing.llm import NativeToolSpec, ToolInputModel
+from clearwing.reporting.safety import redact_text
+
+from .sandbox import HunterContext
+
+_MAX_OUTPUT_CHARS = 100_000
+_MAX_WRITE_CHARS = 256 * 1024
+_ALLOWED_ROOTS = (PurePosixPath("/workspace"), PurePosixPath("/scratch"))
+
+
+class VerificationExecuteInput(ToolInputModel):
+    command: str = Field(
+        min_length=1,
+        max_length=8192,
+        description="Shell command to execute inside the isolated verification sandbox.",
+    )
+    timeout: int = Field(
+        default=300,
+        ge=1,
+        le=600,
+        description="Command timeout in seconds (1-600).",
+    )
+
+
+class VerificationReadInput(ToolInputModel):
+    path: str = Field(min_length=1, max_length=4096)
+    start_line: int = Field(default=1, ge=1)
+    end_line: int | None = Field(default=None, ge=1)
+
+
+class VerificationWriteInput(ToolInputModel):
+    path: str = Field(min_length=1, max_length=4096)
+    contents: str = Field(max_length=_MAX_WRITE_CHARS)
+
+
+def _bounded_output(value: str, label: str) -> str:
+    safe = redact_text(value)
+    if len(safe) <= _MAX_OUTPUT_CHARS:
+        return safe
+    return safe[:_MAX_OUTPUT_CHARS] + (
+        f"\n\n[{label} truncated at {_MAX_OUTPUT_CHARS} characters]"
+    )
+
+
+def _sandbox_path(raw_path: str) -> str:
+    candidate = PurePosixPath(raw_path)
+    if not candidate.is_absolute():
+        candidate = PurePosixPath("/workspace") / candidate
+    if ".." in candidate.parts or "\x00" in raw_path:
+        raise ValueError("verification paths must stay under /workspace or /scratch")
+    if not any(candidate == root or root in candidate.parents for root in _ALLOWED_ROOTS):
+        raise ValueError("verification paths must stay under /workspace or /scratch")
+    return candidate.as_posix()
+
+
+def _workspace_integrity(ctx: HunterContext) -> dict:
+    baseline = getattr(ctx.sandbox, "workspace_baseline_commit", None)
+    if not isinstance(baseline, str) or len(baseline) != 40:
+        return {"available": False, "valid": False}
+    command = (
+        "cd /workspace && "
+        f"git rev-parse HEAD && git diff --name-only {shlex.quote(baseline)} -- && "
+        "git status --porcelain --untracked-files=all"
+    )
+    result = ctx.sandbox.exec(command, timeout=30)
+    lines = result.stdout.splitlines()
+    head = lines[0].strip() if lines else ""
+    changed = [line.strip() for line in lines[1:] if line.strip()]
+    return {
+        "available": True,
+        "valid": result.exit_code == 0 and head == baseline,
+        "baseline_commit": baseline,
+        "head_commit": head,
+        "workspace_changes": changed[:1000],
+        "error": _bounded_output(result.stderr, "workspace integrity")
+        if result.stderr
+        else "",
+    }
+
+
+def build_verification_workspace_tools(ctx: HunterContext) -> list[NativeToolSpec]:
+    """Return only execute/read/write, with verifier-specific bounds and audit data."""
+
+    def execute(command: str, timeout: int = 300) -> dict:
+        if ctx.sandbox is None:
+            return {"error": "no verification sandbox available"}
+        result = ctx.sandbox.exec(command, timeout=timeout)
+        return {
+            "exit_code": result.exit_code,
+            "stdout": _bounded_output(result.stdout, "stdout"),
+            "stderr": _bounded_output(result.stderr, "stderr"),
+            "timed_out": result.timed_out,
+            "duration_seconds": round(result.duration_seconds, 2),
+            "workspace_integrity": _workspace_integrity(ctx),
+        }
+
+    def read_file(path: str, start_line: int = 1, end_line: int | None = None) -> dict:
+        if ctx.sandbox is None:
+            return {"error": "no verification sandbox available"}
+        normalized = _sandbox_path(path)
+        if end_line is None:
+            end_line = start_line + 1999
+        if end_line < start_line or end_line - start_line + 1 > 4000:
+            return {"error": "read range must contain between 1 and 4000 lines"}
+        quoted = shlex.quote(normalized)
+        result = ctx.sandbox.exec(
+            f"sed -n '{start_line},{end_line}p' {quoted}",
+            timeout=30,
+        )
+        if result.exit_code != 0:
+            return {"error": _bounded_output(result.stderr, "read error")}
+        return {
+            "path": normalized,
+            "start_line": start_line,
+            "end_line": end_line,
+            "contents": _bounded_output(result.stdout, "file"),
+        }
+
+    def write_file(path: str, contents: str) -> dict:
+        if ctx.sandbox is None:
+            return {"error": "no verification sandbox available"}
+        normalized = _sandbox_path(path)
+        parent = PurePosixPath(normalized).parent.as_posix()
+        created = ctx.sandbox.exec(f"mkdir -p {shlex.quote(parent)}", timeout=30)
+        if created.exit_code != 0:
+            return {"error": _bounded_output(created.stderr, "write error")}
+        encoded = contents.encode("utf-8")
+        ctx.sandbox.write_file(normalized, encoded)
+        return {
+            "path": normalized,
+            "size_bytes": len(encoded),
+            "sha256": hashlib.sha256(encoded).hexdigest(),
+            "workspace_integrity": _workspace_integrity(ctx),
+        }
+
+    return [
+        NativeToolSpec(
+            name="execute",
+            description=(
+                "Run one bounded shell command in the fresh no-network verification "
+                "sandbox. Use this for builds, tests, debuggers, sanitizers, and PoCs."
+            ),
+            schema=VerificationExecuteInput.model_json_schema(),
+            handler=execute,
+        ),
+        NativeToolSpec(
+            name="read_file",
+            description=(
+                "Read a bounded line range under /workspace or /scratch. Paths may "
+                "be absolute or repository-relative."
+            ),
+            schema=VerificationReadInput.model_json_schema(),
+            handler=read_file,
+        ),
+        NativeToolSpec(
+            name="write_file",
+            description=(
+                "Write a bounded harness or test artifact under /workspace or /scratch."
+            ),
+            schema=VerificationWriteInput.model_json_schema(),
+            handler=write_file,
+        ),
+    ]

--- a/clearwing/sandbox/container.py
+++ b/clearwing/sandbox/container.py
@@ -80,6 +80,7 @@ class SandboxContainer:
         self._container = None
         self.scratch_host_dir: str | None = None
         self.variant: list[str] | None = None
+        self.workspace_baseline_commit: str | None = None
 
     # --- Lifecycle ----------------------------------------------------------
 

--- a/clearwing/sandbox/hunter_sandbox.py
+++ b/clearwing/sandbox/hunter_sandbox.py
@@ -404,10 +404,18 @@ class HunterSandbox:
         if writable_workspace:
             sb.copy_tree_into(self.repo_path, "/workspace")
             try:
-                sb.exec(
-                    "cd /workspace && git init -q && git add -A && git commit -m initial -q",
+                baseline = sb.exec(
+                    "cd /workspace && "
+                    "rm -rf /workspace/.git && "
+                    "find . -name .git -type f -delete && "
+                    "git init -q && git add -A && "
+                    "git -c user.name=clearwing -c user.email=clearwing@localhost "
+                    "commit -m initial -q && git rev-parse HEAD",
                     timeout=120,
                 )
+                if baseline.exit_code != 0:
+                    raise RuntimeError(baseline.stderr or "git baseline creation failed")
+                sb.workspace_baseline_commit = baseline.stdout.strip()
             except Exception:
                 logger.warning("git init in writable workspace failed", exc_info=True)
 

--- a/clearwing/sourcehunt/dynamic_verification.py
+++ b/clearwing/sourcehunt/dynamic_verification.py
@@ -1,0 +1,316 @@
+"""Shared tool loop for independent finding verification."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+
+from clearwing.llm import (
+    AsyncLLMClient,
+    ChatMessage,
+    ChatResponse,
+    NativeToolSpec,
+    ToolCall,
+)
+from clearwing.reporting.safety import redact_tree
+
+from .state import EVIDENCE_LEVELS, EvidenceLevel
+
+logger = logging.getLogger(__name__)
+
+_MAX_TOOL_OUTPUT_CHARS = 16_000
+_DYNAMIC_EVIDENCE_TOOLS = {"execute"}
+_CRASH_SIGNATURE_RE = re.compile(
+    r"(?:"
+    r"AddressSanitizer|UndefinedBehaviorSanitizer|MemorySanitizer|ThreadSanitizer|"
+    r"heap-buffer-overflow|stack-buffer-overflow|use-after-free|double[- ]free|"
+    r"runtime error:|SEGV|SIGSEGV|segmentation fault|core dumped|"
+    r"assertion .* failed|abort trap"
+    r")",
+    re.IGNORECASE,
+)
+_NON_REPRO_RE = re.compile(
+    r"(?:out of memory|oom killed|cannot allocate memory|timed out|timeout expired)",
+    re.IGNORECASE,
+)
+
+VERIFICATION_TOOL_INSTRUCTIONS = """The target repository is available in a
+fresh sandbox at /workspace. Use execute for normal project builds, tests,
+debuggers, sanitizer runs, and reproducer commands; use write_file for a focused
+harness when needed. If a PoC is provided, attempt it before returning the
+verdict. Distinguish a genuine product failure from a broken harness, build
+error, invocation error, timeout, or OOM, and cite the exact command/result in
+your rationale. Keep source
+changes limited to test instrumentation or harnesses and account for them when
+judging the unmodified code."""
+
+_TOOL_REQUIRED_REMINDER = """You returned a verdict without running a dynamic
+verification tool. Do not claim that a crash or behavior was reproduced from
+static reasoning. Call execute now to build or run a focused reproducer. If
+dynamic verification is genuinely impossible, return a
+conservative verdict and explicitly say why it could not be completed."""
+
+
+@dataclass(frozen=True)
+class ToolAssistedVerificationResult:
+    """Final model response plus auditable dynamic-tool usage."""
+
+    response: ChatResponse
+    attempted_dynamic_calls: int
+    completed_dynamic_calls: int
+    qualifying_crash_calls: int = 0
+    evidence: tuple[dict[str, Any], ...] = ()
+
+
+def _clip(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[:limit].rstrip() + f"\n... truncated {len(value) - limit} chars ..."
+
+
+async def _invoke_tool(
+    tools_by_name: dict[str, NativeToolSpec],
+    tool_call: ToolCall,
+) -> tuple[Any, bool]:
+    tool = tools_by_name.get(tool_call.fn_name)
+    if tool is None:
+        return {"error": f"unknown verification tool: {tool_call.fn_name}"}, False
+    arguments = tool_call.fn_arguments
+    if not isinstance(arguments, dict):
+        arguments = {}
+    try:
+        return await tool.ainvoke(arguments), True
+    except Exception as exc:
+        logger.warning("Verification tool %s failed", tool_call.fn_name, exc_info=True)
+        return {"error": f"{type(exc).__name__}: {exc}"}, False
+
+
+def _completed_tool_output(output: Any, invoked: bool) -> bool:
+    if not invoked:
+        return False
+    if isinstance(output, dict):
+        if output.get("error") or output.get("timed_out"):
+            return False
+        exit_code = output.get("exit_code")
+        if isinstance(exit_code, int) and exit_code < 0:
+            return False
+    return True
+
+
+def _qualifies_as_product_crash(
+    *,
+    tool_name: str,
+    arguments: dict[str, Any],
+    output: Any,
+    product_file: str | None,
+    written_crash_markers: bool = False,
+) -> bool:
+    """Recognize concrete product crash output without trusting model prose."""
+    if tool_name != "execute" or not isinstance(output, dict):
+        return False
+    if output.get("error") or output.get("timed_out"):
+        return False
+    exit_code = output.get("exit_code")
+    if not isinstance(exit_code, int) or exit_code in {124, 137} or exit_code < 0:
+        return False
+    combined = f"{output.get('stdout', '')}\n{output.get('stderr', '')}"
+    if _NON_REPRO_RE.search(combined) or not _CRASH_SIGNATURE_RE.search(combined):
+        return False
+    if exit_code == 0 and not re.search(r"runtime error:", combined, re.IGNORECASE):
+        return False
+    if written_crash_markers:
+        return False
+    command = str(arguments.get("command") or "")
+    if _CRASH_SIGNATURE_RE.search(command):
+        # Do not accept `echo AddressSanitizer` (or equivalent) as evidence.
+        return False
+    if product_file:
+        normalized = product_file.removeprefix("./")
+        if normalized not in combined and normalized.rsplit("/", 1)[-1] not in combined:
+            return False
+        integrity = output.get("workspace_integrity")
+        if isinstance(integrity, dict) and integrity.get("available"):
+            if not integrity.get("valid"):
+                return False
+            if any(
+                normalized in str(change)
+                for change in integrity.get("workspace_changes", [])
+            ):
+                return False
+    return True
+
+
+def _stored_arguments(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Persist bounded, redacted tool inputs, including generated harnesses."""
+    safe = redact_tree(arguments)
+    if tool_name != "write_file":
+        return safe
+    contents = str(safe.get("contents") or "")
+    encoded = contents.encode("utf-8")
+    return {
+        **safe,
+        "contents": _clip(contents, _MAX_TOOL_OUTPUT_CHARS),
+        "contents_size_bytes": len(encoded),
+        "contents_sha256": hashlib.sha256(encoded).hexdigest(),
+    }
+
+
+def clamp_dynamic_evidence_level(
+    level: EvidenceLevel,
+    *,
+    qualifying_crash_calls: int,
+) -> EvidenceLevel:
+    """Cap model-selected evidence at the strongest host-observed level."""
+    maximum: EvidenceLevel = (
+        "crash_reproduced" if qualifying_crash_calls > 0 else "static_corroboration"
+    )
+    if EVIDENCE_LEVELS.index(level) > EVIDENCE_LEVELS.index(maximum):
+        return maximum
+    return level
+
+
+async def run_tool_assisted_verification(
+    llm: AsyncLLMClient,
+    *,
+    system_prompt: str,
+    user_message: str,
+    tools: Sequence[NativeToolSpec] | None,
+    response_schema: type[BaseModel] | None = None,
+    response_schema_name: str | None = None,
+    max_tool_rounds: int = 8,
+    max_tool_calls: int = 32,
+    max_wall_seconds: float = 1800.0,
+    product_file: str | None = None,
+) -> ToolAssistedVerificationResult:
+    """Run tools in the verifier's own context, then return its final verdict."""
+    active_tools = list(tools or [])
+    combined_prompt = system_prompt + "\n\n" + VERIFICATION_TOOL_INSTRUCTIONS
+    messages = [ChatMessage("user", user_message)]
+    tools_by_name = {tool.name: tool for tool in active_tools}
+    attempted_dynamic_calls = 0
+    completed_dynamic_calls = 0
+    qualifying_crash_calls = 0
+    evidence: list[dict[str, Any]] = []
+    sent_tool_required_reminder = False
+    total_tool_calls = 0
+    written_crash_markers = False
+    started_at = time.monotonic()
+
+    for _round in range(max_tool_rounds):
+        if time.monotonic() - started_at >= max_wall_seconds:
+            break
+        response = await llm.achat(
+            messages=messages,
+            system=combined_prompt,
+            tools=active_tools,
+            response_schema=response_schema,
+            response_schema_name=response_schema_name,
+        )
+        tool_calls = response.tool_calls or []
+        if not tool_calls:
+            if completed_dynamic_calls == 0 and not sent_tool_required_reminder:
+                messages.append(ChatMessage("assistant", response.first_text or ""))
+                messages.append(ChatMessage("user", _TOOL_REQUIRED_REMINDER))
+                sent_tool_required_reminder = True
+                continue
+            return ToolAssistedVerificationResult(
+                response=response,
+                attempted_dynamic_calls=attempted_dynamic_calls,
+                completed_dynamic_calls=completed_dynamic_calls,
+                qualifying_crash_calls=qualifying_crash_calls,
+                evidence=tuple(evidence),
+            )
+
+        messages.append(
+            ChatMessage(
+                "assistant",
+                response.first_text or "",
+                tool_calls=tool_calls,
+            )
+        )
+        for tool_call in tool_calls:
+            total_tool_calls += 1
+            is_dynamic = tool_call.fn_name in _DYNAMIC_EVIDENCE_TOOLS
+            arguments = (
+                tool_call.fn_arguments if isinstance(tool_call.fn_arguments, dict) else {}
+            )
+            if is_dynamic:
+                attempted_dynamic_calls += 1
+            if total_tool_calls > max_tool_calls:
+                output, invoked = {"error": "verification tool-call limit exceeded"}, False
+            elif time.monotonic() - started_at >= max_wall_seconds:
+                output, invoked = {"error": "verification wall-clock limit exceeded"}, False
+            else:
+                output, invoked = await _invoke_tool(tools_by_name, tool_call)
+            completed = _completed_tool_output(output, invoked)
+            qualifying_crash = _qualifies_as_product_crash(
+                tool_name=tool_call.fn_name,
+                arguments=arguments,
+                output=output,
+                product_file=product_file,
+                written_crash_markers=written_crash_markers,
+            )
+            if is_dynamic and completed:
+                completed_dynamic_calls += 1
+            if is_dynamic and qualifying_crash:
+                qualifying_crash_calls += 1
+            stored_output = redact_tree(output)
+            if isinstance(stored_output, dict):
+                stored_output = {
+                    key: _clip(value, _MAX_TOOL_OUTPUT_CHARS)
+                    if isinstance(value, str)
+                    else value
+                    for key, value in stored_output.items()
+                }
+            stored_arguments = _stored_arguments(tool_call.fn_name, arguments)
+            evidence.append(
+                {
+                    "tool": tool_call.fn_name,
+                    "call_id": tool_call.call_id,
+                    "arguments": stored_arguments,
+                    "output": stored_output,
+                    "completed": completed,
+                    "qualifying_crash": qualifying_crash,
+                }
+            )
+            if tool_call.fn_name == "write_file":
+                written = str(arguments.get("contents") or "")
+                written_crash_markers = written_crash_markers or bool(
+                    _CRASH_SIGNATURE_RE.search(written)
+                )
+            output_text = _clip(
+                json.dumps(redact_tree(output), default=str),
+                _MAX_TOOL_OUTPUT_CHARS,
+            )
+            messages.append(
+                ChatMessage(
+                    "tool",
+                    output_text,
+                    tool_response_call_id=tool_call.call_id,
+                )
+            )
+
+    # The model used every tool round. Remove tools for one final synthesis so
+    # the verifier cannot end with an unpaired call or no verdict.
+    response = await llm.achat(
+        messages=messages,
+        system=combined_prompt,
+        tools=None,
+        response_schema=response_schema,
+        response_schema_name=response_schema_name,
+    )
+    return ToolAssistedVerificationResult(
+        response=response,
+        attempted_dynamic_calls=attempted_dynamic_calls,
+        completed_dynamic_calls=completed_dynamic_calls,
+        qualifying_crash_calls=qualifying_crash_calls,
+        evidence=tuple(evidence),
+    )

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -10,6 +10,8 @@ Pipeline:
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import inspect
 import json
 import logging
 import math
@@ -19,7 +21,7 @@ import subprocess
 import time
 import uuid
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -630,6 +632,7 @@ class SourceHuntRunner:
         self._run_started_at: str | None = None
         self._run_started_monotonic: float | None = None
         self._resolved_model_roles: dict[str, dict[str, str]] = {}
+        self._verification_incomplete = False
 
     def _dump_checkpoint(self) -> None:
         if self._checkpoint is None:
@@ -1413,6 +1416,34 @@ class SourceHuntRunner:
             rejected = verification_result.rejected
             if rejected:
                 self._write_rejected_findings(rejected)
+            if verification_result.status != "completed" and not self.no_verify:
+                self._verification_incomplete = True
+                self._emit_stage(
+                    "exploit",
+                    "skipped",
+                    findings_so_far=len(verified),
+                    detail="Verification did not conclusively process every finding",
+                    files=[str(finding.file or "") for finding in verified],
+                    symbols=self._finding_symbols(verified),
+                    finding_ids=[finding.id for finding in verified],
+                )
+                return self._finalize_result(
+                    start_time=start_time,
+                    repo_path=repo_path,
+                    findings=all_findings,
+                    verified=verified,
+                    exploited=[],
+                    files_ranked=files_ranked,
+                    files_hunted=files_hunted,
+                    spent_per_tier=spent_per_tier,
+                    band_stats=band_stats,
+                    findings_pool=findings_pool,
+                    subsystems_hunted=subsystems_hunted,
+                    subsystem_spent_usd=subsystem_spent,
+                    subsystem_status=hunt_result.subsystem_status,
+                    pipeline_status=pipeline_status,
+                    potentials=all_potentials,
+                )
 
             # 4.5. v0.3: Extract mechanisms from verified findings and persist them
             #      to the cross-run store. Cheap LLM pass; failures are non-fatal.
@@ -1948,6 +1979,7 @@ class SourceHuntRunner:
             "no_exploit": self.no_exploit,
             "exploit_budget_band": self._exploit_budget_band,
             "agent_mode": self._effective_agent_mode,
+            "verified_findings_sha256": self._finding_set_digest(verified),
         }
         self._exploitation_restored = False
         self._emit_stage(
@@ -2023,6 +2055,100 @@ class SourceHuntRunner:
         )
         return result
 
+    def _spawn_verification_sandbox(self) -> Any:
+        """Spawn a writable sandbox for one independent verification pass."""
+        factory = (
+            self._sandbox_manager.spawn
+            if self._sandbox_manager is not None
+            else self.sandbox_factory
+        )
+        if factory is None:
+            return None
+
+        requested_options = {
+            "writable_workspace": True,
+            "timeout_seconds": 600,
+        }
+        if self._sandbox_manager is not None:
+            requested_options.update(
+                session_id=self._session_id + "-v",
+                runtime=self._gvisor_runtime,
+            )
+
+        try:
+            try:
+                parameters = inspect.signature(factory).parameters.values()
+            except (TypeError, ValueError):
+                options = requested_options
+            else:
+                accepts_keywords = any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
+                )
+                supported_names = {parameter.name for parameter in parameters}
+                options = {
+                    key: value
+                    for key, value in requested_options.items()
+                    if accepts_keywords or key in supported_names
+                }
+            return factory(**options)
+        except Exception:
+            logger.warning("Verification sandbox spawn failed", exc_info=True)
+            return None
+
+    def _verification_resources(self, repo_path: str) -> tuple[Any, Any, list]:
+        """Create the runner-owned context and tools for one verifier."""
+        sandbox = self._spawn_verification_sandbox()
+        if sandbox is None:
+            self._verification_sandbox_failed = True
+            return None, None, []
+        try:
+            from clearwing.agent.tools.hunt import (
+                HunterContext,
+                build_verification_tools,
+            )
+
+            sandbox_config = getattr(sandbox, "config", None)
+            network_mode = getattr(sandbox_config, "network_mode", None)
+            if (
+                sandbox_config is not None
+                and isinstance(network_mode, str)
+                and network_mode != "none"
+            ):
+                raise RuntimeError("verification sandbox must disable networking")
+            if (
+                hasattr(sandbox, "workspace_baseline_commit")
+                and not sandbox.workspace_baseline_commit
+            ):
+                raise RuntimeError("verification sandbox has no immutable workspace baseline")
+
+            ctx = HunterContext(
+                repo_path=repo_path,
+                sandbox=sandbox,
+                sandbox_manager=self._sandbox_manager,
+                session_id=self._session_id + "-v",
+                specialist="verifier",
+            )
+            return sandbox, ctx, build_verification_tools(ctx)
+        except Exception:
+            logger.warning("Verification tool setup failed", exc_info=True)
+            self._verification_sandbox_failed = True
+            self._stop_verification_sandbox(sandbox)
+            return None, None, []
+
+    @staticmethod
+    def _stop_verification_sandbox(sandbox: Any, ctx: Any = None) -> None:
+        if ctx is not None:
+            try:
+                ctx.cleanup_variants()
+            except Exception:
+                logger.debug("Verification variant cleanup failed", exc_info=True)
+        if sandbox is None:
+            return
+        try:
+            sandbox.stop()
+        except Exception:
+            logger.debug("Verification sandbox cleanup failed", exc_info=True)
+
     async def _verify(
         self,
         findings: list[Finding],
@@ -2032,14 +2158,29 @@ class SourceHuntRunner:
     ) -> VerificationResult:
         """Run or restore the completed verification stage."""
 
+        verifier_llm = (
+            None
+            if self.no_verify
+            else self._get_native_client(
+                "verifier", self.verifier_llm, budget_stage="verify"
+            )
+        )
         options = {
             "no_verify": self.no_verify,
             "validator_mode": self.validator_mode,
             "adversarial_verifier": self.adversarial_verifier,
             "adversarial_threshold": self.adversarial_threshold,
             "enable_patch_oracle": self.enable_patch_oracle,
+            "verification_protocol": "sandbox-tools-v2",
+            "evidence_policy": "host-observed-v2",
+            "sandbox_runtime": self._gvisor_runtime or "default",
+            "verifier_provider": getattr(verifier_llm, "provider_name", None),
+            "verifier_model": getattr(verifier_llm, "model_name", None),
+            "findings_sha256": self._finding_set_digest(findings),
         }
         self._verification_restored = False
+        self._verification_sandbox_failed = False
+        self._verification_incomplete = False
         self._emit_stage(
             "verify",
             "started",
@@ -2054,9 +2195,14 @@ class SourceHuntRunner:
             if restored is None:
                 raise ValueError("verification checkpoint is invalid or incompatible with this run")
             self._verification_restored = True
-            pipeline_status.record_succeeded("verifier")
             result = restored
-            result.status = "completed"
+            if result.status == "completed":
+                pipeline_status.record_succeeded("verifier")
+            else:
+                self._verification_incomplete = True
+                pipeline_status.record_degraded(
+                    "verifier", "Restored verification was not complete"
+                )
             detail = f"Restored {len(result.verified)} verified findings from checkpoint"
         else:
             result = VerificationResult(verified=[], rejected=[])
@@ -2070,34 +2216,53 @@ class SourceHuntRunner:
                 )
             elif self._budget_exhausted():
                 result.status = "budget_exhausted"
+                self._verification_incomplete = True
                 pipeline_status.record(
                     "verifier",
                     StageOutcome.SKIPPED,
                     fallback_description="Budget exhausted; findings remain unverified",
                 )
             else:
-                verifier_llm = self._get_native_client(
-                    "verifier", self.verifier_llm, budget_stage="verify"
-                )
                 if verifier_llm is None:
-                    result.status = "degraded"
-                    for finding in findings:
-                        finding["verified"] = True
-                    result.verified = findings
-                    pipeline_status.record_degraded(
-                        "verifier", "Findings auto-verified without independent review"
-                    )
+                    if findings:
+                        result.status = "incomplete"
+                        self._verification_incomplete = True
+                        for finding in findings:
+                            finding["verified"] = False
+                            finding["verifier_tie_breaker"] = (
+                                "Independent verifier model unavailable; "
+                                "finding left unverified"
+                            )
+                        pipeline_status.record_degraded(
+                            "verifier", "Independent verifier model unavailable"
+                        )
+                    else:
+                        pipeline_status.record_succeeded("verifier")
                 elif self.validator_mode == "v2":
                     result.verified, result.rejected = await self._verify_v2(
                         verifier_llm, findings, repo_path
                     )
                 else:
                     result.verified = await self._verify_v1(verifier_llm, findings, repo_path)
+                if self._verification_sandbox_failed or self._verification_incomplete:
+                    result.status = "incomplete"
+                    self._verification_incomplete = True
+                    pipeline_status.record_degraded(
+                        "verifier",
+                        "Dynamic verification did not conclusively process every finding",
+                    )
+                elif result.status == "completed":
+                    pipeline_status.record_succeeded("verifier")
             if self._checkpoint is None:
                 raise RuntimeError("verification requires a preprocessing checkpoint")
-            self._checkpoint.verification = VerificationCheckpoint.from_result(
-                result, options=options
-            )
+            if result.status != "completed":
+                # Partial, transient, or operational failures are not durable.
+                self._checkpoint.verification = None
+                self._checkpoint.exploitation = None
+            else:
+                self._checkpoint.verification = VerificationCheckpoint.from_result(
+                    result, options=options
+                )
             self._dump_checkpoint()
             detail = (
                 "Verification skipped (--no-verify)"
@@ -2129,11 +2294,31 @@ class SourceHuntRunner:
             adversarial_threshold=self.adversarial_threshold,
         )
         for finding in all_findings:
+            verification_sandbox, verification_ctx, verification_tools = (
+                self._verification_resources(repo_path)
+            )
             try:
+                if not verification_tools:
+                    finding["verified"] = False
+                    finding["verifier_tie_breaker"] = (
+                        "Dynamic verification unavailable; finding left unverified"
+                    )
+                    continue
                 result = await v.averify(
                     finding,
                     file_content=self._load_file_content(repo_path, finding),
+                    verification_tools=verification_tools,
                 )
+                outcome = result.outcome or (
+                    "confirmed" if result.is_real else "refuted"
+                )
+                if outcome in {"operational_error", "inconclusive"}:
+                    self._verification_incomplete = True
+                    finding["verified"] = False
+                    finding["verifier_tie_breaker"] = result.tie_breaker
+                    if result.dynamic_evidence:
+                        finding["verification_evidence"] = result.dynamic_evidence
+                    continue
                 if self.enable_patch_oracle and result.is_real:
                     result = await self._run_patch_oracle_v1(v, finding, repo_path, result)
                 apply_verifier_result(
@@ -2145,13 +2330,17 @@ class SourceHuntRunner:
                     verified.append(finding)
             except BudgetExceeded:
                 logger.info("Verification stopped at the run budget")
+                self._verification_incomplete = True
                 break
             except Exception:
+                self._verification_incomplete = True
                 logger.warning(
                     "Verifier failed for %s",
                     finding.get("id"),
                     exc_info=True,
                 )
+            finally:
+                self._stop_verification_sandbox(verification_sandbox, verification_ctx)
         return verified
 
     async def _verify_v2(
@@ -2170,12 +2359,32 @@ class SourceHuntRunner:
             gate_threshold=self.adversarial_threshold,
         )
         for finding in all_findings:
+            verification_sandbox, verification_ctx, verification_tools = (
+                self._verification_resources(repo_path)
+            )
             try:
+                if not verification_tools:
+                    finding["verified"] = False
+                    finding["verifier_tie_breaker"] = (
+                        "Dynamic verification unavailable; finding left unverified"
+                    )
+                    continue
                 discoverer_sev = finding.get("severity")
                 verdict = await val.avalidate(
                     finding,
                     file_content=self._load_file_content(repo_path, finding),
+                    verification_tools=verification_tools,
                 )
+                outcome = verdict.outcome or (
+                    "confirmed" if verdict.advance else "refuted"
+                )
+                if outcome in {"operational_error", "inconclusive"}:
+                    self._verification_incomplete = True
+                    finding["verified"] = False
+                    finding["verifier_tie_breaker"] = verdict.tie_breaker
+                    if verdict.dynamic_evidence:
+                        finding["verification_evidence"] = verdict.dynamic_evidence
+                    continue
                 if self.enable_patch_oracle and verdict.advance:
                     verdict = await self._run_patch_oracle_v2(
                         val,
@@ -2196,13 +2405,17 @@ class SourceHuntRunner:
                 self._record_calibration(finding, verdict, discoverer_sev)
             except BudgetExceeded:
                 logger.info("Validation stopped at the run budget")
+                self._verification_incomplete = True
                 break
             except Exception:
+                self._verification_incomplete = True
                 logger.warning(
                     "Validator failed for %s",
                     finding.get("id"),
                     exc_info=True,
                 )
+            finally:
+                self._stop_verification_sandbox(verification_sandbox, verification_ctx)
         return verified, rejected
 
     async def _run_patch_oracle_v1(self, v, finding, repo_path, result):
@@ -3166,9 +3379,13 @@ class SourceHuntRunner:
             subsystem_spent_usd = ledger_subsystem_spend
 
         run_status = (
-            "budget_exhausted"
-            if self._budget_exhausted() or subsystem_status == "budget_exhausted"
-            else "completed"
+            "incomplete"
+            if self._verification_incomplete
+            else (
+                "budget_exhausted"
+                if self._budget_exhausted() or subsystem_status == "budget_exhausted"
+                else "completed"
+            )
         )
         if run_status == "budget_exhausted":
             pipeline_status.record(
@@ -3223,13 +3440,9 @@ class SourceHuntRunner:
 
         return SourceHuntResult(
             exit_code=(
-                0
-                if self._stop_after
-                else (
-                    3
-                    if run_status == "budget_exhausted"
-                    else self._exit_code(findings if self.no_verify else verified)
-                )
+                3
+                if run_status in {"budget_exhausted", "incomplete"}
+                else (0 if self._stop_after else self._exit_code(findings if self.no_verify else verified))
             ),
             repo_url=self.repo_url,
             repo_path=repo_path,
@@ -3298,6 +3511,21 @@ class SourceHuntRunner:
                 )
             )
         return out
+
+    @staticmethod
+    def _finding_set_digest(findings: list[Finding]) -> str:
+        """Bind downstream checkpoints to their exact ordered finding input."""
+        portable = [
+            dict(finding) if isinstance(finding, dict) else asdict(finding)
+            for finding in findings
+        ]
+        encoded = json.dumps(
+            portable,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
 
     @staticmethod
     def _finding_symbols(findings: list[Finding]) -> list[str]:

--- a/clearwing/sourcehunt/state.py
+++ b/clearwing/sourcehunt/state.py
@@ -35,6 +35,13 @@ from clearwing.llm import BaseMessage
 # Canonical definitions now live in clearwing.findings.types.
 # Re-exported here for backwards compatibility.
 
+VerificationOutcome = Literal[
+    "confirmed",
+    "refuted",
+    "inconclusive",
+    "operational_error",
+]
+
 
 def filter_by_evidence(
     findings: list[Finding],
@@ -224,6 +231,8 @@ class ValidatorVerdict:
     patch_oracle_passed: bool | None = None
     patch_oracle_diff: str = ""
     patch_oracle_notes: str = ""
+    dynamic_evidence: list[dict[str, Any]] = field(default_factory=list)
+    outcome: VerificationOutcome | None = None
 
     def to_verifier_result(self):
         from clearwing.sourcehunt.verifier import VerifierResult
@@ -242,6 +251,8 @@ class ValidatorVerdict:
             patch_oracle_passed=self.patch_oracle_passed,
             patch_oracle_diff=self.patch_oracle_diff,
             patch_oracle_notes=self.patch_oracle_notes,
+            dynamic_evidence=self.dynamic_evidence,
+            outcome=self.outcome,
         )
 
 

--- a/clearwing/sourcehunt/validator.py
+++ b/clearwing/sourcehunt/validator.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Sequence
 from itertools import islice
 from typing import Any, Literal, cast
 
@@ -20,10 +21,14 @@ from pydantic import BaseModel, Field
 
 from clearwing.core.event_payloads import ValidationResultPayload
 from clearwing.core.events import EventBus
-from clearwing.llm import AsyncLLMClient, BudgetExceeded
+from clearwing.llm import AsyncLLMClient, BudgetExceeded, NativeToolSpec
 from clearwing.llm.native import response_text
 from clearwing.reporting.safety import redact_text, redact_tree
 
+from .dynamic_verification import (
+    clamp_dynamic_evidence_level,
+    run_tool_assisted_verification,
+)
 from .state import (
     EVIDENCE_LEVELS,
     Axes,
@@ -228,16 +233,18 @@ class _VerdictSchema(BaseModel):
             impactful=self.axes.impactful,
             general=self.axes.general,
         )
+        advance = all(result.passed for _, result in axes.items())
         return ValidatorVerdict(
             finding_id=finding_id,
             axes=axes,
-            advance=self.advance,
-            severity_validated=self.severity if self.advance else None,
+            advance=advance,
+            severity_validated=self.severity if advance else None,
             evidence_level=self.evidence_level,
             pro_argument=self.pro_argument,
             counter_argument=self.counter_argument,
             tie_breaker=self.tie_breaker,
             duplicate_cve=self.duplicate_cve,
+            outcome="confirmed" if advance else "refuted",
         )
 
 
@@ -279,6 +286,8 @@ class Validator:
         self,
         finding: Finding,
         file_content: str = "",
+        *,
+        verification_tools: Sequence[NativeToolSpec] | None = None,
     ) -> ValidatorVerdict:
         user_msg = self._build_user_message(finding, file_content)
         system_prompt = self._prompt_for_finding(finding)
@@ -289,20 +298,51 @@ class Validator:
         # otherwise return empty text under free-form prompting. We validate to
         # the typed wire object and map it to the domain verdict directly (no
         # dict round-trip). Requires a model/gateway with constrained decoding.
+        verification = None
         try:
-            response = await self.llm.aask_text(
-                system=system_prompt,
-                user=user_msg,
-                response_schema=_VerdictSchema,
-                response_schema_name="ValidatorVerdict",
-            )
+            if verification_tools:
+                verification = await run_tool_assisted_verification(
+                    self.llm,
+                    system_prompt=system_prompt,
+                    user_message=user_msg,
+                    tools=verification_tools,
+                    response_schema=_VerdictSchema,
+                    response_schema_name="ValidatorVerdict",
+                    product_file=str(finding.get("file") or "") or None,
+                )
+                response = verification.response
+                if verification.completed_dynamic_calls == 0:
+                    raise RuntimeError(
+                        "dynamic verification incomplete: no build, run, or fuzz tool completed"
+                    )
+            else:
+                response = await self.llm.aask_text(
+                    system=system_prompt,
+                    user=user_msg,
+                    response_schema=_VerdictSchema,
+                    response_schema_name="ValidatorVerdict",
+                )
             schema = _VerdictSchema.model_validate_json(response_text(response))
             verdict = schema.to_verdict(finding.get("id", "unknown"))
+            if verification_tools:
+                verdict.dynamic_evidence = list(verification.evidence)
+                clamped = clamp_dynamic_evidence_level(
+                    verdict.evidence_level,
+                    qualifying_crash_calls=verification.qualifying_crash_calls,
+                )
+                if clamped != verdict.evidence_level:
+                    verdict.evidence_level = clamped
+                    verdict.tie_breaker = (
+                        "Host evidence gate limited the model-selected evidence level. "
+                        + verdict.tie_breaker
+                    ).strip()
         except BudgetExceeded:
             raise
         except Exception as e:
             logger.warning("Validator LLM call failed", exc_info=True)
             verdict = self._error_verdict(finding, f"validator error: {e}")
+            if verification is not None:
+                verdict.dynamic_evidence = list(verification.evidence)
 
         EventBus().emit_validation_result(ValidationResultPayload(
             finding_id=verdict.finding_id,
@@ -422,6 +462,7 @@ class Validator:
             counter_argument="",
             tie_breaker=reason,
             duplicate_cve=None,
+            outcome="operational_error",
         )
 
     async def arun_patch_oracle(
@@ -481,6 +522,8 @@ def apply_validator_verdict(
     }
 
     _bump_evidence(finding, verdict.evidence_level)
+    if verdict.dynamic_evidence:
+        finding["verification_evidence"] = verdict.dynamic_evidence
 
     if verdict.patch_oracle_attempted:
         finding["patch_oracle_passed"] = verdict.patch_oracle_passed

--- a/clearwing/sourcehunt/verifier.py
+++ b/clearwing/sourcehunt/verifier.py
@@ -18,15 +18,31 @@ from __future__ import annotations
 import json
 import logging
 import re
-from dataclasses import dataclass
+from collections.abc import Sequence
+from dataclasses import dataclass, field
 from itertools import islice
 from typing import Any, cast
 
-from clearwing.llm import AsyncLLMClient, BudgetExceeded, extract_json_object
+from clearwing.llm import (
+    AsyncLLMClient,
+    BudgetExceeded,
+    NativeToolSpec,
+    extract_json_object,
+)
 from clearwing.reporting.safety import redact_text, redact_tree
 
+from .dynamic_verification import (
+    clamp_dynamic_evidence_level,
+    run_tool_assisted_verification,
+)
 from .patcher import _invoke_rerun_poc
-from .state import EVIDENCE_LEVELS, EvidenceLevel, Finding, evidence_at_or_above
+from .state import (
+    EVIDENCE_LEVELS,
+    EvidenceLevel,
+    Finding,
+    VerificationOutcome,
+    evidence_at_or_above,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +152,8 @@ class VerifierResult:
     patch_oracle_passed: bool | None = None  # None = not attempted
     patch_oracle_diff: str = ""
     patch_oracle_notes: str = ""
+    dynamic_evidence: list[dict[str, Any]] = field(default_factory=list)
+    outcome: VerificationOutcome | None = None
 
 
 # --- Verifier agent ---------------------------------------------------------
@@ -192,6 +210,8 @@ class Verifier:
         self,
         finding: Finding,
         file_content: str = "",
+        *,
+        verification_tools: Sequence[NativeToolSpec] | None = None,
     ) -> VerifierResult:
         """Run a single verification pass on one finding.
 
@@ -202,7 +222,25 @@ class Verifier:
         user_msg = self._build_user_message(finding, file_content)
         system_prompt = self._prompt_for_finding(finding)
         try:
-            response = await self.llm.aask_text(system=system_prompt, user=user_msg)
+            if verification_tools:
+                verification = await run_tool_assisted_verification(
+                    self.llm,
+                    system_prompt=system_prompt,
+                    user_message=user_msg,
+                    tools=verification_tools,
+                    product_file=str(finding.get("file") or "") or None,
+                )
+                response = verification.response
+                if verification.completed_dynamic_calls == 0:
+                    result = self._error_result(
+                        finding,
+                        response.first_text or "",
+                        "dynamic verification incomplete: no build, run, or fuzz tool completed",
+                    )
+                    result.dynamic_evidence = list(verification.evidence)
+                    return result
+            else:
+                response = await self.llm.aask_text(system=system_prompt, user=user_msg)
             content = response.first_text or ""
         except BudgetExceeded:
             raise
@@ -217,9 +255,23 @@ class Verifier:
                 counter_argument="",
                 tie_breaker=f"verifier error: {e}",
                 duplicate_cve=None,
+                outcome="operational_error",
             )
 
-        return self._parse_response(finding, content)
+        result = self._parse_response(finding, content)
+        if verification_tools:
+            result.dynamic_evidence = list(verification.evidence)
+            clamped = clamp_dynamic_evidence_level(
+                result.evidence_level,
+                qualifying_crash_calls=verification.qualifying_crash_calls,
+            )
+            if clamped != result.evidence_level:
+                result.evidence_level = clamped
+                result.tie_breaker = (
+                    "Host evidence gate limited the model-selected evidence level. "
+                    + result.tie_breaker
+                ).strip()
+        return result
 
     def _build_user_message(self, finding: Finding, file_content: str) -> str:
         # Note: we deliberately do NOT include the hunter's reasoning chain
@@ -294,8 +346,8 @@ class Verifier:
             str(finding.get("code_snippet") or ""),
             str(finding.get("crash_evidence") or ""),
         ]
-        for field in text_fields:
-            for match in _LINE_REF_RE.finditer(field):
+        for text_field in text_fields:
+            for match in _LINE_REF_RE.finditer(text_field):
                 start = int(match.group(1))
                 end = int(match.group(2) or start)
                 refs.extend(range(start, min(end, start + 6) + 1))
@@ -347,6 +399,7 @@ class Verifier:
             tie_breaker=str(parsed.get("tie_breaker", "")),
             duplicate_cve=parsed.get("duplicate_cve"),
             raw_response=content,
+            outcome="confirmed" if is_real else "refuted",
         )
 
     def _error_result(
@@ -365,6 +418,7 @@ class Verifier:
             tie_breaker=reason,
             duplicate_cve=None,
             raw_response=raw,
+            outcome="operational_error",
         )
 
     # --- v0.3 patch oracle -------------------------------------------------
@@ -484,6 +538,8 @@ def apply_verifier_result(
             finding["patch_oracle_passed"] = result.patch_oracle_passed
             if result.patch_oracle_passed:
                 finding.bump_evidence("root_cause_explained")
+        if result.dynamic_evidence:
+            finding["verification_evidence"] = result.dynamic_evidence
     else:
         # Legacy dict path
         finding["verified"] = result.is_real  # type: ignore[index]
@@ -508,4 +564,6 @@ def apply_verifier_result(
                     level = "suspicion"
                 if EVIDENCE_LEVELS.index("root_cause_explained") > EVIDENCE_LEVELS.index(level):
                     finding["evidence_level"] = "root_cause_explained"  # type: ignore[index]
+        if result.dynamic_evidence:
+            finding["verification_evidence"] = result.dynamic_evidence  # type: ignore[index]
     return finding

--- a/tests/test_sandbox_writable_workspace.py
+++ b/tests/test_sandbox_writable_workspace.py
@@ -370,6 +370,8 @@ class TestHunterSandboxWritableWorkspace:
             if isinstance(c[0][0], str) and "git init" in c[0][0]
         ]
         assert len(git_calls) == 1
+        assert "rm -rf /workspace/.git" in git_calls[0][0][0]
+        assert "find . -name .git -type f -delete" in git_calls[0][0][0]
 
     def test_deep_agent_mode_adds_packages(self):
         from clearwing.sandbox.hunter_sandbox import HunterSandbox

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -742,11 +742,24 @@ def test_stop_after_verify_returns_accumulated_verification_result(tmp_path: Pat
 @pytest.mark.asyncio
 async def test_runner_checkpoints_and_restores_verification(tmp_path: Path, monkeypatch):
     finding = Finding(id="finding-1", file="sample.c", severity="high")
+    verifier_client = type(
+        "VerifierClient",
+        (),
+        {"provider_name": "test-provider", "model_name": "test-model"},
+    )()
     first = SourceHuntRunner(
-        repo_url=str(tmp_path), output_dir=str(tmp_path), enable_mechanism_memory=False
+        repo_url=str(tmp_path),
+        output_dir=str(tmp_path),
+        validator_mode="v1",
+        enable_mechanism_memory=False,
     )
     first._checkpoint = SourceHuntCheckpoint()
-    monkeypatch.setattr(first, "_get_native_client", lambda *args, **kwargs: None)
+    monkeypatch.setattr(first, "_get_native_client", lambda *args, **kwargs: verifier_client)
+
+    async def verify_once(*args, **kwargs):
+        return [finding]
+
+    monkeypatch.setattr(first, "_verify_v1", verify_once)
     result = await first._verify(
         [finding], repo_path=str(tmp_path), pipeline_status=PipelineStatus()
     )
@@ -757,13 +770,15 @@ async def test_runner_checkpoints_and_restores_verification(tmp_path: Path, monk
         repo_url=str(tmp_path),
         output_dir=str(tmp_path),
         checkpoint=first._checkpoint.model_dump(mode="json"),
+        validator_mode="v1",
         enable_mechanism_memory=False,
     )
-    monkeypatch.setattr(
-        resumed,
-        "_get_native_client",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("verifier called")),
-    )
+    monkeypatch.setattr(resumed, "_get_native_client", lambda *args, **kwargs: verifier_client)
+
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("verifier called")
+
+    monkeypatch.setattr(resumed, "_verify_v1", fail_if_called)
     restored = await resumed._verify(
         [finding], repo_path=str(tmp_path), pipeline_status=PipelineStatus()
     )

--- a/tests/test_sourcehunt_dynamic_verification.py
+++ b/tests/test_sourcehunt_dynamic_verification.py
@@ -1,0 +1,620 @@
+"""Verifier-only tool-loop and per-finding sandbox lifecycle tests."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from genai_pyo3 import ChatResponse, ToolCall
+
+from clearwing.agent.tools.hunt import (
+    HunterContext,
+    build_hunter_tools,
+    build_verification_tools,
+)
+from clearwing.llm import BudgetExceeded
+from clearwing.sandbox.container import ExecResult
+from clearwing.sourcehunt.checkpoints import SourceHuntCheckpoint
+from clearwing.sourcehunt.dynamic_verification import (
+    ToolAssistedVerificationResult,
+    _qualifies_as_product_crash,
+    run_tool_assisted_verification,
+)
+from clearwing.sourcehunt.runner import SourceHuntRunner
+from clearwing.sourcehunt.state import Finding, PipelineStatus
+from clearwing.sourcehunt.validator import Validator
+from clearwing.sourcehunt.verifier import Verifier, VerifierResult
+
+
+class _FakeSandbox:
+    def __init__(self, exec_result: ExecResult | None = None) -> None:
+        self.commands: list[object] = []
+        self.stop_calls = 0
+        self.exec_result = exec_result or ExecResult(0, "/workspace\n", "", 0.01)
+
+    def exec(self, command, timeout=None):
+        self.commands.append(command)
+        return self.exec_result
+
+    def write_file(self, path: str, content: bytes) -> None:
+        pass
+
+    def stop(self) -> None:
+        self.stop_calls += 1
+
+
+class _FakeResponse:
+    def __init__(self, text: str = "", tool_calls: list[ToolCall] | None = None):
+        self.first_text = text
+        self.tool_calls = tool_calls or []
+
+
+class _ToolLoopLLM:
+    def __init__(self, responses: list[_FakeResponse] | None = None) -> None:
+        self.calls: list[dict] = []
+        self.responses = responses or [
+            _FakeResponse(
+                tool_calls=[ToolCall("call-1", "execute", json.dumps({"command": "pwd"}))]
+            ),
+            _FakeResponse(text="The command completed successfully in /workspace."),
+        ]
+
+    async def achat(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+def _finding() -> dict:
+    return {
+        "id": "finding-1",
+        "file": "src/example.c",
+        "line_number": 7,
+        "finding_type": "memory_safety",
+        "cwe": "CWE-787",
+        "severity": "high",
+        "description": "reported overflow",
+        "evidence_level": "static_corroboration",
+    }
+
+
+def _verdict_payload() -> dict:
+    axis = {"passed": True, "confidence": "high", "rationale": "confirmed"}
+    return {
+        "axes": {
+            "real": axis,
+            "triggerable": axis,
+            "impactful": {**axis, "boundary_crossed": "user"},
+            "general": axis,
+        },
+        "advance": True,
+        "severity": "high",
+        "evidence_level": "root_cause_explained",
+        "pro_argument": "sandbox evidence supports the report",
+        "counter_argument": "none survived",
+        "tie_breaker": "the reproducer",
+        "duplicate_cve": None,
+    }
+
+
+def _legacy_verdict_payload(finding_id: str = "finding-1") -> dict:
+    return {
+        "is_real": True,
+        "severity": "high",
+        "evidence_level": "crash_reproduced",
+        "pro_argument": "the sandbox reproducer confirms the report",
+        "counter_argument": "the command completed under normal invocation",
+        "tie_breaker": "the sanitizer result",
+        "duplicate_cve": None,
+        "finding_id": finding_id,
+    }
+
+
+def test_downstream_checkpoint_digest_tracks_finding_content() -> None:
+    original = _finding()
+    changed = {**original, "description": "different root cause"}
+
+    assert SourceHuntRunner._finding_set_digest([original]) != (
+        SourceHuntRunner._finding_set_digest([changed])
+    )
+
+
+def test_dynamic_tools_are_verifier_only() -> None:
+    ctx = HunterContext(repo_path="/tmp/repo", sandbox=_FakeSandbox())
+    hunter_names = {tool.name for tool in build_hunter_tools(ctx)}
+    verifier_names = {tool.name for tool in build_verification_tools(ctx)}
+
+    assert "compile_file" not in hunter_names
+    assert "execute" not in hunter_names
+    assert verifier_names == {"execute", "read_file", "write_file"}
+
+
+def test_verification_sandbox_bypasses_deep_factory_keyword_collision(tmp_path) -> None:
+    sandbox = _FakeSandbox()
+    manager = MagicMock()
+    manager.spawn.return_value = sandbox
+    runner = SourceHuntRunner(
+        repo_url="test",
+        output_dir=str(tmp_path),
+        sandbox_factory=lambda **kwargs: manager.spawn(
+            writable_workspace=True,
+            timeout_seconds=kwargs.pop("timeout_seconds", 30),
+            **kwargs,
+        ),
+        enable_calibration=False,
+        enable_mechanism_memory=False,
+        enable_patch_oracle=False,
+    )
+    runner._sandbox_manager = manager
+
+    assert runner._spawn_verification_sandbox() is sandbox
+    manager.spawn.assert_called_once_with(
+        writable_workspace=True,
+        timeout_seconds=600,
+        session_id=runner._session_id + "-v",
+        runtime=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_verifier_loop_executes_tools_then_returns_verdict() -> None:
+    llm = _ToolLoopLLM()
+    sandbox = _FakeSandbox()
+
+    verification = await run_tool_assisted_verification(
+        llm,
+        system_prompt="independent verifier",
+        user_message="Verify finding-1 without hunter context.",
+        tools=build_verification_tools(HunterContext(repo_path="/tmp/repo", sandbox=sandbox)),
+    )
+
+    assert sandbox.commands == ["pwd"]
+    assert verification.response.first_text == (
+        "The command completed successfully in /workspace."
+    )
+    assert verification.attempted_dynamic_calls == 1
+    assert verification.completed_dynamic_calls == 1
+    assert {tool.name for tool in llm.calls[0]["tools"]} == {
+        "execute",
+        "read_file",
+        "write_file",
+    }
+    tool_message = llm.calls[1]["messages"][-1]
+    assert tool_message.role == "tool"
+    assert tool_message.tool_response_call_id == "call-1"
+    assert '"stdout": "/workspace\\n"' in tool_message.content
+
+
+@pytest.mark.asyncio
+async def test_verifier_loop_forces_final_synthesis_after_tool_limit() -> None:
+    llm = _ToolLoopLLM()
+    tools = build_verification_tools(HunterContext(repo_path="/tmp/repo", sandbox=_FakeSandbox()))
+
+    verification = await run_tool_assisted_verification(
+        llm,
+        system_prompt="independent verifier",
+        user_message="Verify finding-1.",
+        tools=tools,
+        max_tool_rounds=1,
+    )
+
+    assert verification.response.first_text == (
+        "The command completed successfully in /workspace."
+    )
+    assert llm.calls[0]["tools"]
+    assert llm.calls[1]["tools"] is None
+
+
+@pytest.mark.asyncio
+async def test_verifier_retries_then_rejects_unsubstantiated_dynamic_claim() -> None:
+    claimed_verdict = json.dumps(_legacy_verdict_payload())
+    llm = _ToolLoopLLM(
+        responses=[
+            _FakeResponse(text=claimed_verdict),
+            _FakeResponse(text=claimed_verdict),
+        ]
+    )
+
+    result = await Verifier(llm).averify(
+        _finding(),
+        verification_tools=build_verification_tools(
+            HunterContext(repo_path="/tmp/repo", sandbox=_FakeSandbox())
+        ),
+    )
+
+    assert result.is_real is False
+    assert result.evidence_level == "suspicion"
+    assert "dynamic verification incomplete" in result.tie_breaker
+    assert len(llm.calls) == 2
+    reminder = llm.calls[1]["messages"][-1]
+    assert reminder.role == "user"
+    assert "Do not claim" in reminder.content
+
+
+@pytest.mark.asyncio
+async def test_legacy_verifier_does_not_trust_model_only_crash_claim() -> None:
+    sandbox = _FakeSandbox()
+    llm = _ToolLoopLLM(
+        responses=[
+            _FakeResponse(
+                tool_calls=[ToolCall("legacy-call", "execute", json.dumps({"command": "pwd"}))]
+            ),
+            _FakeResponse(text=json.dumps(_legacy_verdict_payload())),
+        ]
+    )
+
+    result = await Verifier(llm).averify(
+        _finding(),
+        verification_tools=build_verification_tools(
+            HunterContext(repo_path="/tmp/repo", sandbox=sandbox)
+        ),
+    )
+
+    assert result.is_real is True
+    assert result.evidence_level == "static_corroboration"
+    assert "Host evidence gate" in result.tie_breaker
+    assert sandbox.commands == ["pwd"]
+    assert len(llm.calls) == 2
+    assert llm.calls[1]["messages"][-1].tool_response_call_id == "legacy-call"
+
+
+@pytest.mark.asyncio
+async def test_legacy_verifier_clamps_every_level_above_host_evidence() -> None:
+    payload = _legacy_verdict_payload()
+    payload["evidence_level"] = "root_cause_explained"
+    llm = _ToolLoopLLM(
+        responses=[
+            _FakeResponse(
+                tool_calls=[ToolCall("static-call", "execute", json.dumps({"command": "pwd"}))]
+            ),
+            _FakeResponse(text=json.dumps(payload)),
+        ]
+    )
+
+    result = await Verifier(llm).averify(
+        _finding(),
+        verification_tools=build_verification_tools(
+            HunterContext(repo_path="/tmp/repo", sandbox=_FakeSandbox())
+        ),
+    )
+
+    assert result.evidence_level == "static_corroboration"
+    assert "Host evidence gate" in result.tie_breaker
+
+
+@pytest.mark.asyncio
+async def test_legacy_verifier_accepts_product_sanitizer_crash() -> None:
+    sandbox = _FakeSandbox(
+        ExecResult(
+            1,
+            "",
+            "ERROR: AddressSanitizer: heap-buffer-overflow\n    #0 src/example.c:7",
+            0.01,
+        )
+    )
+    llm = _ToolLoopLLM(
+        responses=[
+            _FakeResponse(
+                tool_calls=[
+                    ToolCall("asan-call", "execute", json.dumps({"command": "./repro"}))
+                ]
+            ),
+            _FakeResponse(text=json.dumps(_legacy_verdict_payload())),
+        ]
+    )
+
+    result = await Verifier(llm).averify(
+        _finding(),
+        verification_tools=build_verification_tools(
+            HunterContext(repo_path="/tmp/repo", sandbox=sandbox)
+        ),
+    )
+
+    assert result.is_real is True
+    assert result.evidence_level == "crash_reproduced"
+    assert result.dynamic_evidence[0]["qualifying_crash"] is True
+    assert result.dynamic_evidence[0]["arguments"] == {"command": "./repro"}
+
+
+def test_host_crash_gate_rejects_echo_timeout_oom_and_unrelated_crashes() -> None:
+    real_output = {
+        "exit_code": 1,
+        "stdout": "",
+        "stderr": "AddressSanitizer: heap-buffer-overflow at src/example.c:7",
+        "timed_out": False,
+    }
+
+    assert not _qualifies_as_product_crash(
+        tool_name="execute",
+        arguments={"command": "echo AddressSanitizer: src/example.c:7"},
+        output=real_output,
+        product_file="src/example.c",
+    )
+    assert not _qualifies_as_product_crash(
+        tool_name="execute",
+        arguments={"command": "./repro"},
+        output={**real_output, "exit_code": -1},
+        product_file="src/example.c",
+    )
+    assert _qualifies_as_product_crash(
+        tool_name="execute",
+        arguments={"command": "./repro"},
+        output={
+            **real_output,
+            "exit_code": 0,
+            "stderr": "runtime error: src/example.c:7 out of bounds",
+        },
+        product_file="src/example.c",
+    )
+    assert not _qualifies_as_product_crash(
+        tool_name="execute",
+        arguments={"command": "./repro"},
+        output={**real_output, "timed_out": True},
+        product_file="src/example.c",
+    )
+    assert not _qualifies_as_product_crash(
+        tool_name="execute",
+        arguments={"command": "./repro"},
+        output={**real_output, "stderr": "OOM killed after AddressSanitizer src/example.c:7"},
+        product_file="src/example.c",
+    )
+    assert not _qualifies_as_product_crash(
+        tool_name="execute",
+        arguments={"command": "./repro"},
+        output={**real_output, "stderr": "AddressSanitizer in harness.c:4"},
+        product_file="src/example.c",
+    )
+
+
+@pytest.mark.asyncio
+async def test_verifier_records_written_harness_and_rejects_its_fake_crash_text() -> None:
+    sandbox = _FakeSandbox(
+        ExecResult(
+            1,
+            "",
+            "AddressSanitizer: heap-buffer-overflow at src/example.c:7",
+            0.01,
+        )
+    )
+    harness = 'puts("AddressSanitizer: heap-buffer-overflow src/example.c:7");'
+    llm = _ToolLoopLLM(
+        responses=[
+            _FakeResponse(
+                tool_calls=[
+                    ToolCall(
+                        "write-call",
+                        "write_file",
+                        json.dumps({"path": "/scratch/fake.c", "contents": harness}),
+                    )
+                ]
+            ),
+            _FakeResponse(
+                tool_calls=[
+                    ToolCall("fake-call", "execute", json.dumps({"command": "./fake"}))
+                ]
+            ),
+            _FakeResponse(text=json.dumps(_legacy_verdict_payload())),
+        ]
+    )
+
+    result = await Verifier(llm).averify(
+        _finding(),
+        verification_tools=build_verification_tools(
+            HunterContext(repo_path="/tmp/repo", sandbox=sandbox)
+        ),
+    )
+
+    assert [item["tool"] for item in result.dynamic_evidence] == [
+        "write_file",
+        "execute",
+    ]
+    written = result.dynamic_evidence[0]["arguments"]
+    assert written["contents"] == harness
+    assert len(written["contents_sha256"]) == 64
+    assert result.dynamic_evidence[1]["qualifying_crash"] is False
+    assert result.evidence_level == "static_corroboration"
+
+
+@pytest.mark.asyncio
+async def test_runner_leaves_finding_unverified_when_sandbox_is_unavailable(tmp_path) -> None:
+    finding = _finding()
+    runner = SourceHuntRunner(
+        repo_url="test",
+        output_dir=str(tmp_path),
+        sandbox_factory=lambda **_kwargs: None,
+        enable_calibration=False,
+        enable_mechanism_memory=False,
+        enable_patch_oracle=False,
+    )
+    runner._verification_sandbox_failed = False
+    runner._load_file_content = MagicMock(return_value="int vulnerable(void);")
+    verifier = MagicMock()
+    verifier.averify = AsyncMock()
+
+    with patch("clearwing.sourcehunt.runner.Verifier", return_value=verifier):
+        verified = await runner._verify_v1(MagicMock(), [finding], "/tmp/repo")
+
+    assert verified == []
+    assert finding["verified"] is False
+    assert "unavailable" in finding["verifier_tie_breaker"]
+    assert runner._verification_sandbox_failed is True
+    verifier.averify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_runner_fails_closed_when_verifier_model_is_unavailable(tmp_path) -> None:
+    provider_manager = MagicMock()
+    provider_manager.get_native_client.return_value = None
+    finding = Finding(**_finding())
+    runner = SourceHuntRunner(
+        repo_url="test",
+        local_path=str(tmp_path),
+        output_dir=str(tmp_path / "results"),
+        provider_manager=provider_manager,
+        enable_calibration=False,
+        enable_mechanism_memory=False,
+        enable_patch_oracle=False,
+    )
+    runner._checkpoint = SourceHuntCheckpoint()
+
+    result = await runner._verify(
+        [finding],
+        repo_path=str(tmp_path),
+        pipeline_status=PipelineStatus(),
+    )
+
+    assert result.status == "incomplete"
+    assert result.verified == []
+    assert finding.verified is False
+    assert runner._checkpoint.verification is None
+    assert runner._verification_incomplete is True
+
+
+@pytest.mark.asyncio
+async def test_runner_gives_each_v1_finding_a_fresh_sandbox_and_cleans_it(
+    tmp_path,
+) -> None:
+    sandboxes: list[_FakeSandbox] = []
+
+    def sandbox_factory(**_kwargs) -> _FakeSandbox:
+        sandbox = _FakeSandbox()
+        sandboxes.append(sandbox)
+        return sandbox
+
+    runner = SourceHuntRunner(
+        repo_url="test",
+        output_dir=str(tmp_path),
+        sandbox_factory=sandbox_factory,
+        enable_calibration=False,
+        enable_mechanism_memory=False,
+        enable_patch_oracle=False,
+    )
+    runner._load_file_content = MagicMock(return_value="int vulnerable(void);")
+    seen_tool_lists: list[list] = []
+
+    async def verify_one(finding, file_content="", *, verification_tools=None):
+        assert file_content == "int vulnerable(void);"
+        tools = list(verification_tools or [])
+        seen_tool_lists.append(tools)
+        execute = next(tool for tool in tools if tool.name == "execute")
+        await execute.ainvoke({"command": "pwd"})
+        return VerifierResult(
+            finding_id=finding.get("id", "unknown"),
+            is_real=True,
+            severity_verified="high",
+            evidence_level="crash_reproduced",
+            pro_argument="reproduced",
+            counter_argument="",
+            tie_breaker="sandbox",
+            duplicate_cve=None,
+        )
+
+    fake_verifier = MagicMock()
+    fake_verifier.averify = AsyncMock(side_effect=verify_one)
+    cleaned_contexts = []
+    original_cleanup = HunterContext.cleanup_variants
+
+    def track_cleanup(ctx):
+        cleaned_contexts.append(ctx)
+        original_cleanup(ctx)
+
+    findings = [_finding(), {**_finding(), "id": "finding-2"}]
+    with (
+        patch("clearwing.sourcehunt.runner.Verifier", return_value=fake_verifier),
+        patch.object(HunterContext, "cleanup_variants", new=track_cleanup),
+    ):
+        verified = await runner._verify_v1(MagicMock(), findings, "/tmp/repo")
+
+    assert len(verified) == 2
+    assert len(sandboxes) == 2
+    assert sandboxes[0] is not sandboxes[1]
+    assert [sandbox.commands for sandbox in sandboxes] == [["pwd"], ["pwd"]]
+    assert [sandbox.stop_calls for sandbox in sandboxes] == [1, 1]
+    assert len(cleaned_contexts) == 2
+    assert cleaned_contexts[0] is not cleaned_contexts[1]
+    assert seen_tool_lists[0] is not seen_tool_lists[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [RuntimeError("verifier failed"), BudgetExceeded("verification budget exhausted")],
+    ids=["error", "budget_exceeded"],
+)
+async def test_runner_cleans_v1_sandbox_when_verification_stops(
+    tmp_path,
+    failure: Exception,
+) -> None:
+    sandboxes: list[_FakeSandbox] = []
+
+    def sandbox_factory(**_kwargs) -> _FakeSandbox:
+        sandbox = _FakeSandbox()
+        sandboxes.append(sandbox)
+        return sandbox
+
+    runner = SourceHuntRunner(
+        repo_url="test",
+        output_dir=str(tmp_path),
+        sandbox_factory=sandbox_factory,
+        enable_calibration=False,
+        enable_mechanism_memory=False,
+        enable_patch_oracle=False,
+    )
+    runner._load_file_content = MagicMock(return_value="int vulnerable(void);")
+    fake_verifier = MagicMock()
+    fake_verifier.averify = AsyncMock(side_effect=failure)
+    cleaned_contexts = []
+    original_cleanup = HunterContext.cleanup_variants
+
+    def track_cleanup(ctx):
+        cleaned_contexts.append(ctx)
+        original_cleanup(ctx)
+
+    with (
+        patch("clearwing.sourcehunt.runner.Verifier", return_value=fake_verifier),
+        patch.object(HunterContext, "cleanup_variants", new=track_cleanup),
+    ):
+        verified = await runner._verify_v1(
+            MagicMock(),
+            [_finding(), {**_finding(), "id": "finding-2"}],
+            "/tmp/repo",
+        )
+
+    assert verified == []
+    expected_attempts = 1 if isinstance(failure, BudgetExceeded) else 2
+    assert len(sandboxes) == expected_attempts
+    assert [sandbox.stop_calls for sandbox in sandboxes] == [1] * expected_attempts
+    assert len(cleaned_contexts) == expected_attempts
+
+
+@pytest.mark.asyncio
+async def test_validator_judges_sandbox_evidence_without_hunter_reasoning() -> None:
+    llm = AsyncMock()
+    llm.aask_text.return_value = ChatResponse(content=[{"text": json.dumps(_verdict_payload())}])
+    validator = Validator(llm)
+
+    with patch(
+        "clearwing.sourcehunt.validator.run_tool_assisted_verification",
+        new=AsyncMock(
+            return_value=ToolAssistedVerificationResult(
+                response=ChatResponse(
+                    content=[{"text": json.dumps(_verdict_payload())}]
+                ),
+                attempted_dynamic_calls=1,
+                completed_dynamic_calls=1,
+            )
+        ),
+    ) as tool_loop:
+        verdict = await validator.avalidate(
+            _finding(),
+            file_content="int vulnerable(void);",
+            verification_tools=[MagicMock()],
+        )
+
+    assert verdict.advance is True
+    tool_loop.assert_awaited_once()
+    tool_request = tool_loop.await_args.kwargs["user_message"]
+    assert "reported overflow" in tool_request
+    assert "hunter reasoning" not in tool_request
+    assert tool_loop.await_args.kwargs["response_schema_name"] == "ValidatorVerdict"
+    llm.aask_text.assert_not_awaited()

--- a/tests/test_sourcehunt_runner.py
+++ b/tests/test_sourcehunt_runner.py
@@ -17,8 +17,9 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from genai_pyo3 import ChatResponse
+from genai_pyo3 import ChatResponse, ToolCall
 
+from clearwing.sandbox.container import ExecResult
 from clearwing.sourcehunt.checkpoints import HuntResult
 from clearwing.sourcehunt.pool import assign_tier
 from clearwing.sourcehunt.preprocessor import Preprocessor
@@ -467,6 +468,27 @@ class TestAdversarialVerifierDefault:
         ALL calls for the one with the adversarial system prompt.
         """
         verifier_llm = _make_verifier_llm()
+        tool_response = MagicMock()
+        tool_response.first_text = ""
+        tool_response.tool_calls = [
+            ToolCall("verify-call", "execute", json.dumps({"command": "true"}))
+        ]
+        verdict_response = MagicMock()
+        verdict_response.first_text = json.dumps(
+            {
+                "is_real": True,
+                "severity": "high",
+                "evidence_level": "root_cause_explained",
+                "pro_argument": "source and execution support the report",
+                "counter_argument": "",
+                "tie_breaker": "focused execution",
+                "duplicate_cve": None,
+            }
+        )
+        verdict_response.tool_calls = []
+        verifier_llm.achat.side_effect = [tool_response, verdict_response]
+        sandbox = MagicMock()
+        sandbox.exec.return_value = ExecResult(0, "", "", 0.01)
         runner = SourceHuntRunner(
             repo_url=str(FIXTURE_PY_SQLI),
             local_path=str(FIXTURE_PY_SQLI),
@@ -486,20 +508,20 @@ class TestAdversarialVerifierDefault:
             enable_mechanism_memory=False,
             enable_patch_oracle=False,
             enable_variant_loop=False,
-            sandbox_factory=MagicMock(),
+            sandbox_factory=lambda **_kwargs: sandbox,
         )
         runner._hunt = AsyncMock(return_value=_mock_hunt_result())
         runner.run()
         # Find the call whose system prompt contains STEEL-MAN
         found_adversarial = False
-        for call in verifier_llm.aask_text.call_args_list:
+        for call in verifier_llm.achat.call_args_list:
             system_prompt = call.kwargs.get("system", "")
             if "STEEL-MAN" in system_prompt:
                 found_adversarial = True
                 break
         assert found_adversarial, (
             "Expected at least one verifier LLM call to use the adversarial "
-            f"(STEEL-MAN) system prompt; got {len(verifier_llm.aask_text.call_args_list)} calls"
+            f"(STEEL-MAN) system prompt; got {len(verifier_llm.achat.call_args_list)} calls"
         )
 
 


### PR DESCRIPTION
Stack 6/7; depends on the sandbox-startup containment PR.

Complete the architecture intended by #173: keep constrained hunters static, then verify each reported finding through a bounded tool loop in a fresh writable no-network sandbox. The verifier exposes only execute, read_file, and write_file, records redacted tool evidence, distinguishes confirmed, refuted, inconclusive, and operational errors, and host-clamps evidence so model prose cannot promote a finding beyond observed behavior.

Validation: 93 verifier, checkpoint, runner, and sandbox tests passed independently at this snapshot. The jq CVE-2026-32316 reproduction reached crash_reproduced with an ASan heap-buffer-overflow in jvp_utf8_encode.