### PR TITLE
fix(providers): preserve per-route model pricing

### DIFF
--- a/clearwing/llm/budget.py
+++ b/clearwing/llm/budget.py
@@ -26,7 +26,7 @@ from clearwing.observability.telemetry import CostTracker
 from clearwing.reporting.safety import redact_text
 
 if TYPE_CHECKING:
-    from clearwing.providers.env import LLMEndpoint
+    from clearwing.providers.env import EndpointPricing, LLMEndpoint
 
 
 class BudgetExceeded(RuntimeError):
@@ -58,9 +58,27 @@ def _endpoint_pricing(endpoint: LLMEndpoint | None) -> ModelPricing | None:
     pricing-table behavior. Returns ``None`` when the endpoint is absent or
     carries no pricing, so runs without endpoint pricing are unaffected.
     """
-    pricing = getattr(endpoint, "pricing", None)
+    return _pricing_value(getattr(endpoint, "pricing", None))
+
+
+def _pricing_value(pricing: EndpointPricing | None) -> ModelPricing | None:
+    """Convert one explicit endpoint/client pricing value for ledger use."""
     if pricing is None:
         return None
+    values = {
+        "input": float(pricing.input_per_mtok),
+        "output": float(pricing.output_per_mtok),
+        "cached": (
+            float(pricing.cached_per_mtok)
+            if pricing.cached_per_mtok is not None
+            else float(pricing.input_per_mtok)
+        ),
+    }
+    for name, value in values.items():
+        if not math.isfinite(value) or value < 0:
+            raise BudgetConfigurationError(
+                f"endpoint {name} token price must be a finite value >= 0"
+            )
     cached = (
         pricing.cached_per_mtok if pricing.cached_per_mtok is not None else pricing.input_per_mtok
     )
@@ -239,6 +257,7 @@ class SpendLedger:
         model: str,
         provider: str,
         supports_output_limit: bool,
+        endpoint_pricing: EndpointPricing | None = None,
     ) -> ModelPricing:
         """Fail before spending when strict pricing/capping is unavailable."""
 
@@ -246,6 +265,7 @@ class SpendLedger:
             model,
             provider=provider,
             strict=self.enforcing,
+            endpoint_pricing=endpoint_pricing,
         )
         if self.enforcing and pricing.output_per_million > 0 and not supports_output_limit:
             raise BudgetConfigurationError(
@@ -264,6 +284,7 @@ class SpendLedger:
         requested_max_output_tokens: int | None,
         supports_output_limit: bool,
         metadata: dict[str, Any] | None = None,
+        endpoint_pricing: EndpointPricing | None = None,
     ) -> BudgetReservation:
         """Atomically reserve the worst-case price and return the output cap."""
 
@@ -271,6 +292,7 @@ class SpendLedger:
             model=model,
             provider=provider,
             supports_output_limit=supports_output_limit,
+            endpoint_pricing=endpoint_pricing,
         )
         input_token_upper_bound = max(0, int(input_token_upper_bound))
         metadata = dict(metadata or {})
@@ -612,12 +634,16 @@ class SpendLedger:
         *,
         provider: str,
         strict: bool,
+        endpoint_pricing: EndpointPricing | None = None,
     ) -> ModelPricing:
         # Highest precedence: the active endpoint's own price. When an
         # LLMEndpoint carries a `pricing` block it is the authoritative,
         # already-resolved per-model price and outranks both the operator
         # override and the built-in pricing table. Absent it (the default for
         # every endpoint) this is None and the existing sources apply unchanged.
+        call_pricing = _pricing_value(endpoint_pricing)
+        if call_pricing is not None:
+            return call_pricing
         if self._endpoint_pricing is not None:
             return self._endpoint_pricing
 

--- a/clearwing/llm/native.py
+++ b/clearwing/llm/native.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urljoin
 
 import aiohttp
@@ -41,6 +41,9 @@ from .budget import (
     SpendLedger,
     current_spend_metadata,
 )
+
+if TYPE_CHECKING:
+    from clearwing.providers.env import EndpointPricing
 
 logger = logging.getLogger(__name__)
 tracer = get_oi_tracer(__name__)
@@ -557,11 +560,13 @@ class AsyncLLMClient:
         default_top_p: float | None = None,
         default_timeout_seconds: int | None = None,
         context_budget_tokens: int | None = None,
+        pricing: EndpointPricing | None = None,
     ) -> None:
         self.model_name = model_name
         self.provider_name = provider_name
         self.api_key = api_key
         self.base_url = base_url
+        self.pricing = pricing
         self._default_headers: dict[str, str] | None = None
 
         # `openai_codex` is clearwing's label for the OAuth-authenticated
@@ -701,6 +706,7 @@ class AsyncLLMClient:
             model=self.model_name,
             provider=self.provider_name,
             supports_output_limit=self.provider_name != "openai_codex",
+            endpoint_pricing=self.pricing,
         )
         bound = copy.copy(self)
         bound._spend_ledger = ledger
@@ -735,6 +741,7 @@ class AsyncLLMClient:
             requested_max_output_tokens=max_tokens,
             supports_output_limit=self.provider_name != "openai_codex",
             metadata=current_spend_metadata(),
+            endpoint_pricing=self.pricing,
         )
 
     @staticmethod

--- a/clearwing/providers/manager.py
+++ b/clearwing/providers/manager.py
@@ -19,7 +19,7 @@ from .binding import (
     validate_inference,
 )
 from .catalog import preset_by_key
-from .env import LLMEndpoint, resolve_llm_endpoint
+from .env import EndpointPricing, LLMEndpoint, resolve_llm_endpoint
 from .roles import ROLES, TASK_ROLES, RoleAssignment, Tier, recommend_roles, role_for_task
 from .runtime import runtime_routing
 
@@ -41,6 +41,9 @@ class ProviderConfig:
     # "openai", "openai_resp", "openai_codex", "anthropic", "gemini",
     # "ollama". Left empty for the default behavior (heuristic).
     adapter: str = ""
+    # Optional authoritative price supplied by the route owner. This follows
+    # the provider config to the native client so aliases can use distinct rates.
+    pricing: EndpointPricing | None = None
 
 
 @dataclass
@@ -338,6 +341,7 @@ class ProviderManager:
                     api_key=api_key,
                     base_url=base_url,
                     adapter=pcfg.get("adapter", ""),
+                    pricing=_pricing_from_config(pcfg.get("pricing")),
                 )
             )
 
@@ -386,6 +390,7 @@ class ProviderManager:
                     api_key=pcfg.get("api_key", ""),
                     base_url=pcfg.get("base_url", ""),
                     adapter=pcfg.get("adapter", ""),
+                    pricing=_pricing_from_config(pcfg.get("pricing")),
                 )
             )
             routes.append(
@@ -832,6 +837,7 @@ class ProviderManager:
             api_key=endpoint.api_key or "",
             provider_name=provider_name,
             max_concurrency=_native_concurrency_for_task(task, provider_name),
+            pricing=endpoint.pricing,
         )
 
     def _endpoint_for_task(self, task: str) -> LLMEndpoint:
@@ -893,6 +899,7 @@ class ProviderManager:
                 api_key=config.api_key if config else "",
                 provider_name="anthropic",
                 max_concurrency=_native_concurrency_for_task(task, "anthropic"),
+                pricing=config.pricing if config else None,
                 **common,
             )
 
@@ -904,6 +911,7 @@ class ProviderManager:
                 api_key=config.api_key if config else "",
                 provider_name=provider_name,
                 max_concurrency=_native_concurrency_for_task(task, provider_name),
+                pricing=config.pricing if config else None,
                 **common,
             )
 
@@ -913,6 +921,7 @@ class ProviderManager:
                 api_key=config.api_key if config else "",
                 provider_name="gemini",
                 max_concurrency=_native_concurrency_for_task(task, "gemini"),
+                pricing=config.pricing if config else None,
                 **common,
             )
 
@@ -928,6 +937,7 @@ class ProviderManager:
                 api_key=config.api_key if config else "",
                 provider_name="ollama",
                 max_concurrency=_native_concurrency_for_task(task, "ollama"),
+                pricing=config.pricing if config else None,
                 **common,
             )
 
@@ -939,6 +949,7 @@ class ProviderManager:
                 api_key=config.api_key,
                 provider_name=provider_name,
                 max_concurrency=_native_concurrency_for_task(task, provider_name),
+                pricing=config.pricing,
                 **common,
             )
         raise ValueError(f"Unknown provider: {provider}")
@@ -1003,6 +1014,29 @@ def _expand_env(value: Any) -> str:
     if s.startswith("${") and s.endswith("}"):
         return os.environ.get(s[2:-1], "")
     return s
+
+
+def _pricing_from_config(value: Any) -> EndpointPricing | None:
+    """Parse an optional provider pricing block without treating zero as absent."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("provider pricing must be an object")
+    missing = [name for name in ("input_per_mtok", "output_per_mtok") if name not in value]
+    if missing:
+        raise ValueError(f"provider pricing is missing: {', '.join(missing)}")
+    return EndpointPricing(
+        input_per_mtok=float(value["input_per_mtok"]),
+        output_per_mtok=float(value["output_per_mtok"]),
+        cached_per_mtok=(
+            float(value["cached_per_mtok"]) if value.get("cached_per_mtok") is not None else None
+        ),
+        cache_creation_per_mtok=(
+            float(value["cache_creation_per_mtok"])
+            if value.get("cache_creation_per_mtok") is not None
+            else None
+        ),
+    )
 
 
 def _adapter_for_endpoint(endpoint: LLMEndpoint) -> str:

--- a/tests/test_llm_spend_budget.py
+++ b/tests/test_llm_spend_budget.py
@@ -686,6 +686,35 @@ def test_endpoint_without_pricing_falls_back_to_table(tmp_path):
     assert pricing.source == "pricing_table:claude-sonnet-4-6"
 
 
+def test_client_pricing_overrides_strict_unknown_model_rejection(tmp_path):
+    """Per-route pricing follows a native client into the shared run ledger."""
+
+    ledger = SpendLedger(
+        limit_usd=1.0,
+        session_id="client-priced",
+        repo_url="/tmp/repo",
+        output_dir=tmp_path,
+    )
+    client = AsyncLLMClient(
+        model_name="glm-5.3",
+        provider_name="anthropic",
+        api_key="test",
+        pricing=EndpointPricing(input_per_mtok=0.0, output_per_mtok=0.0),
+    )
+
+    bound = client.with_spend_ledger(ledger, stage="hunt")
+    pricing = ledger.validate_model(
+        model=bound.model_name,
+        provider=bound.provider_name,
+        supports_output_limit=True,
+        endpoint_pricing=bound.pricing,
+    )
+
+    assert pricing.source == "endpoint_pricing"
+    assert pricing.input_per_million == 0.0
+    assert pricing.output_per_million == 0.0
+
+
 def test_no_endpoint_preserves_strict_unknown_model_rejection(tmp_path):
     """Omitting the endpoint entirely keeps today's strict-budget behavior."""
 

--- a/tests/test_providers_env.py
+++ b/tests/test_providers_env.py
@@ -24,6 +24,7 @@ from clearwing.providers import (
     ENV_API_KEY,
     ENV_BASE_URL,
     ENV_MODEL,
+    EndpointPricing,
     LLMEndpoint,
     ProviderManager,
     resolve_llm_endpoint,
@@ -428,3 +429,32 @@ class TestProviderManagerFromConfig:
         # The named provider configs were stored
         assert pm._configs["openrouter"].api_key == "sk-or-routed"
         assert pm._configs["local_llama"].api_key == "ollama"
+
+    def test_zero_pricing_survives_model_alias_resolution(self, clean_env):
+        cfg = {
+            "model_aliases": {
+                "sourcehunt": {
+                    "provider": {
+                        "model": "glm-5.3",
+                        "base_url": "https://api.z.ai/api/anthropic/v1",
+                        "api_key": "coding-plan-key",
+                        "adapter": "anthropic",
+                        "pricing": {
+                            "input_per_mtok": 0,
+                            "output_per_mtok": 0,
+                            "cached_per_mtok": 0,
+                            "cache_creation_per_mtok": 0,
+                        },
+                    }
+                }
+            }
+        }
+
+        client = ProviderManager.from_config(cfg).get_native_client("hunter")
+
+        assert client.pricing == EndpointPricing(
+            input_per_mtok=0.0,
+            output_per_mtok=0.0,
+            cached_per_mtok=0.0,
+            cache_creation_per_mtok=0.0,
+        )


### PR DESCRIPTION
## Summary

Preserve explicit pricing on each configured provider route all the way into the native LLM client and shared spend ledger.

Without this, a CWPro-style `model_aliases` map can select the correct model/endpoint/key while losing that route's price. Strict budget enforcement then rejects subscription models such as GLM 5.3 as unknown-priced, or a ledger-level endpoint price can be reused for the wrong alias.

- parse optional pricing on every provider config, preserving explicit zero values
- bind that pricing to the native client selected for the route
- give per-call client pricing precedence in the shared ledger
- reject non-finite or negative endpoint prices

## Validation

- Ruff: affected source and tests pass
- pytest: 55 passed across spend-budget and provider-resolution suites
- `git diff --check`