### PR TITLE
fix(sandbox): preserve Docker TLS client settings

### DIFF
--- a/clearwing/sandbox/dind.py
+++ b/clearwing/sandbox/dind.py
@@ -69,9 +69,13 @@ def get_docker_client(timeout: int = 60):
     import docker
 
     host = get_docker_host()
+    # kwargs_from_env honors DOCKER_TLS_VERIFY and DOCKER_CERT_PATH. Passing
+    # only base_url here would silently downgrade a TLS-configured client.
     if host:
         logger.debug("Connecting to Docker daemon at %s", host)
-        client = docker.DockerClient(base_url=host)
+        kwargs = docker.utils.kwargs_from_env()
+        kwargs["base_url"] = host
+        client = docker.DockerClient(**kwargs)
     else:
         client = docker.from_env()
 

--- a/tests/test_dind.py
+++ b/tests/test_dind.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from clearwing.sandbox.dind import (
     _CLEARWING_ENV,
     _DEFAULT_SOCKET,
@@ -82,9 +80,14 @@ class TestGetDockerClient:
     def test_connects_to_explicit_host(self, mock_host):
         mock_client = MagicMock()
         mock_client.ping.return_value = True
-        with patch("docker.DockerClient", return_value=mock_client) as mock_ctor:
+        with (
+            patch("docker.utils.kwargs_from_env", return_value={"tls": "configured-tls"}),
+            patch("docker.DockerClient", return_value=mock_client) as mock_ctor,
+        ):
             client = get_docker_client(timeout=1)
-        mock_ctor.assert_called_once_with(base_url="tcp://sidecar:2375")
+        mock_ctor.assert_called_once_with(
+            base_url="tcp://sidecar:2375", tls="configured-tls"
+        )
         assert client is mock_client
 
     @patch("clearwing.sandbox.dind.get_docker_host", return_value=None)


### PR DESCRIPTION
## Summary

Preserve Docker SDK TLS configuration when Clearwing uses an explicit Docker host.

Previously `get_docker_client()` passed only `base_url` to `DockerClient`, silently discarding `DOCKER_TLS_VERIFY` and `DOCKER_CERT_PATH`. The client now starts with `docker.utils.kwargs_from_env()` and overrides only the resolved host.

## Validation

- Ruff passes for the implementation and focused test
- `tests/test_dind.py`: 11 passed
- `git diff --check`