### PR TITLE
fix(sourcehunt): reject stop-after for proof flow

### DIFF
--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -475,6 +475,8 @@ class SourceHuntRunner:
             raise ValueError("flow must be 'legacy' or 'proof'")
         if checkpoint is not None and flow != "legacy":
             raise ValueError("checkpoint restoration is currently supported only for legacy flow")
+        if stop_after is not None and flow != "legacy":
+            raise ValueError("stop_after is currently supported only for legacy flow")
         if proof_max_actions < 1:
             raise ValueError("proof_max_actions must be positive")
         if proof_max_model_calls < 0 or proof_max_dynamic_actions < 0:

--- a/tests/test_sourcehunt_flow_compatibility.py
+++ b/tests/test_sourcehunt_flow_compatibility.py
@@ -39,6 +39,11 @@ def test_cli_and_config_keep_legacy_as_the_default(tmp_path) -> None:
     assert runner._flow == "legacy"
 
 
+def test_proof_flow_rejects_legacy_stop_after_contract(tmp_path) -> None:
+    with pytest.raises(ValueError, match="stop_after.*only for legacy flow"):
+        _runner(tmp_path, flow="proof", stop_after="preprocess")
+
+
 @pytest.mark.asyncio
 async def test_legacy_routes_without_loading_the_proof_engine(tmp_path, monkeypatch) -> None:
     class LegacyPathEntered(RuntimeError):


### PR DESCRIPTION
Summary:
- reject the legacy stop_after stage contract when flow is proof
- fail at runner construction instead of silently carrying an inapplicable control into the proof engine

Tests:
- uv run --frozen --extra dev pytest -q tests/test_sourcehunt_flow_compatibility.py
- uv run --frozen --extra dev ruff check clearwing/sourcehunt/runner.py tests/test_sourcehunt_flow_compatibility.py