### PR TITLE
fix(sourcehunt): bound machine-mode result payload

### DIFF
--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1434,37 +1434,55 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
 
 
 def _public_result(result: Any) -> dict[str, Any]:
+    max_findings_per_bucket = 16
+
+    def text(value: Any, maximum_bytes: int) -> str | None:
+        if not isinstance(value, str) or not value:
+            return None
+        return value.encode("utf-8")[:maximum_bytes].decode("utf-8", errors="ignore")
+
     def finding(value: Any) -> dict[str, Any]:
         item = asdict(value) if not isinstance(value, dict) else dict(value)
-        item.pop("extra", None)
         file = item.get("file")
         if isinstance(file, str) and os.path.isabs(file):
-            item["file"] = os.path.basename(file)
-        return item
+            file = os.path.basename(file)
+        public = {
+            "id": text(item.get("id"), 512),
+            "title": text(item.get("title"), 1024),
+            "finding_type": text(item.get("finding_type"), 512),
+            "severity": text(item.get("severity"), 64),
+            "severity_verified": text(item.get("severity_verified"), 64),
+            "file": text(file, 2048),
+            "line_number": item.get("line_number")
+            if isinstance(item.get("line_number"), int)
+            else None,
+            "end_line": item.get("end_line") if isinstance(item.get("end_line"), int) else None,
+            "cwe": text(item.get("cwe"), 128),
+            "description": text(item.get("description"), 4096),
+            "evidence_level": text(item.get("evidence_level"), 128),
+            "confidence": text(item.get("confidence"), 64),
+            "code_snippet": text(item.get("code_snippet"), 8192),
+            "recommendation": text(item.get("recommendation"), 4096),
+            "verified": item.get("verified") if isinstance(item.get("verified"), bool) else None,
+        }
+        return {key: value for key, value in public.items() if value is not None and value != ""}
+
+    def findings_bucket(values: list[Any]) -> list[dict[str, Any]]:
+        return [finding(item) for item in values[:max_findings_per_bucket]]
+
+    findings = list(result.findings)
+    verified_findings = list(result.verified_findings)
 
     return {
-        "status": result.status,
-        "exit_code": result.exit_code,
-        "repo_url": result.repo_url,
-        "session_id": result.session_id,
-        "findings": [finding(item) for item in result.findings],
-        "verified_findings": [finding(item) for item in result.verified_findings],
-        "exploited_findings": [finding(item) for item in result.exploited_findings],
+        "status": text(result.status, 64),
+        "findings": findings_bucket(findings),
+        "verified_findings": findings_bucket(verified_findings),
+        "finding_count": len(findings),
         "files_ranked": result.files_ranked,
         "files_hunted": result.files_hunted,
         "duration_seconds": result.duration_seconds,
         "cost_usd": result.cost_usd,
         "tokens_used": result.tokens_used,
-        "budget_usd": result.budget_usd,
-        "checkpoint": result.checkpoint,
-        "pipeline": {
-            name: {
-                "outcome": stage.outcome.value,
-                "error": stage.error,
-                "fallback_description": stage.fallback_description,
-            }
-            for name, stage in result.pipeline_status.stages.items()
-        },
     }
 
 

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1472,12 +1472,16 @@ def _public_result(result: Any) -> dict[str, Any]:
 
     findings = list(result.findings)
     verified_findings = list(result.verified_findings)
+    exploited_findings = list(result.exploited_findings)
 
     return {
         "status": text(result.status, 64),
         "findings": findings_bucket(findings),
         "verified_findings": findings_bucket(verified_findings),
+        "exploited_findings": findings_bucket(exploited_findings),
         "finding_count": len(findings),
+        "verified_finding_count": len(verified_findings),
+        "exploited_finding_count": len(exploited_findings),
         "files_ranked": result.files_ranked,
         "files_hunted": result.files_hunted,
         "duration_seconds": result.duration_seconds,

--- a/tests/test_machine_cli.py
+++ b/tests/test_machine_cli.py
@@ -242,12 +242,38 @@ class _SourceResult:
     )
 
 
-def test_sourcehunt_public_result_removes_host_paths():
-    result = sourcehunt._public_result(_SourceResult())
-    assert result["findings"] == [{"file": "app.py"}]
-    assert "repo_path" not in result
-    assert "output_paths" not in result
-    assert result["checkpoint"]["schema_version"] == 1
+def test_sourcehunt_public_result_is_bounded_and_removes_workspace_state():
+    source = _SourceResult(
+        findings=[
+            {
+                "file": f"/private/repo/file-{index}.py",
+                "description": "x" * 10_000,
+                "extra": {"artifact": "/private/proof"},
+            }
+            for index in range(20)
+        ]
+    )
+    result = sourcehunt._public_result(source)
+    assert len(result["findings"]) == 16
+    assert result["findings"][0]["file"] == "file-0.py"
+    assert len(result["findings"][0]["description"].encode("utf-8")) == 4096
+    assert result["finding_count"] == 20
+    assert set(result) == {
+        "status",
+        "findings",
+        "verified_findings",
+        "finding_count",
+        "files_ranked",
+        "files_hunted",
+        "duration_seconds",
+        "cost_usd",
+        "tokens_used",
+    }
+    assert "extra" not in result["findings"][0]
+    assert "checkpoint" not in result
+    assert "pipeline" not in result
+    assert "session_id" not in result
+    assert "repo_url" not in result
     assert "/private" not in repr(result)
 
 

--- a/tests/test_machine_cli.py
+++ b/tests/test_machine_cli.py
@@ -243,26 +243,43 @@ class _SourceResult:
 
 
 def test_sourcehunt_public_result_is_bounded_and_removes_workspace_state():
-    source = _SourceResult(
-        findings=[
+    def _bucket(prefix: str, count: int) -> list[dict]:
+        return [
             {
-                "file": f"/private/repo/file-{index}.py",
+                "file": f"/private/repo/{prefix}-{index}.py",
                 "description": "x" * 10_000,
                 "extra": {"artifact": "/private/proof"},
             }
-            for index in range(20)
+            for index in range(count)
         ]
+
+    source = _SourceResult(
+        findings=_bucket("file", 20),
+        verified_findings=_bucket("verified", 30),
+        exploited_findings=_bucket("exploited", 18),
     )
     result = sourcehunt._public_result(source)
+
+    # Every finding bucket is capped, but its true total is preserved alongside.
     assert len(result["findings"]) == 16
-    assert result["findings"][0]["file"] == "file-0.py"
-    assert len(result["findings"][0]["description"].encode("utf-8")) == 4096
     assert result["finding_count"] == 20
+    assert len(result["verified_findings"]) == 16
+    assert result["verified_finding_count"] == 30
+    assert len(result["exploited_findings"]) == 16
+    assert result["exploited_finding_count"] == 18
+
+    assert result["findings"][0]["file"] == "file-0.py"
+    assert result["exploited_findings"][0]["file"] == "exploited-0.py"
+    assert len(result["findings"][0]["description"].encode("utf-8")) == 4096
+
     assert set(result) == {
         "status",
         "findings",
         "verified_findings",
+        "exploited_findings",
         "finding_count",
+        "verified_finding_count",
+        "exploited_finding_count",
         "files_ranked",
         "files_hunted",
         "duration_seconds",
@@ -270,6 +287,7 @@ def test_sourcehunt_public_result_is_bounded_and_removes_workspace_state():
         "tokens_used",
     }
     assert "extra" not in result["findings"][0]
+    assert "extra" not in result["exploited_findings"][0]
     assert "checkpoint" not in result
     assert "pipeline" not in result
     assert "session_id" not in result


### PR DESCRIPTION
Summary:
- project machine-mode SourceHunt results onto an explicit public allowlist
- cap finding buckets and finding text fields while preserving absolute-path and extra-field redaction
- keep checkpoint, pipeline, session, repository, and output-path state out of machine results

Tests:
- uv run --frozen --extra dev pytest -q tests/test_machine_cli.py
- uv run --frozen --extra dev ruff check clearwing/ui/commands/sourcehunt.py tests/test_machine_cli.py