### PR TITLE
fix(sourcehunt): confine host source readers

### DIFF
--- a/clearwing/agent/tools/hunt/discovery.py
+++ b/clearwing/agent/tools/hunt/discovery.py
@@ -22,6 +22,11 @@ from pydantic import Field
 
 from clearwing.llm import NativeToolSpec, ToolInputModel
 from clearwing.reporting.safety import redact_text
+from clearwing.sourcehunt.paths import (
+    resolve_repo_directory,
+    resolve_repo_file,
+    resolve_repo_path,
+)
 from clearwing.sourcehunt.semgrep_sidecar import SemgrepSidecar, finding_to_dict
 
 from .potentials import build_potential_tools
@@ -88,17 +93,14 @@ def _normalize_path(repo_path: str, path: str) -> str:
     Returns a repo-relative path (no leading slash). Caller can prepend
     repo_path or '/workspace' depending on context.
     """
-    repo_root = os.path.abspath(repo_path)
     # Strip a leading slash/backslash so POSIX-looking inputs like
     # "/foo/bar" still resolve inside the repo on Windows.
     if path.startswith(("/", "\\")):
         path = path.lstrip("/\\")
-    # Resolve and check it's still under repo_path
-    abs_path = os.path.abspath(os.path.join(repo_root, path))
-    common = os.path.commonpath([abs_path, repo_root])
-    if common != repo_root:
+    resolved = resolve_repo_path(repo_path, path, allow_root=True, allow_missing=True)
+    if resolved is None:
         raise ValueError(f"path escapes repo: {path}")
-    return Path(os.path.relpath(abs_path, repo_root)).as_posix()
+    return resolved.relative_to(Path(repo_path).resolve()).as_posix()
 
 
 def _container_path(rel_path: str) -> str:
@@ -162,7 +164,11 @@ def _grep_python_fallback(
 
     for full in candidate_files:
         fname = os.path.basename(full)
-        rel_file = Path(os.path.relpath(full, repo_path)).as_posix()
+        requested = Path(os.path.relpath(full, repo_path)).as_posix()
+        safe_path = resolve_repo_file(repo_path, requested)
+        if safe_path is None:
+            continue
+        rel_file = safe_path.relative_to(Path(repo_path).resolve()).as_posix()
         if file_glob and not (
             fnmatch.fnmatch(rel_file, file_glob)
             or fnmatch.fnmatch(fname, file_glob)
@@ -170,7 +176,7 @@ def _grep_python_fallback(
         ):
             continue
         try:
-            with open(full, encoding="utf-8", errors="ignore") as f:
+            with safe_path.open(encoding="utf-8", errors="ignore") as f:
                 for i, line in enumerate(f, 1):
                     if regex.search(line):
                         matches.append(
@@ -210,9 +216,11 @@ def build_discovery_tools(ctx: HunterContext) -> list:
         except ValueError as e:
             return f"Error: {e}"
         ctx.files_read.add(rel)
-        host_path = os.path.join(ctx.repo_path, rel)
+        host_path = resolve_repo_file(ctx.repo_path, rel)
+        if host_path is None:
+            return f"Error reading {rel}: not a repository source file"
         try:
-            with open(host_path, encoding="utf-8", errors="replace") as f:
+            with host_path.open(encoding="utf-8", errors="replace") as f:
                 lines = f.readlines()
         except OSError as e:
             return f"Error reading {rel}: {e}"
@@ -241,12 +249,23 @@ def build_discovery_tools(ctx: HunterContext) -> list:
             rel = _normalize_path(ctx.repo_path, dir_path)
         except ValueError as e:
             return [f"Error: {e}"]
-        base = os.path.join(ctx.repo_path, rel)
-        if not os.path.isdir(base):
+        base_path = resolve_repo_directory(ctx.repo_path, rel)
+        if base_path is None:
             return [f"Error: not a directory: {rel}"]
+        base = str(base_path)
         out: list[str] = []
         base_depth = base.rstrip(os.sep).count(os.sep)
         for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [
+                directory
+                for directory in dirnames
+                if directory != ".git"
+                and resolve_repo_directory(
+                    ctx.repo_path,
+                    os.path.relpath(os.path.join(dirpath, directory), ctx.repo_path),
+                )
+                is not None
+            ]
             depth = dirpath.rstrip(os.sep).count(os.sep) - base_depth
             if depth >= max_depth:
                 dirnames[:] = []
@@ -255,6 +274,11 @@ def build_discovery_tools(ctx: HunterContext) -> list:
                     Path(os.path.relpath(os.path.join(dirpath, d), ctx.repo_path)).as_posix() + "/"
                 )
             for f in filenames:
+                if resolve_repo_file(
+                    ctx.repo_path,
+                    os.path.relpath(os.path.join(dirpath, f), ctx.repo_path),
+                ) is None:
+                    continue
                 out.append(
                     Path(os.path.relpath(os.path.join(dirpath, f), ctx.repo_path)).as_posix()
                 )

--- a/clearwing/analysis/source_analyzer.py
+++ b/clearwing/analysis/source_analyzer.py
@@ -606,6 +606,8 @@ class SourceAnalyzer:
 
     def _iter_source_files(self, root: str):
         """Yield source file paths, skipping irrelevant directories."""
+        from clearwing.sourcehunt.paths import resolve_repo_file
+
         gitignore = _GitignoreMatcher.from_repo(root) if self.respect_gitignore else None
         for dirpath, dirnames, filenames in os.walk(root):
             # Prune skip directories
@@ -623,7 +625,12 @@ class SourceAnalyzer:
                 if gitignore and gitignore.matches_file(full_path):
                     continue
                 try:
-                    if os.path.getsize(full_path) > self.MAX_FILE_SIZE:
+                    safe_path = resolve_repo_file(
+                        root, os.path.relpath(full_path, root)
+                    )
+                    if safe_path is None:
+                        continue
+                    if safe_path.stat().st_size > self.MAX_FILE_SIZE:
                         continue
                 except OSError:
                     continue

--- a/clearwing/sourcehunt/callgraph.py
+++ b/clearwing/sourcehunt/callgraph.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Any
 
 from clearwing.core.events import EventBus
+from clearwing.sourcehunt.paths import resolve_repo_file
 
 logger = logging.getLogger(__name__)
 
@@ -310,7 +311,12 @@ class CallGraphBuilder:
             dirnames[:] = [d for d in dirnames if d not in skip_dirs]
             for fname in filenames:
                 if os.path.splitext(fname)[1].lower() in _LANG_EXT_MAP:
-                    yield os.path.join(dirpath, fname)
+                    candidate = os.path.join(dirpath, fname)
+                    safe_path = resolve_repo_file(
+                        repo_path, os.path.relpath(candidate, repo_path)
+                    )
+                    if safe_path is not None:
+                        yield candidate
 
     def _ingest_file(
         self,

--- a/clearwing/sourcehunt/paths.py
+++ b/clearwing/sourcehunt/paths.py
@@ -29,26 +29,55 @@ def safe_repo_relative_path(reference: object) -> str | None:
         return None
     normalized = value.replace("\\", "/")
     path = PurePosixPath(normalized)
-    if path.is_absolute() or any(part in {"", ".."} for part in path.parts):
+    if path.is_absolute() or any(
+        part in {"", ".."} or part.casefold() == ".git" for part in path.parts
+    ):
         return None
     cleaned = path.as_posix()
     return cleaned if cleaned not in {"", "."} else None
 
 
-def resolve_repo_file(repo_root: str | Path, reference: object) -> Path | None:
-    """Resolve an existing regular file only when it remains under *repo_root*.
+def resolve_repo_path(
+    repo_root: str | Path,
+    reference: object,
+    *,
+    allow_root: bool = False,
+    allow_missing: bool = False,
+) -> Path | None:
+    """Resolve an existing entry only when it remains under *repo_root*.
 
     ``Path.resolve`` follows symlinks, so an in-repo link to a host file fails
     the containment check instead of becoming an outbound model context read.
     """
 
-    relative = safe_repo_relative_path(reference)
+    raw = normalize_repo_reference(reference)
+    relative = (
+        "." if allow_root and raw in {"", ".", "./"} else safe_repo_relative_path(raw)
+    )
     if relative is None:
         return None
     try:
         root = Path(repo_root).resolve()
         candidate = (root / relative).resolve()
-        candidate.relative_to(root)
+        resolved_relative = candidate.relative_to(root)
     except (OSError, RuntimeError, ValueError):
         return None
-    return candidate if candidate.is_file() else None
+    if any(part.casefold() == ".git" for part in resolved_relative.parts) or (
+        not allow_missing and not candidate.exists()
+    ):
+        return None
+    return candidate
+
+
+def resolve_repo_file(repo_root: str | Path, reference: object) -> Path | None:
+    """Resolve an existing regular repository source file."""
+
+    candidate = resolve_repo_path(repo_root, reference)
+    return candidate if candidate is not None and candidate.is_file() else None
+
+
+def resolve_repo_directory(repo_root: str | Path, reference: object = ".") -> Path | None:
+    """Resolve an existing repository directory, including the root itself."""
+
+    candidate = resolve_repo_path(repo_root, reference, allow_root=True)
+    return candidate if candidate is not None and candidate.is_dir() else None

--- a/clearwing/sourcehunt/preprocessor.py
+++ b/clearwing/sourcehunt/preprocessor.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from clearwing.analysis import SourceAnalyzer
 from clearwing.analysis.source_analyzer import AnalyzerFinding as StaticFinding
 from clearwing.analysis.source_analyzer import _GitignoreMatcher
+from clearwing.sourcehunt.paths import resolve_repo_directory, resolve_repo_file
 
 from .callgraph import CallGraph, CallGraphBuilder
 from .semgrep_sidecar import SemgrepSidecar
@@ -252,9 +253,14 @@ def _count_imports_by(
             if gitignore and gitignore.matches_file(other):
                 continue
             try:
-                if os.path.getsize(other) > SourceAnalyzer.MAX_FILE_SIZE:
+                safe_other = resolve_repo_file(
+                    repo_path, os.path.relpath(other, repo_path)
+                )
+                if safe_other is None:
                     continue
-                with open(other, encoding="utf-8", errors="ignore") as f:
+                if safe_other.stat().st_size > SourceAnalyzer.MAX_FILE_SIZE:
+                    continue
+                with safe_other.open(encoding="utf-8", errors="ignore") as f:
                     head = f.read(64 * 1024)  # only scan the first 64 KB
                 if pattern.search(head):
                     count += 1
@@ -575,15 +581,25 @@ class Preprocessor:
         from clearwing.sourcehunt.callgraph import _LANG_EXT_MAP
         result: list[str] = []
         for sp in subsystem_paths:
-            abs_sp = sp if os.path.isabs(sp) else os.path.join(repo_path, sp)
-            if os.path.isfile(abs_sp):
+            requested = os.path.relpath(sp, repo_path) if os.path.isabs(sp) else sp
+            abs_sp = resolve_repo_file(repo_path, requested)
+            if abs_sp is not None:
                 if Path(abs_sp).suffix.lower() in _LANG_EXT_MAP:
-                    result.append(abs_sp)
-            elif os.path.isdir(abs_sp):
-                for dirpath, _, filenames in os.walk(abs_sp):
+                    result.append(str(abs_sp))
+                continue
+            directory = resolve_repo_directory(repo_path, requested)
+            if directory is not None:
+                for dirpath, dirnames, filenames in os.walk(directory):
+                    dirnames[:] = [directory for directory in dirnames if directory != ".git"]
                     for fname in filenames:
-                        if Path(fname).suffix.lower() in _LANG_EXT_MAP:
-                            result.append(os.path.join(dirpath, fname))
+                        if Path(fname).suffix.lower() not in _LANG_EXT_MAP:
+                            continue
+                        candidate = os.path.join(dirpath, fname)
+                        safe_candidate = resolve_repo_file(
+                            repo_path, os.path.relpath(candidate, repo_path)
+                        )
+                        if safe_candidate is not None:
+                            result.append(str(safe_candidate))
         return result
 
     @staticmethod

--- a/clearwing/sourcehunt/taint.py
+++ b/clearwing/sourcehunt/taint.py
@@ -35,6 +35,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from clearwing.sourcehunt.paths import resolve_repo_file
+
 logger = logging.getLogger(__name__)
 
 
@@ -918,7 +920,12 @@ class TaintAnalyzer:
         for dirpath, dirnames, filenames in os.walk(repo_path):
             dirnames[:] = [d for d in dirnames if d not in self.SKIP_DIRS]
             for fname in filenames:
-                yield os.path.join(dirpath, fname)
+                candidate = os.path.join(dirpath, fname)
+                safe_path = resolve_repo_file(
+                    repo_path, os.path.relpath(candidate, repo_path)
+                )
+                if safe_path is not None:
+                    yield candidate
 
 
 # --- Tree-sitter node-type tables ------------------------------------------

--- a/clearwing/sourcehunt/variant_loop.py
+++ b/clearwing/sourcehunt/variant_loop.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from clearwing.llm import AsyncLLMClient, BudgetExceeded, extract_json_object
 from clearwing.reporting.safety import redact_tree
+from clearwing.sourcehunt.paths import resolve_repo_file
 
 from .state import Finding
 
@@ -216,9 +217,12 @@ class VariantSearcher:
                 if rel in exclude_paths:
                     continue
                 try:
-                    if os.path.getsize(full_path) > self.MAX_FILE_SIZE:
+                    safe_path = resolve_repo_file(repo_path, rel)
+                    if safe_path is None:
                         continue
-                    with open(full_path, encoding="utf-8", errors="replace") as f:
+                    if safe_path.stat().st_size > self.MAX_FILE_SIZE:
+                        continue
+                    with safe_path.open(encoding="utf-8", errors="replace") as f:
                         for i, line in enumerate(f, 1):
                             if rel == source_file and i == source_line:
                                 continue  # skip the source finding's own line

--- a/tests/test_sourcehunt_hunter.py
+++ b/tests/test_sourcehunt_hunter.py
@@ -603,6 +603,47 @@ class TestHunterToolsHostFallback:
         out = read.invoke({"path": "../../../etc/passwd"})
         assert "Error" in out
 
+    def test_read_source_file_checked_in_symlink_escape_blocked(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        outside = tmp_path / "outside.c"
+        outside.write_text("secret outside the run lease\n")
+        (repo / "leak.c").symlink_to(outside)
+
+        ctx = HunterContext(repo_path=str(repo))
+        read = next(t for t in build_hunter_tools(ctx) if t.name == "read_source_file")
+
+        out = read.invoke({"path": "leak.c"})
+        assert "Error" in out
+        assert "secret outside" not in out
+
+    def test_read_source_file_git_metadata_blocked_and_hidden(self, tmp_path):
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+
+        ctx = HunterContext(repo_path=str(repo))
+        tools = build_hunter_tools(ctx)
+        read = next(t for t in tools if t.name == "read_source_file")
+        listing = next(t for t in tools if t.name == "list_source_tree")
+
+        assert "Error" in read.invoke({"path": ".git/HEAD"})
+        assert not any(
+            entry.startswith(".git") for entry in listing.invoke({"dir_path": "."})
+        )
+
+    def test_grep_source_does_not_follow_symlink_outside_repository(self, tmp_path):
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        outside = tmp_path / "outside.c"
+        outside.write_text("UNIQUE_SECRET_TOKEN\n")
+        (repo / "leak.c").symlink_to(outside)
+
+        ctx = HunterContext(repo_path=str(repo))
+        grep = next(t for t in build_hunter_tools(ctx) if t.name == "grep_source")
+
+        assert grep.invoke({"pattern": "UNIQUE_SECRET_TOKEN", "path": "."}) == []
+
     def test_list_source_tree(self):
         ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
         tools = build_hunter_tools(ctx)

--- a/tests/test_sourcehunt_path_safety.py
+++ b/tests/test_sourcehunt_path_safety.py
@@ -4,8 +4,15 @@ from pathlib import Path
 
 import pytest
 
-from clearwing.sourcehunt.paths import resolve_repo_file, safe_repo_relative_path
+from clearwing.sourcehunt.callgraph import CallGraphBuilder
+from clearwing.sourcehunt.paths import (
+    resolve_repo_directory,
+    resolve_repo_file,
+    safe_repo_relative_path,
+)
 from clearwing.sourcehunt.poc_runner import PocRunner
+from clearwing.sourcehunt.taint import TaintAnalyzer
+from clearwing.sourcehunt.variant_loop import VariantPattern, VariantSearcher
 
 
 @pytest.mark.parametrize(
@@ -40,6 +47,36 @@ def test_resolve_repo_file_rejects_symlink_escape(tmp_path: Path) -> None:
     except OSError:
         pytest.skip("symlinks are unavailable on this platform")
     assert resolve_repo_file(repo, "source.c") is None
+
+
+def test_repository_paths_hide_git_metadata(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    (repo / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    assert safe_repo_relative_path(".git/HEAD") is None
+    assert safe_repo_relative_path(".GIT/config") is None
+    assert resolve_repo_file(repo, ".git/HEAD") is None
+    assert resolve_repo_directory(repo, ".git") is None
+
+
+def test_recursive_host_walkers_skip_symlink_escape(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    safe = repo / "safe.c"
+    safe.write_text("int safe(void) { return 0; }\n", encoding="utf-8")
+    outside = tmp_path / "outside.c"
+    outside.write_text("UNIQUE_SECRET_TOKEN\n", encoding="utf-8")
+    (repo / "leak.c").symlink_to(outside)
+
+    assert list(CallGraphBuilder()._walk_repo(str(repo))) == [str(safe)]
+    assert list(TaintAnalyzer()._walk(str(repo))) == [str(safe)]
+    matches = VariantSearcher().search(
+        str(repo),
+        VariantPattern(grep_regex="UNIQUE_SECRET_TOKEN", semantic_description="secret"),
+        {"id": "source", "file": "safe.c", "line_number": 1},
+    )
+    assert matches == []
 
 
 class _NoExecSandbox:

--- a/tests/test_sourcehunt_preprocessor.py
+++ b/tests/test_sourcehunt_preprocessor.py
@@ -19,6 +19,22 @@ from clearwing.sourcehunt.preprocessor import (
     _tag_file,
 )
 
+
+def test_preprocessor_does_not_read_checked_in_symlink_outside_repository(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "safe.py").write_text("print('safe')\n")
+    outside = tmp_path / "outside.py"
+    outside.write_text("eval(user_controlled)\n")
+    (repo / "leak.py").symlink_to(outside)
+
+    result = Preprocessor(repo_url=str(repo), local_path=str(repo)).run()
+
+    paths = {target["path"] for target in result.file_targets}
+    assert "safe.py" in paths
+    assert "leak.py" not in paths
+    assert all("outside.py" not in finding.file_path for finding in result.static_findings)
+
 FIXTURE_C_PROPAGATION = Path(__file__).parent / "fixtures" / "vuln_samples" / "c_propagation"
 FIXTURE_PY_SQLI = Path(__file__).parent / "fixtures" / "vuln_samples" / "py_sqli"
 


### PR DESCRIPTION
Summary:
- extend the existing clearwing.sourcehunt.paths policy to reject Git metadata and symlink escapes
- route hunter read/list/grep and recursive analyzer, callgraph, taint, preprocessor, and variant walkers through the shared confinement helper
- retain current source-output redaction and avoid a second path abstraction

Tests:
- 190 focused tests across path safety, hunter, preprocessor, callgraph, taint, and variant-loop suites
- focused Ruff checks for every changed source and test file