### PR TITLE
fix(sandbox): support legacy Docker builders

### DIFF
--- a/clearwing/sandbox/hunter_sandbox.py
+++ b/clearwing/sandbox/hunter_sandbox.py
@@ -275,7 +275,7 @@ class HunterSandbox:
             _t = time.monotonic()
             try:
                 proc = subprocess.Popen(
-                    ["docker", "build", "--progress=plain", "--platform", platform_flag, "-t", tag, build_dir],
+                    ["docker", "build", "--platform", platform_flag, "-t", tag, build_dir],
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     text=True,

--- a/tests/test_hunter_sandbox.py
+++ b/tests/test_hunter_sandbox.py
@@ -142,6 +142,7 @@ class TestHunterSandboxBuildImage:
         args = mock_popen.call_args[0][0]
         assert "docker" in args[0]
         assert tag in args
+        assert not any(arg.startswith("--progress") for arg in args)
 
     @patch("clearwing.sandbox.hunter_sandbox.subprocess.run")
     def test_build_image_reuses_cached(self, mock_run, temp_repo: Path):


### PR DESCRIPTION
Summary:
- remove only the BuildKit-specific --progress=plain argument from the SourceHunt docker build invocation
- assert the runtime build argv does not pass any --progress option

Tests:
- uv run --frozen --extra dev pytest -q tests/test_hunter_sandbox.py::TestHunterSandboxBuildImage::test_build_image_calls_images_build
- uv run --frozen --extra dev ruff check clearwing/sandbox/hunter_sandbox.py tests/test_hunter_sandbox.py