### PR TITLE
fix(sourcehunt): make Semgrep explicitly opt-in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /build
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 COPY pyproject.toml uv.lock ./
-RUN uv pip install --system --no-cache -r pyproject.toml
+RUN uv pip install --system --no-cache --extra sourcehunt -r pyproject.toml
 
 COPY . .
 RUN uv pip install --system --no-cache --no-deps .

--- a/clearwing/sourcehunt/commit_monitor.py
+++ b/clearwing/sourcehunt/commit_monitor.py
@@ -45,6 +45,7 @@ class CommitMonitorConfig:
     depth: str = "standard"
     budget_usd: float = 0.0
     sandbox_cpus: float | None = None
+    enable_semgrep: bool = False
     on_finding: Callable | None = None
     runner_factory: Callable | None = None  # test injection point
     # v0.4 GitHub Checks integration
@@ -276,6 +277,7 @@ class CommitMonitor:
                 output_dir=self.config.output_dir,
                 provider_manager=provider_manager,
                 sandbox_cpus=self.config.sandbox_cpus,
+                enable_semgrep=self.config.enable_semgrep,
             )
         try:
             result = runner.run()

--- a/clearwing/sourcehunt/config.py
+++ b/clearwing/sourcehunt/config.py
@@ -76,6 +76,7 @@ class FeatureFlags:
     no_rank: bool = False
     seed_harness_crashes: bool = False
     preprocessing: bool = True
+    enable_semgrep: bool = False
     adversarial_verifier: bool = True
     adversarial_threshold: str | None = "static_corroboration"
     validator_mode: str = "v2"  # "v1" (old Verifier) | "v2" (4-axis Validator)

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -277,6 +277,7 @@ class SourceHuntRunner:
         enable_artifact_store: bool = False,
         gvisor_runtime: str | None = None,
         preprocessing: bool = True,
+        enable_semgrep: bool = False,
         seed_harness_crashes: bool = False,
         respect_gitignore: bool = False,
         live: bool = False,
@@ -381,6 +382,7 @@ class SourceHuntRunner:
             no_rank = no_rank or f.no_rank
             seed_harness_crashes = seed_harness_crashes or f.seed_harness_crashes
             preprocessing = preprocessing and f.preprocessing
+            enable_semgrep = enable_semgrep or f.enable_semgrep
             adversarial_verifier = adversarial_verifier and f.adversarial_verifier
             adversarial_threshold = (
                 adversarial_threshold
@@ -475,6 +477,8 @@ class SourceHuntRunner:
             raise ValueError("flow must be 'legacy' or 'proof'")
         if checkpoint is not None and flow != "legacy":
             raise ValueError("checkpoint restoration is currently supported only for legacy flow")
+        if enable_semgrep and flow != "legacy":
+            raise ValueError("Semgrep is currently supported only for legacy flow")
         if proof_max_actions < 1:
             raise ValueError("proof_max_actions must be positive")
         if proof_max_model_calls < 0 or proof_max_dynamic_actions < 0:
@@ -586,6 +590,7 @@ class SourceHuntRunner:
         self._sandbox_cpus = None if sandbox_cpus is None else float(sandbox_cpus)
         self._gvisor_runtime = self._check_runtime_available(gvisor_runtime)
         self._preprocessing = preprocessing
+        self._enable_semgrep = enable_semgrep
         self._seed_harness_crashes = seed_harness_crashes
         self._respect_gitignore = respect_gitignore
         self._live = live
@@ -2755,14 +2760,14 @@ class SourceHuntRunner:
 
     @tracer.chain(name="Preprocess")
     def _preprocess(self) -> PreprocessResult:
-        # v0.2: enable callgraph + reachability + Semgrep by default at
-        # standard/deep depths. Quick depth stays cheap — just enumerate
-        # and tag files.
+        # Callgraph, reachability, and taint run by default at standard/deep
+        # depths. Semgrep is an external subprocess and remains explicitly
+        # opt-in at every depth.
         options = {
             "tag_files": True,
             "build_callgraph": self.depth != "quick" and self._preprocessing,
             "propagate_reachability": self.depth != "quick" and self._preprocessing,
-            "run_semgrep": self.depth != "quick" and self._preprocessing,
+            "run_semgrep": self._enable_semgrep and self._preprocessing,
             "run_taint": self.depth != "quick" and self._preprocessing,
             "respect_gitignore": self._respect_gitignore,
             "subsystem_paths": sorted(self._subsystem_paths or []),

--- a/clearwing/sourcehunt/semgrep_sidecar.py
+++ b/clearwing/sourcehunt/semgrep_sidecar.py
@@ -15,6 +15,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -27,6 +28,15 @@ _BUNDLED_RULES_DIR = Path(__file__).parent / "semgrep_rules"
 
 DEFAULT_SEMGREP_CONFIG = "p/security-audit"
 SEMGREP_TIMEOUT_SECONDS = 300
+
+
+def _active_environment_semgrep() -> str | None:
+    """Return the Semgrep executable installed beside the running Python."""
+
+    candidate = Path(sys.executable).with_name("semgrep")
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
 
 
 @dataclass
@@ -65,7 +75,14 @@ class SemgrepSidecar:
 
     @property
     def available(self) -> bool:
-        return shutil.which(self.binary) is not None
+        return self._command() is not None
+
+    def _command(self) -> str | None:
+        if self.binary == "semgrep":
+            active_environment_binary = _active_environment_semgrep()
+            if active_environment_binary is not None:
+                return active_environment_binary
+        return shutil.which(self.binary)
 
     def run_scan(self, repo_path: str, base_path: str | None = None) -> list[SemgrepFinding]:
         """Invoke `semgrep --json --config <config> <repo_path>`.
@@ -74,12 +91,13 @@ class SemgrepSidecar:
         returns an empty list — Semgrep is a hint source, not a
         correctness-critical dependency.
         """
-        if not self.available:
+        command = self._command()
+        if command is None:
             logger.debug("Semgrep binary not found; skipping")
             return []
 
         cmd = [
-            self.binary,
+            command,
             "scan",
             "--json",
             "--config",

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -320,6 +320,12 @@ def add_parser(subparsers):
         help="Exclude files and directories matched by the target repo's root .gitignore",
     )
     parser.add_argument(
+        "--semgrep",
+        action="store_true",
+        default=False,
+        help="Run the Semgrep hint scan during preprocessing (default: disabled)",
+    )
+    parser.add_argument(
         "--budget",
         type=float,
         default=0.0,
@@ -694,7 +700,7 @@ def add_parser(subparsers):
 def handle(cli, args):
     """Run the sourcehunt pipeline."""
     if args.machine_fd is not None:
-        raise SystemExit(_handle_machine(args.machine_fd))
+        raise SystemExit(_handle_machine(args.machine_fd, enable_semgrep=args.semgrep))
     if not args.repo:
         args._command_parser.error("the following arguments are required: repo")
 
@@ -1088,6 +1094,7 @@ def handle(cli, args):
                 depth=args.depth,
                 budget_usd=args.budget,
                 sandbox_cpus=args.sandbox_cpus,
+                enable_semgrep=args.semgrep,
                 output_dir=args.output_dir,
                 enable_github_checks=args.github_checks,
                 github_check_name=args.github_check_name,
@@ -1133,6 +1140,7 @@ def handle(cli, args):
                 depth=args.depth,
                 budget_usd=args.budget,
                 sandbox_cpus=args.sandbox_cpus,
+                enable_semgrep=args.semgrep,
                 enable_github_checks=args.github_checks,
                 github_check_name=args.github_check_name,
             )
@@ -1209,6 +1217,7 @@ def handle(cli, args):
         enable_artifact_store=getattr(args, "encrypt_artifacts", False),
         gvisor_runtime="runsc" if getattr(args, "gvisor", False) else None,
         respect_gitignore=args.respect_gitignore,
+        enable_semgrep=args.semgrep,
         live=args.live,
         sandbox_cpus=args.sandbox_cpus,
         flow=args.flow,
@@ -1310,7 +1319,7 @@ def handle(cli, args):
     sys.exit(result.exit_code)
 
 
-def _handle_machine(descriptor: int) -> int:
+def _handle_machine(descriptor: int, *, enable_semgrep: bool = False) -> int:
     from ...providers import ProviderManager, install_runtime_routing
     from ...sourcehunt.runner import SourceHuntRunner
     from ..machine import MachineChannel
@@ -1348,6 +1357,7 @@ def _handle_machine(descriptor: int) -> int:
                 output_formats=parsed.get("format"),
                 checkpoint=parsed.get("checkpoint"),
                 stop_after=parsed.get("stop_after"),
+                enable_semgrep=enable_semgrep or parsed["semgrep"],
                 provider_manager=provider_manager,
                 on_progress=lambda progress: channel.emit("progress", progress),
             ).arun()
@@ -1380,6 +1390,7 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "subsystem_max_parallel",
         "subsystem_max_files",
         "no_per_file_hunt",
+        "semgrep",
         "checkpoint",
         "stop_after",
     }
@@ -1407,6 +1418,7 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "no_rank": _boolean(value.get("no_rank", False), "no_rank"),
         "no_per_file_hunt": _boolean(value.get("no_per_file_hunt", False), "no_per_file_hunt"),
         "subsystem_hunt": _boolean(value.get("subsystem_hunt", False), "subsystem_hunt"),
+        "semgrep": _boolean(value.get("semgrep", False), "semgrep"),
     }
     if "subsystem_paths" in value:
         parsed["subsystem_paths"] = value["subsystem_paths"]

--- a/tests/test_machine_cli.py
+++ b/tests/test_machine_cli.py
@@ -168,6 +168,117 @@ def test_sourcehunt_machine_request_accepts_checkpoint_object():
         )
 
 
+def test_sourcehunt_machine_request_semgrep_is_strict_and_default_off():
+    assert sourcehunt._machine_request({"repo_url": "https://example.test/repo"})["semgrep"] is False
+    assert (
+        sourcehunt._machine_request(
+            {"repo_url": "https://example.test/repo", "semgrep": True}
+        )["semgrep"]
+        is True
+    )
+    with pytest.raises(ValueError, match="semgrep must be a boolean"):
+        sourcehunt._machine_request(
+            {"repo_url": "https://example.test/repo", "semgrep": "true"}
+        )
+
+
+def test_sourcehunt_machine_handler_propagates_semgrep(monkeypatch):
+    captured = {}
+
+    class FakeChannel:
+        workspace = {
+            "local_path": "/workspace/source",
+            "output_dir": "/workspace/results",
+            "checkpoint_path": "/workspace/results/checkpoint.json",
+        }
+
+        def __init__(self, descriptor, operation):
+            assert descriptor == 7
+            assert operation == "sourcehunt"
+
+        def read_start(self):
+            return (
+                {"repo_url": "https://example.test/repo", "semgrep": True},
+                {"provider": {"model": "test-model"}},
+            )
+
+        def emit(self, *_args):
+            pass
+
+        def result(self, value):
+            captured["result"] = value
+
+        def error(self, error):
+            raise AssertionError(f"unexpected machine error: {error}")
+
+        def close(self):
+            pass
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            captured["runner"] = kwargs
+
+        async def arun(self):
+            return _SourceResult()
+
+    monkeypatch.setattr("clearwing.ui.machine.MachineChannel", FakeChannel)
+    monkeypatch.setattr("clearwing.providers.install_runtime_routing", lambda routing: None)
+    monkeypatch.setattr(
+        "clearwing.providers.ProviderManager.from_config",
+        lambda routing: SimpleNamespace(),
+    )
+    monkeypatch.setattr("clearwing.sourcehunt.runner.SourceHuntRunner", FakeRunner)
+
+    assert sourcehunt._handle_machine(7) == 0
+    assert captured["runner"]["enable_semgrep"] is True
+
+
+def test_sourcehunt_machine_handler_honors_visible_cli_semgrep(monkeypatch):
+    captured = {}
+
+    class FakeChannel:
+        workspace = {}
+
+        def __init__(self, _descriptor, _operation):
+            pass
+
+        def read_start(self):
+            return (
+                {"repo_url": "https://example.test/repo"},
+                {"provider": {"model": "test-model"}},
+            )
+
+        def emit(self, *_args):
+            pass
+
+        def result(self, _value):
+            pass
+
+        def error(self, error):
+            raise AssertionError(f"unexpected machine error: {error}")
+
+        def close(self):
+            pass
+
+    class FakeRunner:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def arun(self):
+            return _SourceResult()
+
+    monkeypatch.setattr("clearwing.ui.machine.MachineChannel", FakeChannel)
+    monkeypatch.setattr("clearwing.providers.install_runtime_routing", lambda routing: None)
+    monkeypatch.setattr(
+        "clearwing.providers.ProviderManager.from_config",
+        lambda routing: SimpleNamespace(),
+    )
+    monkeypatch.setattr("clearwing.sourcehunt.runner.SourceHuntRunner", FakeRunner)
+
+    assert sourcehunt._handle_machine(7, enable_semgrep=True) == 0
+    assert captured["enable_semgrep"] is True
+
+
 def test_operate_machine_uses_host_routing_and_emits_typed_records():
     parent, channel = _channel("operate", {"target": "host", "goals": ["scan"]})
     request, routing = channel.read_start()

--- a/tests/test_sourcehunt_semgrep.py
+++ b/tests/test_sourcehunt_semgrep.py
@@ -43,12 +43,40 @@ class TestSemgrepFinding:
 
 class TestSemgrepAvailability:
     def test_available_true_when_binary_found(self):
-        with patch("shutil.which", return_value="/usr/local/bin/semgrep"):
+        with (
+            patch(
+                "clearwing.sourcehunt.semgrep_sidecar._active_environment_semgrep",
+                return_value=None,
+            ),
+            patch("shutil.which", return_value="/usr/local/bin/semgrep"),
+        ):
             assert SemgrepSidecar().available is True
 
     def test_available_false_when_binary_missing(self):
-        with patch("shutil.which", return_value=None):
+        with (
+            patch(
+                "clearwing.sourcehunt.semgrep_sidecar._active_environment_semgrep",
+                return_value=None,
+            ),
+            patch("shutil.which", return_value=None),
+        ):
             assert SemgrepSidecar().available is False
+
+    def test_prefers_semgrep_from_the_running_python_environment(self):
+        with (
+            patch(
+                "clearwing.sourcehunt.semgrep_sidecar._active_environment_semgrep",
+                return_value="/opt/clearwing/.venv/bin/semgrep",
+            ),
+            patch("shutil.which", return_value=None),
+            patch(
+                "subprocess.run",
+                return_value=_fake_proc(json.dumps({"results": []}), returncode=0),
+            ) as mock_run,
+        ):
+            SemgrepSidecar().run_scan("/abs/repo")
+
+        assert mock_run.call_args.args[0][0] == "/opt/clearwing/.venv/bin/semgrep"
 
 
 # --- run_scan mocking subprocess -------------------------------------------
@@ -95,7 +123,13 @@ def _fake_proc(stdout: str, returncode: int = 1):
 
 class TestRunScanMocked:
     def test_not_available_returns_empty(self):
-        with patch("shutil.which", return_value=None):
+        with (
+            patch(
+                "clearwing.sourcehunt.semgrep_sidecar._active_environment_semgrep",
+                return_value=None,
+            ),
+            patch("shutil.which", return_value=None),
+        ):
             findings = SemgrepSidecar().run_scan("/abs/repo")
         assert findings == []
 

--- a/tests/test_sourcehunt_semgrep_enablement.py
+++ b/tests/test_sourcehunt_semgrep_enablement.py
@@ -1,0 +1,95 @@
+"""Semgrep must be installed-capable but explicitly enabled by its caller."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from clearwing.sourcehunt.config import FeatureFlags, SourceHuntConfig, TargetConfig
+from clearwing.sourcehunt.runner import SourceHuntRunner
+from clearwing.ui.commands import sourcehunt as sourcehunt_command
+
+
+def _parse(*args: str) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog="clearwing")
+    subparsers = parser.add_subparsers(dest="command")
+    sourcehunt_command.add_parser(subparsers)
+    return parser.parse_args(["sourcehunt", "test-repository", *args])
+
+
+def _runner(tmp_path, **overrides) -> SourceHuntRunner:
+    options = {
+        "repo_url": "test-repository",
+        "local_path": str(tmp_path),
+        "output_dir": str(tmp_path / "results"),
+        "enable_calibration": False,
+        "enable_knowledge_graph": False,
+        "enable_mechanism_memory": False,
+    }
+    options.update(overrides)
+    return SourceHuntRunner(**options)
+
+
+def test_cli_semgrep_is_visible_and_default_off() -> None:
+    assert _parse().semgrep is False
+    assert _parse("--semgrep").semgrep is True
+
+
+@pytest.mark.parametrize("depth", ["quick", "standard", "deep"])
+def test_runner_does_not_enable_semgrep_implicitly(tmp_path, monkeypatch, depth) -> None:
+    preprocessor = MagicMock()
+    preprocessor.return_value.run.return_value = MagicMock()
+    monkeypatch.setattr("clearwing.sourcehunt.runner.Preprocessor", preprocessor)
+    monkeypatch.setattr(
+        "clearwing.sourcehunt.runner.PreprocessCheckpoint.from_result",
+        MagicMock(return_value=MagicMock()),
+    )
+    runner = _runner(tmp_path, depth=depth)
+    runner._checkpoint = MagicMock(preprocess=None)
+    monkeypatch.setattr(runner, "_dump_checkpoint", MagicMock())
+
+    runner._preprocess()
+
+    assert preprocessor.call_args.kwargs["run_semgrep"] is False
+
+
+def test_runner_propagates_explicit_semgrep_even_at_quick_depth(tmp_path, monkeypatch) -> None:
+    preprocessor = MagicMock()
+    preprocessor.return_value.run.return_value = MagicMock()
+    monkeypatch.setattr("clearwing.sourcehunt.runner.Preprocessor", preprocessor)
+    monkeypatch.setattr(
+        "clearwing.sourcehunt.runner.PreprocessCheckpoint.from_result",
+        MagicMock(return_value=MagicMock()),
+    )
+    runner = _runner(tmp_path, depth="quick", enable_semgrep=True)
+    runner._checkpoint = MagicMock(preprocess=None)
+    monkeypatch.setattr(runner, "_dump_checkpoint", MagicMock())
+
+    runner._preprocess()
+
+    assert preprocessor.call_args.kwargs["run_semgrep"] is True
+
+
+def test_config_can_explicitly_enable_semgrep(tmp_path) -> None:
+    config = SourceHuntConfig(
+        target=TargetConfig(repo_url="test-repository", local_path=str(tmp_path)),
+        features=FeatureFlags(enable_semgrep=True),
+    )
+
+    runner = SourceHuntRunner(config=config, output_dir=str(tmp_path / "results"))
+
+    assert runner._enable_semgrep is True
+
+
+def test_proof_flow_rejects_semgrep_instead_of_ignoring_it(tmp_path) -> None:
+    with pytest.raises(ValueError, match="Semgrep is currently supported only for legacy flow"):
+        _runner(tmp_path, flow="proof", enable_semgrep=True)
+
+
+def test_container_installs_sourcehunt_extra() -> None:
+    dockerfile = (Path(__file__).parents[1] / "Dockerfile").read_text()
+
+    assert "uv pip install --system --no-cache --extra sourcehunt -r pyproject.toml" in dockerfile


### PR DESCRIPTION
Summary:
- install the SourceHunt extra reproducibly in the container without activating Semgrep
- default Semgrep off in runner/config/CLI and machine API paths
- expose explicit --semgrep and strict machine request semgrep: true|false activation
- propagate the setting through one-shot, watch, webhook, and machine execution
- prefer the Semgrep executable beside the running Python after activation, so absolute venv/systemd launches do not depend on ambient PATH
- reject Semgrep with the proof flow instead of silently ignoring it

Contract:
- installation or discoverability alone never activates Semgrep
- standard/deep depth no longer implies Semgrep
- explicit CLI or machine API policy is required

Tests:
- 38 passed: Semgrep runner/config/CLI/machine/sidecar contract and machine protocol
- 14 passed: flow compatibility and commit-monitor propagation
- Ruff passed on all changed Python files
- git diff --check passed