### PR TITLE
feat(asm): attack-surface management — external discovery, continuous monitoring, engagement

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Clearwing is a dual-mode offensive-security tool:
 - **Campaign orchestration** — runs sourcehunt across dozens or
   hundreds of repositories from a single YAML config with shared
   budget, checkpoint/resume, and aggregate reporting.
+- **Attack-surface management** — passive external discovery (subdomains,
+  cert transparency, Wayback, DNS/liveness), a scope-keyed asset inventory with
+  delta detection, continuous monitoring with Slack/webhook alerts on new
+  assets, KEV/EPSS-prioritized findings, and mass sweeps that feed the scanners.
+  See [`docs/asm.md`](docs/asm.md).
 - **Responsible disclosure** — human-in-the-loop validation
   workflow with MITRE/HackerOne template generation, SHA-3
   cryptographic commitments for provable priority, timeline

--- a/clearwing/agent/tools/__init__.py
+++ b/clearwing/agent/tools/__init__.py
@@ -23,6 +23,15 @@ def _get_browser_tools() -> list[Any]:
         return []
 
 
+def _get_discovery_tools() -> list[Any]:
+    try:
+        from .recon.discovery_tools import get_discovery_tools
+
+        return get_discovery_tools()
+    except ImportError:
+        return []
+
+
 def _get_proxy_tools() -> list[Any]:
     try:
         from .recon.proxy_tools import get_proxy_tools
@@ -242,6 +251,7 @@ def get_all_tools() -> list[Any]:
     ]
 
     tools.extend(_get_browser_tools())
+    tools.extend(_get_discovery_tools())
     tools.extend(_get_proxy_tools())
     tools.extend(_get_webcrypto_tools())
     tools.extend(_get_auth_recorder_tools())

--- a/clearwing/agent/tools/recon/discovery_tools.py
+++ b/clearwing/agent/tools/recon/discovery_tools.py
@@ -1,0 +1,374 @@
+"""External attack-surface discovery tools (passive-first, host-safe).
+
+These populate the *front half* of an engagement that Clearwing otherwise
+lacked: given a root domain, find the subdomains, hosts, URLs, and technologies
+that make up its attack surface. Everything here is read-only reconnaissance:
+
+- **Passive** sources (certificate transparency via crt.sh, the Wayback Machine,
+  and optional Shodan/Censys/GitHub when keys are configured) query public
+  third-party archives *about* the target — host-safe, exactly like Clearwing's
+  existing NVD/CVE lookups. No `interrupt()` gate is needed.
+- **Light active** probing (DNS resolution, HTTP liveness) touches the target
+  read-only, matching the existing `proxy_request` / `scan_ports` behavior.
+
+Heavy active enumeration (amass brute force, masscan) is intentionally *not*
+here — that belongs in the Kali container (`kali_execute`).
+
+Each tool wraps a plain helper function (e.g. `crtsh_subdomains`) so the ASM
+orchestrator and tests can call the logic directly, and so the HTTP fetch is a
+single monkeypatchable seam.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from clearwing.agent.tooling import tool
+
+logger = logging.getLogger(__name__)
+
+_USER_AGENT = "clearwing-asm/0.5 (+https://github.com/Lazarus-AI/clearwing)"
+_HTTP_TIMEOUT = 20
+_MAX_BYTES = 8_000_000
+
+
+# --- HTTP seam (monkeypatched in tests) -------------------------------------
+
+
+def _http_get(url: str, *, timeout: int = _HTTP_TIMEOUT, accept: str = "*/*") -> str:
+    """GET *url* and return the (size-capped) body text, or "" on any failure."""
+    request = urllib.request.Request(
+        url, headers={"User-Agent": _USER_AGENT, "Accept": accept}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            return response.read(_MAX_BYTES).decode("utf-8", errors="replace")
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        logger.debug("HTTP GET failed for %s: %s", url, exc)
+        return ""
+
+
+def _http_get_json(url: str, *, timeout: int = _HTTP_TIMEOUT) -> object:
+    body = _http_get(url, timeout=timeout, accept="application/json")
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return None
+
+
+# --- Passive discovery helpers ----------------------------------------------
+
+
+def _clean_name(name: str) -> str:
+    return name.strip().lower().lstrip("*.").rstrip(".")
+
+
+def crtsh_subdomains(domain: str) -> list[str]:
+    """Subdomains of *domain* from certificate-transparency logs (crt.sh)."""
+    url = "https://crt.sh/?q=%25." + urllib.parse.quote(domain) + "&output=json"
+    data = _http_get_json(url)
+    names: set[str] = set()
+    if isinstance(data, list):
+        for row in data:
+            if not isinstance(row, dict):
+                continue
+            for raw in str(row.get("name_value", "")).splitlines():
+                candidate = _clean_name(raw)
+                if candidate == domain or candidate.endswith("." + domain):
+                    names.add(candidate)
+    return sorted(names)
+
+
+def crtsh_certs(domain: str) -> list[dict]:
+    """Recent certificate records for *domain* (issuer + names + validity)."""
+    url = "https://crt.sh/?q=" + urllib.parse.quote(domain) + "&output=json"
+    data = _http_get_json(url)
+    certs: list[dict] = []
+    if isinstance(data, list):
+        for row in data[:200]:
+            if not isinstance(row, dict):
+                continue
+            certs.append(
+                {
+                    "issuer": row.get("issuer_name", ""),
+                    "common_name": row.get("common_name", ""),
+                    "names": [_clean_name(n) for n in str(row.get("name_value", "")).splitlines()],
+                    "not_before": row.get("not_before", ""),
+                    "not_after": row.get("not_after", ""),
+                }
+            )
+    return certs
+
+
+def wayback_urls(domain: str, limit: int = 5000) -> list[str]:
+    """Historical URLs for *domain* from the Wayback Machine CDX API."""
+    url = (
+        "https://web.archive.org/cdx/search/cdx?url="
+        + urllib.parse.quote(domain)
+        + "/*&output=json&fl=original&collapse=urlkey&limit="
+        + str(int(limit))
+    )
+    data = _http_get_json(url)
+    urls: list[str] = []
+    if isinstance(data, list) and data:
+        # First row is the header (["original"]); the rest are single-item rows.
+        for row in data[1:]:
+            if isinstance(row, list) and row:
+                urls.append(str(row[0]))
+    return sorted(set(urls))
+
+
+def github_subdomains(domain: str, env_var: str = "GITHUB_API_KEY") -> list[str]:
+    """Subdomains mined from public GitHub code search (needs a GitHub token)."""
+    import re
+
+    token = os.environ.get(env_var, "")
+    if not token:
+        return []
+    query = urllib.parse.quote(f'"{domain}"')
+    url = f"https://api.github.com/search/code?q={query}&per_page=100"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "User-Agent": _USER_AGENT,
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=_HTTP_TIMEOUT) as response:  # noqa: S310
+            payload = json.loads(response.read(_MAX_BYTES).decode("utf-8", "replace"))
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+        return []
+    pattern = re.compile(r"(?:[a-z0-9_-]+\.)+" + re.escape(domain), re.IGNORECASE)
+    names = {_clean_name(m.group(0)) for m in pattern.finditer(json.dumps(payload))}
+    return sorted(names)
+
+
+# --- Light active helpers ---------------------------------------------------
+
+
+def resolve_name(name: str) -> list[str]:
+    """Resolve *name* to its IPv4/IPv6 addresses (empty on failure)."""
+    try:
+        infos = socket.getaddrinfo(name, None)
+    except (socket.gaierror, OSError, UnicodeError):
+        return []
+    return sorted({info[4][0] for info in infos})
+
+
+def probe_url(url: str, *, timeout: int = 10) -> dict:
+    """HTTP(S) liveness probe: status, server, and a light tech fingerprint."""
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            headers = {k.lower(): v for k, v in response.headers.items()}
+            body = response.read(65536).decode("utf-8", errors="replace")
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        headers = {k.lower(): v for k, v in (exc.headers or {}).items()}
+        body = ""
+        status = exc.code
+    except (urllib.error.URLError, OSError, ValueError):
+        return {"url": url, "live": False}
+    return {
+        "url": url,
+        "live": True,
+        "status": status,
+        "server": headers.get("server", ""),
+        "technologies": _fingerprint(headers, body),
+    }
+
+
+_TECH_HEADER_MARKERS = {
+    "x-powered-by": None,
+    "server": None,
+    "x-generator": None,
+    "x-aspnet-version": "ASP.NET",
+}
+_TECH_BODY_MARKERS = {
+    "wp-content": "WordPress",
+    "/_next/": "Next.js",
+    "csrfmiddlewaretoken": "Django",
+    "drupal-settings-json": "Drupal",
+    "__NUXT__": "Nuxt.js",
+}
+
+
+def _fingerprint(headers: dict[str, str], body: str) -> list[str]:
+    techs: set[str] = set()
+    for header, label in _TECH_HEADER_MARKERS.items():
+        value = headers.get(header, "")
+        if value:
+            techs.add(label or value.split("/")[0].strip())
+    for marker, label in _TECH_BODY_MARKERS.items():
+        if marker in body:
+            techs.add(label)
+    return sorted(t for t in techs if t)
+
+
+# --- Agent tools ------------------------------------------------------------
+
+
+@tool
+def discover_subdomains(domain: str) -> dict:
+    """Enumerate subdomains of a root domain from passive sources.
+
+    Queries certificate-transparency logs (crt.sh) and, when the corresponding
+    API keys are configured in the environment, GitHub code search. Read-only:
+    it queries public archives, never the target directly.
+
+    Args:
+        domain: The root domain, e.g. "example.com".
+
+    Returns:
+        {"domain": str, "subdomains": [str], "count": int, "sources": [str]}.
+    """
+    sources = ["crt.sh"]
+    names = set(crtsh_subdomains(domain))
+    gh = github_subdomains(domain)
+    if gh:
+        sources.append("github")
+        names.update(gh)
+    return {
+        "domain": domain,
+        "subdomains": sorted(names),
+        "count": len(names),
+        "sources": sources,
+    }
+
+
+@tool
+def lookup_cert_transparency(domain: str) -> dict:
+    """Fetch certificate-transparency records for a domain (issuers, names, validity)."""
+    certs = crtsh_certs(domain)
+    return {"domain": domain, "certificates": certs, "count": len(certs)}
+
+
+@tool
+def discover_wayback_urls(domain: str, limit: int = 5000) -> dict:
+    """Discover historical URLs for a domain via the Wayback Machine (passive)."""
+    urls = wayback_urls(domain, limit=limit)
+    return {"domain": domain, "urls": urls, "count": len(urls)}
+
+
+@tool
+def resolve_hosts(names: list[str]) -> dict:
+    """Resolve a list of hostnames to IP addresses via DNS.
+
+    Args:
+        names: Hostnames to resolve.
+
+    Returns:
+        {"resolved": {name: [ip]}, "unresolved": [name]}.
+    """
+    resolved: dict[str, list[str]] = {}
+    unresolved: list[str] = []
+    for name in names:
+        ips = resolve_name(name)
+        if ips:
+            resolved[name] = ips
+        else:
+            unresolved.append(name)
+    return {"resolved": resolved, "unresolved": unresolved}
+
+
+@tool
+def probe_liveness(hosts: list[str]) -> dict:
+    """Probe hosts/URLs for HTTP(S) liveness and light technology fingerprints.
+
+    Each entry may be a bare host (both https:// and http:// are tried) or a
+    full URL. Read-only GET requests only.
+
+    Returns:
+        {"live": [ {url, status, server, technologies} ], "dead": [str]}.
+    """
+    live: list[dict] = []
+    dead: list[str] = []
+    for host in hosts:
+        candidates = [host] if "://" in host else [f"https://{host}", f"http://{host}"]
+        hit = None
+        for candidate in candidates:
+            result = probe_url(candidate)
+            if result.get("live"):
+                hit = result
+                break
+        if hit is not None:
+            live.append(hit)
+        else:
+            dead.append(host)
+    return {"live": live, "dead": dead}
+
+
+@tool
+def screenshot_surface(urls: list[str], out_dir: str = "/tmp/asm-screenshots") -> dict:
+    """Screenshot each URL and write an HTML thumbnail gallery for triage.
+
+    Loops the Playwright browser tools over the URLs (one shared browser) and
+    writes `<out_dir>/gallery.html` linking every capture — fast visual triage
+    of a discovered surface.
+    """
+    from pathlib import Path
+
+    from clearwing.agent.tools.recon.browser_tools import browser_navigate, browser_screenshot
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    shots: list[dict] = []
+    for index, url in enumerate(urls):
+        path = str(out / f"shot-{index:03d}.png")
+        nav = browser_navigate(url)
+        if nav.get("status") == "error":
+            shots.append({"url": url, "ok": False, "error": nav.get("error", "navigation failed")})
+            continue
+        shot = browser_screenshot(path=path)
+        shots.append({"url": url, "ok": bool(shot.get("success")), "path": path, "title": nav.get("title", "")})
+    gallery = out / "gallery.html"
+    gallery.write_text(_render_gallery(shots), encoding="utf-8")
+    return {"gallery": str(gallery), "screenshots": shots, "count": len(shots)}
+
+
+def _render_gallery(shots: list[dict]) -> str:
+    import html as _html
+    from pathlib import Path
+
+    cards = []
+    for shot in shots:
+        if shot.get("ok"):
+            img = f'<img src="{_html.escape(Path(shot["path"]).name)}" loading="lazy">'
+        else:
+            img = f'<div class="err">{_html.escape(str(shot.get("error", "no capture")))}</div>'
+        title = _html.escape(shot.get("title") or shot["url"])
+        link = _html.escape(shot["url"])
+        cards.append(
+            f'<figure>{img}<figcaption>{title}<br><a href="{link}">{link}</a></figcaption></figure>'
+        )
+    return (
+        "<!doctype html><meta charset=utf-8><title>ASM surface gallery</title>"
+        "<style>body{font-family:sans-serif;background:#111;color:#eee}"
+        "figure{display:inline-block;width:320px;margin:8px;vertical-align:top}"
+        "img{width:320px;border:1px solid #333}.err{height:180px;display:flex;"
+        "align-items:center;justify-content:center;background:#222;color:#a44}"
+        "figcaption{font-size:12px;word-break:break-all}a{color:#6af}</style>"
+        "<h1>Attack surface</h1>" + "".join(cards)
+    )
+
+
+def get_discovery_tools() -> list:
+    """Return the external-discovery agent tools."""
+    return [
+        discover_subdomains,
+        lookup_cert_transparency,
+        discover_wayback_urls,
+        resolve_hosts,
+        probe_liveness,
+        screenshot_surface,
+    ]

--- a/clearwing/asm/__init__.py
+++ b/clearwing/asm/__init__.py
@@ -1,0 +1,25 @@
+"""Attack-Surface Management (ASM) — discovery, continuity, and engagement.
+
+Clearwing is deep on a known target. This subsystem adds the front half of an
+engagement: discovering what's out there (subdomains, hosts, ports, services,
+URLs, technologies), tracking what changed over time, and feeding new assets
+into Clearwing's existing deep scanning / verification pipeline.
+
+Layout:
+    assets.py       — Asset + AssetStore (scope-keyed SQLite, delta detection)
+    scope.py        — Scope engagement model
+    discovery.py    — passive/active discovery orchestration
+    monitor.py      — continuous ASM poll loop + deep-tool integration
+    notify.py       — outbound Slack/webhook notifier
+    threatintel.py  — CISA KEV / EPSS enrichment
+    sweep.py        — mass parallel scanning across the surface
+    modes.py        — named workflow playbooks
+    report.py       — per-scope aggregate reporting
+"""
+
+from __future__ import annotations
+
+from clearwing.asm.assets import ASSET_TYPES, Asset, AssetStore
+from clearwing.asm.scope import Scope
+
+__all__ = ["ASSET_TYPES", "Asset", "AssetStore", "Scope"]

--- a/clearwing/asm/assets.py
+++ b/clearwing/asm/assets.py
@@ -1,0 +1,263 @@
+"""Scope-keyed asset inventory with delta detection.
+
+Modeled on :class:`clearwing.sourcehunt.historical_findings_db.HistoricalFindingsDB`
+— a small SQLite store whose whole job is answering "is this new since last
+time?". Here the key is the engagement *scope* (the analog of that store's
+``repo_url``) and the rows are discovered assets.
+
+The store is authoritative for the temporal delta (``first_seen`` / ``last_seen``
+and the "which of these did we not know about?" answer). A separate projection
+into the knowledge graph (see :mod:`clearwing.asm.discovery`) makes the same
+assets queryable and visualizable; this module never depends on that graph.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from clearwing.reporting.safety import redact_text
+
+logger = logging.getLogger(__name__)
+
+#: The kinds of asset the inventory tracks. Kept deliberately small and flat;
+#: hierarchy is expressed via ``parent_id`` rather than distinct tables.
+ASSET_TYPES = (
+    "domain",  # a root domain in scope, e.g. example.com
+    "subdomain",  # a discovered name, e.g. api.example.com
+    "host",  # a resolvable/live host (name or ip acting as one)
+    "ip",  # a resolved address
+    "port",  # an open port on a host: "<host>:<port>/<proto>"
+    "service",  # a service on a port: "<port_id>:<name>"
+    "url",  # a discovered URL
+    "technology",  # a fingerprinted technology on a host/url
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS assets (
+    id TEXT PRIMARY KEY,
+    scope TEXT NOT NULL,
+    asset_type TEXT NOT NULL,
+    value TEXT NOT NULL,
+    parent_id TEXT,
+    source TEXT,
+    metadata_json TEXT,
+    first_seen REAL NOT NULL,
+    last_seen REAL NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active'
+);
+CREATE INDEX IF NOT EXISTS idx_asset_scope ON assets(scope);
+CREATE INDEX IF NOT EXISTS idx_asset_scope_type ON assets(scope, asset_type);
+CREATE INDEX IF NOT EXISTS idx_asset_parent ON assets(parent_id);
+"""
+
+
+def _default_db_path() -> Path:
+    from clearwing.core.config import clearwing_home
+
+    return clearwing_home() / "asm" / "assets.db"
+
+
+@dataclass
+class Asset:
+    """One node of an attack surface, keyed deterministically within a scope."""
+
+    scope: str
+    asset_type: str
+    value: str
+    parent_id: str | None = None
+    source: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    first_seen: float | None = None
+    last_seen: float | None = None
+    status: str = "active"
+
+    @property
+    def id(self) -> str:
+        """Deterministic id — identical (scope, type, value) is the same asset."""
+        return self.compute_id(self.scope, self.asset_type, self.value)
+
+    @staticmethod
+    def compute_id(scope: str, asset_type: str, value: str) -> str:
+        digest = hashlib.sha256(f"{scope}|{asset_type}|{value}".encode()).hexdigest()
+        return f"asset-{digest[:24]}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "scope": self.scope,
+            "asset_type": self.asset_type,
+            "value": self.value,
+            "parent_id": self.parent_id,
+            "source": self.source,
+            "metadata": dict(self.metadata),
+            "first_seen": self.first_seen,
+            "last_seen": self.last_seen,
+            "status": self.status,
+        }
+
+
+class AssetStore:
+    """Cross-run asset inventory. Idempotent ingest; returns the delta."""
+
+    def __init__(self, path: Path | None = None):
+        self._path = path or _default_db_path()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._path))
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> AssetStore:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    # -- ingest ---------------------------------------------------------
+
+    def record_observations(self, scope: str, assets: list[Asset]) -> list[Asset]:
+        """Upsert *assets* under *scope*; return only the ones that were NEW.
+
+        A previously-unseen asset is inserted (and returned as part of the
+        delta); an already-known one has its ``last_seen`` (and any richer
+        metadata/parent) refreshed but is not returned. This is the primitive
+        the monitor uses to act only on genuinely new surface.
+        """
+        now = time.time()
+        new_assets: list[Asset] = []
+        for asset in assets:
+            if asset.asset_type not in ASSET_TYPES:
+                logger.debug("Skipping asset of unknown type %r", asset.asset_type)
+                continue
+            asset.scope = scope
+            asset_id = asset.id
+            existing = self._conn.execute(
+                "SELECT first_seen FROM assets WHERE id = ?", (asset_id,)
+            ).fetchone()
+            metadata_json = json.dumps(_redact_metadata(asset.metadata), sort_keys=True)
+            if existing is None:
+                asset.first_seen = now
+                asset.last_seen = now
+                self._conn.execute(
+                    """INSERT INTO assets
+                    (id, scope, asset_type, value, parent_id, source,
+                     metadata_json, first_seen, last_seen, status)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    (
+                        asset_id,
+                        scope,
+                        asset.asset_type,
+                        redact_text(asset.value),
+                        asset.parent_id,
+                        asset.source,
+                        metadata_json,
+                        now,
+                        now,
+                        asset.status,
+                    ),
+                )
+                new_assets.append(asset)
+            else:
+                asset.first_seen = existing["first_seen"]
+                asset.last_seen = now
+                # Refresh last_seen and enrich parent/source/metadata in place.
+                self._conn.execute(
+                    """UPDATE assets SET last_seen = ?,
+                       parent_id = COALESCE(?, parent_id),
+                       source = CASE WHEN ? != '' THEN ? ELSE source END,
+                       metadata_json = ?, status = ?
+                       WHERE id = ?""",
+                    (
+                        now,
+                        asset.parent_id,
+                        asset.source,
+                        asset.source,
+                        metadata_json,
+                        asset.status,
+                        asset_id,
+                    ),
+                )
+        self._conn.commit()
+        return new_assets
+
+    # -- query ----------------------------------------------------------
+
+    def is_new(self, scope: str, asset: Asset) -> bool:
+        """True if this exact asset has never been recorded for the scope."""
+        row = self._conn.execute(
+            "SELECT 1 FROM assets WHERE id = ? LIMIT 1",
+            (Asset.compute_id(scope, asset.asset_type, asset.value),),
+        ).fetchone()
+        return row is None
+
+    def known_assets(self, scope: str, asset_type: str | None = None) -> list[Asset]:
+        query = "SELECT * FROM assets WHERE scope = ?"
+        params: list[Any] = [scope]
+        if asset_type is not None:
+            query += " AND asset_type = ?"
+            params.append(asset_type)
+        query += " ORDER BY asset_type, value"
+        rows = self._conn.execute(query, params).fetchall()
+        return [_row_to_asset(row) for row in rows]
+
+    def deltas_since(self, scope: str, since_ts: float) -> list[Asset]:
+        """Assets first seen at or after *since_ts* — the "what's new" view."""
+        rows = self._conn.execute(
+            "SELECT * FROM assets WHERE scope = ? AND first_seen >= ? "
+            "ORDER BY first_seen DESC",
+            (scope, since_ts),
+        ).fetchall()
+        return [_row_to_asset(row) for row in rows]
+
+    def scopes(self) -> list[str]:
+        rows = self._conn.execute(
+            "SELECT DISTINCT scope FROM assets ORDER BY scope"
+        ).fetchall()
+        return [row["scope"] for row in rows]
+
+    def stats(self, scope: str) -> dict[str, int]:
+        """Count of assets per type for a scope (for reports / `asm list`)."""
+        rows = self._conn.execute(
+            "SELECT asset_type, COUNT(*) AS n FROM assets WHERE scope = ? "
+            "GROUP BY asset_type",
+            (scope,),
+        ).fetchall()
+        return {row["asset_type"]: row["n"] for row in rows}
+
+
+def _redact_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in metadata.items():
+        out[key] = redact_text(value) if isinstance(value, str) else value
+    return out
+
+
+def _row_to_asset(row: sqlite3.Row) -> Asset:
+    try:
+        metadata = json.loads(row["metadata_json"]) if row["metadata_json"] else {}
+    except (json.JSONDecodeError, TypeError):
+        metadata = {}
+    return Asset(
+        scope=row["scope"],
+        asset_type=row["asset_type"],
+        value=row["value"],
+        parent_id=row["parent_id"],
+        source=row["source"] or "",
+        metadata=metadata if isinstance(metadata, dict) else {},
+        first_seen=row["first_seen"],
+        last_seen=row["last_seen"],
+        status=row["status"],
+    )
+
+
+__all__ = ["ASSET_TYPES", "Asset", "AssetStore"]

--- a/clearwing/asm/discovery.py
+++ b/clearwing/asm/discovery.py
@@ -1,0 +1,166 @@
+"""Orchestrate the discovery tools into a normalized set of scoped assets.
+
+`run_discovery(scope)` fans the passive/active discovery helpers over a scope's
+root domains and returns a flat list of :class:`~clearwing.asm.assets.Asset`
+objects with parent links wired (domain → subdomain → ip, domain → url,
+subdomain → technology). The helpers are called via the module so tests can
+monkeypatch a single seam.
+
+`project_to_graph` mirrors the same assets into the knowledge graph so they are
+queryable (`query_knowledge_graph`) and visualizable (attack-graph HTML). The
+:class:`AssetStore` remains authoritative for the temporal delta.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from clearwing.agent.tools.recon import discovery_tools as dt
+from clearwing.asm.assets import Asset
+from clearwing.asm.scope import Scope
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DiscoveryOptions:
+    passive: bool = True  # crt.sh + wayback + optional github
+    resolve: bool = True  # DNS-resolve discovered names
+    probe: bool = True  # HTTP liveness + tech fingerprint
+    wayback: bool = True  # historical URL mining
+    max_probe: int = 200  # cap live probes per run
+
+
+@dataclass
+class DiscoveryResult:
+    scope: str
+    assets: list[Asset] = field(default_factory=list)
+
+
+def run_discovery(scope: Scope, options: DiscoveryOptions | None = None) -> DiscoveryResult:
+    """Discover the current attack surface for *scope*. Never raises on a source
+    failure — a dead source just contributes nothing."""
+    opts = options or DiscoveryOptions()
+    assets: list[Asset] = []
+    names_seen: list[str] = []
+
+    for domain in scope.domains:
+        domain_assets, resolvable = _discover_domain(scope, domain, opts)
+        assets.extend(domain_assets)
+        names_seen.extend(resolvable)
+
+    if opts.probe:
+        for host in list(dict.fromkeys(names_seen))[: opts.max_probe]:
+            assets.extend(_probe_host(scope, host))
+
+    return DiscoveryResult(scope=scope.name, assets=assets)
+
+
+def _discover_domain(
+    scope: Scope, domain: str, opts: DiscoveryOptions
+) -> tuple[list[Asset], list[str]]:
+    """Discover one root domain: subdomains, URLs, resolved IPs."""
+    assets: list[Asset] = [Asset(scope.name, "domain", domain, source="scope")]
+    names: set[str] = {domain}
+    domain_id = _id(scope, "domain", domain)
+
+    if opts.passive:
+        found = set(_safe(dt.crtsh_subdomains, domain, default=[]))
+        found |= set(_safe(dt.github_subdomains, domain, default=[]))
+        for name in sorted(found):
+            if name != domain and scope.in_scope(name):
+                names.add(name)
+                assets.append(
+                    Asset(scope.name, "subdomain", name, parent_id=domain_id, source="crt.sh")
+                )
+
+    if opts.wayback:
+        for url in _safe(dt.wayback_urls, domain, default=[])[:5000]:
+            assets.append(Asset(scope.name, "url", url, parent_id=domain_id, source="wayback"))
+
+    resolvable: list[str] = []
+    if opts.resolve:
+        for name in sorted(names):
+            ips = _safe(dt.resolve_name, name, default=[])
+            if ips:
+                resolvable.append(name)
+            parent = _id(scope, _name_type(name, domain), name)
+            for ip in ips:
+                assets.append(Asset(scope.name, "ip", ip, parent_id=parent, source="dns"))
+
+    return assets, resolvable
+
+
+def _probe_host(scope: Scope, host: str) -> list[Asset]:
+    """HTTP(S) liveness + tech fingerprint for one host (https preferred)."""
+    parent = _id(scope, _host_type_for(host, scope), host)
+    for scheme in ("https", "http"):
+        result = _safe(dt.probe_url, f"{scheme}://{host}", default={})
+        if not result.get("live"):
+            continue
+        assets = [
+            Asset(scope.name, "host", result["url"], parent_id=parent, source="probe",
+                  metadata={"status": result.get("status"), "server": result.get("server", "")})
+        ]
+        assets.extend(
+            Asset(scope.name, "technology", tech, parent_id=parent, source="probe")
+            for tech in result.get("technologies", [])
+        )
+        return assets
+    return []
+
+
+def project_to_graph(kg, assets: list[Asset]) -> None:
+    """Mirror discovered assets into the knowledge graph (best-effort)."""
+    parents = {a.id: a for a in assets}
+    for asset in assets:
+        try:
+            if asset.asset_type == "domain":
+                kg.add_domain(asset.value)
+            elif asset.asset_type == "subdomain":
+                root = _parent_value(asset, parents)
+                kg.add_subdomain(root or asset.value, asset.value)
+            elif asset.asset_type == "ip":
+                name = _parent_value(asset, parents) or asset.value
+                kg.add_host_resolution(name, asset.value)
+            elif asset.asset_type == "url":
+                host = _parent_value(asset, parents) or asset.value
+                kg.add_url(host, asset.value)
+            elif asset.asset_type == "technology":
+                host = _parent_value(asset, parents) or ""
+                if host:
+                    kg.add_technology(host, asset.value)
+        except Exception:
+            logger.debug("Could not project asset %s into graph", asset.value, exc_info=True)
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _id(scope: Scope, asset_type: str, value: str) -> str:
+    return Asset.compute_id(scope.name, asset_type, value)
+
+
+def _name_type(name: str, domain: str) -> str:
+    return "domain" if name == domain else "subdomain"
+
+
+def _host_type_for(host: str, scope: Scope) -> str:
+    return "domain" if host in scope.domains else "subdomain"
+
+
+def _parent_value(asset: Asset, parents: dict[str, Asset]) -> str | None:
+    parent = parents.get(asset.parent_id or "")
+    return parent.value if parent else None
+
+
+def _safe(fn, *args, default=None):
+    try:
+        return fn(*args)
+    except Exception:
+        logger.debug("discovery source %s failed", getattr(fn, "__name__", fn), exc_info=True)
+        return default
+
+
+__all__ = ["DiscoveryOptions", "DiscoveryResult", "run_discovery", "project_to_graph"]

--- a/clearwing/asm/modes.py
+++ b/clearwing/asm/modes.py
@@ -1,0 +1,63 @@
+"""Named workflow playbooks for ASM runs.
+
+Sn1per's value partly came from curated named "modes" (recon, web, stealth,
+nuke...) that compose many steps behind one word. These are Clearwing's
+equivalent — presets that toggle the discovery/scan/sweep/screenshot steps of an
+`asm scan`. They compose the existing engine; they add no new detection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from clearwing.asm.discovery import DiscoveryOptions
+
+
+@dataclass(frozen=True)
+class AsmMode:
+    name: str
+    description: str
+    discovery: DiscoveryOptions
+    scan_new_assets: bool = False
+    sweep: bool = False
+    screenshot: bool = False
+
+
+MODES: dict[str, AsmMode] = {
+    "recon": AsmMode(
+        name="recon",
+        description="Passive discovery only — subdomains, URLs, DNS. No probing.",
+        discovery=DiscoveryOptions(passive=True, resolve=True, probe=False, wayback=True),
+    ),
+    "stealth": AsmMode(
+        name="stealth",
+        description="Passive-only, no DNS resolution or probing (leaves no trace on the target).",
+        discovery=DiscoveryOptions(passive=True, resolve=False, probe=False, wayback=True),
+    ),
+    "web-assessment": AsmMode(
+        name="web-assessment",
+        description="Discover + probe live web hosts + screenshot gallery for triage.",
+        discovery=DiscoveryOptions(passive=True, resolve=True, probe=True, wayback=True),
+        screenshot=True,
+    ),
+    "external-sweep": AsmMode(
+        name="external-sweep",
+        description="Full discovery, then port/service/vuln scan across every host.",
+        discovery=DiscoveryOptions(passive=True, resolve=True, probe=True, wayback=True),
+        scan_new_assets=True,
+        sweep=True,
+    ),
+}
+
+DEFAULT_MODE = "recon"
+
+
+def get_mode(name: str | None) -> AsmMode:
+    """Return the named mode, defaulting to `recon`. Raises on an unknown name."""
+    key = (name or DEFAULT_MODE).strip().lower()
+    if key not in MODES:
+        raise ValueError(f"Unknown asm mode {name!r}; choose from: {', '.join(sorted(MODES))}")
+    return MODES[key]
+
+
+__all__ = ["AsmMode", "MODES", "DEFAULT_MODE", "get_mode"]

--- a/clearwing/asm/monitor.py
+++ b/clearwing/asm/monitor.py
@@ -1,0 +1,170 @@
+"""Continuous attack-surface monitor.
+
+Modeled on :class:`clearwing.sourcehunt.commit_monitor.CommitMonitor`: a
+poll-interval loop (`max_iterations=0` runs forever; cancel is responsive
+because sleeps happen in 1-second chunks). Each cycle:
+
+1. runs discovery over the scope,
+2. records observations in the :class:`AssetStore` and keeps only the *new*
+   assets (the delta),
+3. for every new asset: emits `ASSET_DISCOVERED`, mirrors it into the knowledge
+   graph, and — when enabled — drives Clearwing's *existing* deep tools on new
+   hosts (port/service/vuln scan, optionally KEV/EPSS-prioritized).
+
+It never exploits and never triggers approval-gated actions automatically; it
+discovers and scans, then hands any findings to the normal pipeline. Discovery
+and scanning are injectable so tests run without a network.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from clearwing.asm.assets import Asset, AssetStore
+from clearwing.asm.discovery import DiscoveryOptions, project_to_graph, run_discovery
+from clearwing.asm.scope import Scope
+from clearwing.core.event_payloads import AssetDiscoveredPayload
+from clearwing.core.events import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AsmMonitorConfig:
+    scope: Scope
+    poll_interval_seconds: float = 86400.0
+    max_iterations: int = 0  # 0 = run forever
+    scan_new_assets: bool = True
+    threat_intel: bool = True
+    discovery_options: DiscoveryOptions = field(default_factory=DiscoveryOptions)
+    store: AssetStore | None = None
+    knowledge_graph: object | None = None
+    # Injection seams (default to the real implementations):
+    discover_fn: Callable[[Scope, DiscoveryOptions], list[Asset]] | None = None
+    scan_fn: Callable[[Asset], list[dict]] | None = None
+    on_cycle: Callable[[list[Asset]], None] | None = None
+
+
+class AsmMonitor:
+    """Run one or many discovery cycles over a scope, acting only on new assets."""
+
+    def __init__(self, config: AsmMonitorConfig):
+        self.config = config
+        self._store = config.store or AssetStore()
+        self._owns_store = config.store is None
+        self._cancelled = False
+        self.iterations = 0
+
+    # -- lifecycle ------------------------------------------------------
+
+    def run(self) -> None:
+        """Loop cycles until cancelled or `max_iterations` is reached."""
+        try:
+            while not self._cancelled:
+                self.iterations += 1
+                new_assets = self.cycle()
+                logger.info(
+                    "ASM cycle %d for scope %s: %d new assets",
+                    self.iterations,
+                    self.config.scope.name,
+                    len(new_assets),
+                )
+                if self.config.max_iterations and self.iterations >= self.config.max_iterations:
+                    break
+                if not self._cancelled:
+                    self._sleep(self.config.poll_interval_seconds)
+        finally:
+            if self._owns_store:
+                self._store.close()
+
+    def cancel(self) -> None:
+        self._cancelled = True
+
+    # -- one cycle ------------------------------------------------------
+
+    def cycle(self) -> list[Asset]:
+        """Discover → record delta → notify/scan new assets. Returns the delta."""
+        scope = self.config.scope
+        discovered = self._discover(scope)
+        new_assets = self._store.record_observations(scope.name, discovered)
+
+        if self.config.knowledge_graph is not None and new_assets:
+            project_to_graph(self.config.knowledge_graph, new_assets)
+
+        bus = EventBus()
+        for asset in new_assets:
+            bus.emit_asset_discovered(
+                AssetDiscoveredPayload(
+                    scope=scope.name,
+                    asset_type=asset.asset_type,
+                    value=asset.value,
+                    source=asset.source,
+                    parent=asset.parent_id,
+                )
+            )
+
+        if self.config.scan_new_assets:
+            for asset in new_assets:
+                if asset.asset_type in ("ip", "host"):
+                    self._scan(asset)
+
+        if self.config.on_cycle is not None:
+            self.config.on_cycle(new_assets)
+        return new_assets
+
+    # -- injectable steps ----------------------------------------------
+
+    def _discover(self, scope: Scope) -> list[Asset]:
+        if self.config.discover_fn is not None:
+            return self.config.discover_fn(scope, self.config.discovery_options)
+        return run_discovery(scope, self.config.discovery_options).assets
+
+    def _scan(self, asset: Asset) -> list[dict]:
+        try:
+            findings = (
+                self.config.scan_fn(asset)
+                if self.config.scan_fn is not None
+                else _default_scan(asset.value)
+            )
+        except Exception:
+            logger.debug("Deep scan of %s failed", asset.value, exc_info=True)
+            return []
+        if findings and self.config.threat_intel:
+            try:
+                from clearwing.asm.threatintel import ThreatIntel
+
+                findings = ThreatIntel().enrich(findings)
+            except Exception:
+                logger.debug("threat-intel enrichment failed", exc_info=True)
+        return findings
+
+    # -- interruptible sleep -------------------------------------------
+
+    def _sleep(self, seconds: float) -> None:
+        deadline = time.monotonic() + seconds
+        while not self._cancelled and time.monotonic() < deadline:
+            time.sleep(min(1.0, deadline - time.monotonic()))
+
+
+def _default_scan(target: str) -> list[dict]:
+    """Run the existing port/service/vuln scanners on a host (best-effort)."""
+    import asyncio
+
+    from clearwing.agent.tools.scan.scanner_tools import (
+        detect_services,
+        scan_ports,
+        scan_vulnerabilities,
+    )
+
+    async def _run() -> list[dict]:
+        ports = await scan_ports(target)
+        services = await detect_services(target, ports)
+        return await scan_vulnerabilities(target, services)
+
+    return asyncio.run(_run())
+
+
+__all__ = ["AsmMonitor", "AsmMonitorConfig"]

--- a/clearwing/asm/notify.py
+++ b/clearwing/asm/notify.py
@@ -1,0 +1,108 @@
+"""Outbound notifications for new assets and findings.
+
+The event bus already carries `ASSET_DISCOVERED` (emitted by the ASM monitor)
+and `FINDING_RECORDED` (emitted by the hunt pipeline). This subscribes to both
+and pushes a short message to a Slack incoming-webhook and/or a generic webhook
+— the outbound half Clearwing didn't have. Modeled on the sourcehunt CLI's
+`_on_finding` subscribe/unsubscribe pattern; best-effort like `github_checks`
+(a failed POST is logged, never raised, so notifications can't break a scan).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any
+
+from clearwing.core.events import EventBus, EventType
+
+logger = logging.getLogger(__name__)
+
+
+class Notifier:
+    """Pushes new-asset / new-finding events to Slack and/or a webhook."""
+
+    def __init__(self, slack_url: str = "", webhook_url: str = "", timeout: int = 10):
+        self.slack_url = slack_url
+        self.webhook_url = webhook_url
+        self.timeout = timeout
+        self._subscribed = False
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.slack_url or self.webhook_url)
+
+    @classmethod
+    def from_config(cls, asm_config: dict[str, Any]) -> Notifier:
+        """Build from the `asm` config section (env var wins over the literal)."""
+        section = asm_config or {}
+        slack_env = section.get("slack_webhook_env", "CLEARWING_SLACK_WEBHOOK")
+        slack = os.environ.get(slack_env, "") or section.get("slack_webhook_url", "")
+        webhook = section.get("webhook_url", "")
+        return cls(slack_url=slack, webhook_url=webhook)
+
+    def subscribe(self) -> None:
+        if self._subscribed or not self.enabled:
+            return
+        bus = EventBus()
+        bus.subscribe(EventType.ASSET_DISCOVERED, self._on_asset)
+        bus.subscribe(EventType.FINDING_RECORDED, self._on_finding)
+        self._subscribed = True
+
+    def unsubscribe(self) -> None:
+        if not self._subscribed:
+            return
+        bus = EventBus()
+        bus.unsubscribe(EventType.ASSET_DISCOVERED, self._on_asset)
+        bus.unsubscribe(EventType.FINDING_RECORDED, self._on_finding)
+        self._subscribed = False
+
+    def __enter__(self) -> Notifier:
+        self.subscribe()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.unsubscribe()
+
+    # -- event handlers -------------------------------------------------
+
+    def _on_asset(self, payload: Any) -> None:
+        scope = getattr(payload, "scope", "?")
+        atype = getattr(payload, "asset_type", "asset")
+        value = getattr(payload, "value", "")
+        source = getattr(payload, "source", "")
+        self.notify(f":satellite: New {atype} in *{scope}*: `{value}`" + (f" (via {source})" if source else ""))
+
+    def _on_finding(self, data: Any) -> None:
+        if not isinstance(data, dict):
+            return
+        severity = data.get("severity", "info")
+        ftype = data.get("finding_type", "finding")
+        where = data.get("file") or data.get("hunter_target") or ""
+        self.notify(f":rotating_light: New *{severity}* {ftype}" + (f" in `{where}`" if where else ""))
+
+    # -- transport ------------------------------------------------------
+
+    def notify(self, text: str) -> None:
+        """Send *text* to every configured sink. Never raises."""
+        if self.slack_url:
+            self._post(self.slack_url, {"text": text})
+        if self.webhook_url:
+            self._post(self.webhook_url, {"text": text, "source": "clearwing-asm"})
+
+    def _post(self, url: str, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            url, data=data, headers={"Content-Type": "application/json"}, method="POST"
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout):  # noqa: S310
+                pass
+        except (urllib.error.URLError, OSError, ValueError) as exc:
+            logger.debug("notification POST to %s failed: %s", url, exc)
+
+
+__all__ = ["Notifier"]

--- a/clearwing/asm/report.py
+++ b/clearwing/asm/report.py
@@ -1,0 +1,117 @@
+"""Per-scope aggregate attack-surface report.
+
+Renders the current inventory, the delta since a given time, and any findings
+(threat-intel-prioritized) into markdown / json under
+``results/asm/<scope>/``. Findings reuse the canonical shapes; the asset graph
+can additionally be visualized via
+:meth:`clearwing.reporting.report_generator.ReportGenerator.generate_attack_graph`.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+from clearwing.asm.assets import ASSET_TYPES, AssetStore
+
+
+def build_report(
+    store: AssetStore,
+    scope: str,
+    *,
+    since: float | None = None,
+    findings: list[dict] | None = None,
+) -> dict[str, Any]:
+    """Assemble the report data structure for *scope*."""
+    by_type: dict[str, list[str]] = {}
+    for asset_type in ASSET_TYPES:
+        values = [a.value for a in store.known_assets(scope, asset_type)]
+        if values:
+            by_type[asset_type] = values
+    delta = [
+        {"type": a.asset_type, "value": a.value, "source": a.source}
+        for a in (store.deltas_since(scope, since) if since is not None else [])
+    ]
+    return {
+        "scope": scope,
+        "generated_at": time.time(),
+        "stats": store.stats(scope),
+        "assets": by_type,
+        "new_since_last": delta,
+        "findings": findings or [],
+    }
+
+
+def render_json(report: dict[str, Any]) -> str:
+    return json.dumps(report, indent=2, sort_keys=True, default=str)
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines: list[str] = [f"# Attack surface — {report['scope']}", ""]
+    stats = report.get("stats", {})
+    total = sum(stats.values())
+    lines.append(f"**{total} assets** — " + ", ".join(f"{n} {t}" for t, n in sorted(stats.items())))
+    lines.append("")
+
+    delta = report.get("new_since_last", [])
+    if delta:
+        lines.append(f"## New since last run ({len(delta)})")
+        for item in delta[:200]:
+            lines.append(f"- `{item['value']}` ({item['type']}, via {item['source']})")
+        lines.append("")
+
+    findings = report.get("findings", [])
+    if findings:
+        lines.append(f"## Findings ({len(findings)}) — prioritized")
+        for f in findings[:100]:
+            flags = []
+            if f.get("known_exploited"):
+                flags.append("**KEV**")
+            if f.get("epss") is not None:
+                flags.append(f"EPSS {f['epss']:.2f}")
+            tag = (" — " + ", ".join(flags)) if flags else ""
+            ident = f.get("cve") or f.get("cwe") or f.get("finding_type", "?")
+            lines.append(
+                f"- [{f.get('severity', 'info')}] `{ident}` on "
+                f"{f.get('target', f.get('service', '?'))}{tag}"
+            )
+        lines.append("")
+
+    for asset_type, values in report.get("assets", {}).items():
+        lines.append(f"## {asset_type} ({len(values)})")
+        for value in values[:500]:
+            lines.append(f"- `{value}`")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def write_report(
+    store: AssetStore,
+    scope: str,
+    *,
+    out_dir: str | Path | None = None,
+    formats: tuple[str, ...] = ("markdown", "json"),
+    since: float | None = None,
+    findings: list[dict] | None = None,
+) -> dict[str, str]:
+    """Build and write the report; return {format: path}."""
+    from clearwing.core.config import default_results_dir
+
+    base = Path(out_dir) if out_dir is not None else Path(default_results_dir("asm")) / scope
+    base.mkdir(parents=True, exist_ok=True)
+    report = build_report(store, scope, since=since, findings=findings)
+    paths: dict[str, str] = {}
+    if "json" in formats:
+        p = base / "asm-report.json"
+        p.write_text(render_json(report), encoding="utf-8")
+        paths["json"] = str(p)
+    if "markdown" in formats:
+        p = base / "asm-report.md"
+        p.write_text(render_markdown(report), encoding="utf-8")
+        paths["markdown"] = str(p)
+    return paths
+
+
+__all__ = ["build_report", "render_json", "render_markdown", "write_report"]

--- a/clearwing/asm/scope.py
+++ b/clearwing/asm/scope.py
@@ -1,0 +1,91 @@
+"""The engagement scope — the key that ties a surface together across runs.
+
+A scope is just a named set of roots (domains / CIDRs / seed URLs) plus
+exclusions. Its ``name`` is the engagement key used everywhere else (the
+:class:`~clearwing.asm.assets.AssetStore` partition, the report directory, the
+knowledge-graph namespace) — the ASM analog of a source-hunt ``repo_url``.
+
+Scopes can be defined once in ``~/.clearwing/config.yaml`` under
+``asm.scopes.<name>`` and referenced by name, or synthesized on the fly from a
+single domain on the command line.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+_SCOPE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_DOMAIN_RE = re.compile(r"^(?=.{1,253}$)([A-Za-z0-9_-]{1,63}\.)+[A-Za-z]{2,}$")
+
+
+class ScopeError(ValueError):
+    """A scope definition is malformed or unsafe."""
+
+
+@dataclass
+class Scope:
+    """A named attack-surface engagement."""
+
+    name: str
+    domains: list[str] = field(default_factory=list)
+    cidrs: list[str] = field(default_factory=list)
+    seed_urls: list[str] = field(default_factory=list)
+    exclusions: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not _SCOPE_NAME_RE.fullmatch(self.name):
+            raise ScopeError(
+                f"Invalid scope name {self.name!r}; use letters, digits, '.', '_' or '-'"
+            )
+        self.domains = [d.strip().lower() for d in self.domains if d.strip()]
+        for domain in self.domains:
+            if not _DOMAIN_RE.fullmatch(domain):
+                raise ScopeError(f"Invalid domain in scope {self.name!r}: {domain!r}")
+
+    def in_scope(self, name: str) -> bool:
+        """Whether a discovered name belongs to this scope (and isn't excluded)."""
+        candidate = name.strip().lower().rstrip(".")
+        if any(candidate == ex or candidate.endswith("." + ex) for ex in self.exclusions):
+            return False
+        return any(
+            candidate == root or candidate.endswith("." + root) for root in self.domains
+        )
+
+    @classmethod
+    def from_domain(cls, domain: str, name: str | None = None) -> Scope:
+        """Build an ad-hoc single-domain scope (the `asm scan <domain>` path)."""
+        domain = domain.strip().lower().rstrip(".")
+        scope_name = name or domain.replace(".", "_")
+        return cls(name=scope_name, domains=[domain])
+
+    @classmethod
+    def from_config(cls, name: str, config_section: dict[str, Any]) -> Scope:
+        """Load a named scope from an ``asm.scopes`` mapping."""
+        scopes = (config_section or {}).get("scopes") or {}
+        raw = scopes.get(name)
+        if raw is None:
+            raise ScopeError(f"No scope named {name!r} configured under asm.scopes")
+        return cls(
+            name=name,
+            domains=list(raw.get("domains") or []),
+            cidrs=list(raw.get("cidrs") or []),
+            seed_urls=list(raw.get("seed_urls") or []),
+            exclusions=[e.strip().lower() for e in (raw.get("exclusions") or [])],
+        )
+
+    @classmethod
+    def resolve(cls, target: str, config_section: dict[str, Any] | None = None) -> Scope:
+        """Resolve a CLI target to a Scope: a configured name, else a bare domain."""
+        section = config_section or {}
+        if (section.get("scopes") or {}).get(target) is not None:
+            return cls.from_config(target, section)
+        if _DOMAIN_RE.fullmatch(target.strip().lower().rstrip(".")):
+            return cls.from_domain(target)
+        raise ScopeError(
+            f"{target!r} is neither a configured asm scope nor a valid domain"
+        )
+
+
+__all__ = ["Scope", "ScopeError"]

--- a/clearwing/asm/sweep.py
+++ b/clearwing/asm/sweep.py
@@ -1,0 +1,87 @@
+"""Mass parallel scanning across a discovered surface.
+
+Once discovery has populated the :class:`AssetStore`, a sweep fans the existing
+port/service/vuln scanners across every known host in a scope concurrently
+(bounded), aggregates the findings, and prioritizes them with threat intel.
+This is the "scan the whole surface, not one host" capability, reusing
+Clearwing's deep scanners rather than reimplementing detection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from clearwing.asm.assets import AssetStore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SweepResult:
+    scope: str
+    hosts_scanned: list[str] = field(default_factory=list)
+    findings: list[dict] = field(default_factory=list)
+
+
+async def _default_scan_async(target: str) -> list[dict]:
+    from clearwing.agent.tools.scan.scanner_tools import (
+        detect_services,
+        scan_ports,
+        scan_vulnerabilities,
+    )
+
+    ports = await scan_ports(target)
+    services = await detect_services(target, ports)
+    vulns = await scan_vulnerabilities(target, services)
+    for vuln in vulns:
+        vuln.setdefault("target", target)
+    return vulns
+
+
+async def sweep_scope_async(
+    store: AssetStore,
+    scope: str,
+    *,
+    max_parallel: int = 10,
+    threat_intel: bool = True,
+    scan_async: Callable[[str], Awaitable[list[dict]]] | None = None,
+) -> SweepResult:
+    """Scan every known host/ip in *scope* concurrently. Best-effort per host."""
+    scanner = scan_async or _default_scan_async
+    hosts = sorted(
+        {a.value for a in store.known_assets(scope, "ip")}
+        | {a.value for a in store.known_assets(scope, "host")}
+    )
+    semaphore = asyncio.Semaphore(max(1, max_parallel))
+
+    async def _one(host: str) -> list[dict]:
+        async with semaphore:
+            try:
+                return await scanner(host)
+            except Exception:
+                logger.debug("sweep scan of %s failed", host, exc_info=True)
+                return []
+
+    per_host = await asyncio.gather(*(_one(h) for h in hosts))
+    findings = [f for group in per_host for f in group]
+
+    if findings and threat_intel:
+        try:
+            from clearwing.asm.threatintel import ThreatIntel
+
+            findings = ThreatIntel().enrich(findings)
+        except Exception:
+            logger.debug("threat-intel enrichment failed", exc_info=True)
+
+    return SweepResult(scope=scope, hosts_scanned=hosts, findings=findings)
+
+
+def sweep_scope(store: AssetStore, scope: str, **kwargs) -> SweepResult:
+    """Synchronous wrapper around :func:`sweep_scope_async`."""
+    return asyncio.run(sweep_scope_async(store, scope, **kwargs))
+
+
+__all__ = ["SweepResult", "sweep_scope", "sweep_scope_async"]

--- a/clearwing/asm/threatintel.py
+++ b/clearwing/asm/threatintel.py
@@ -1,0 +1,142 @@
+"""Threat-intel enrichment for prioritization (CISA KEV + FIRST EPSS).
+
+Clearwing already finds CVEs via `scan_vulnerabilities`. This layer answers
+"which of these actually matter right now" from two free public feeds:
+
+- **CISA KEV** — the Known Exploited Vulnerabilities catalog (a CVE here is
+  being exploited in the wild).
+- **EPSS** — FIRST's Exploit Prediction Scoring System (0..1 probability of
+  exploitation in the next 30 days).
+
+Enriched findings sort KEV-first, then by EPSS, then by CVSS/severity — so the
+monitor, sweep, and reports lead with what's dangerous. The KEV catalog is
+cached under ``~/.clearwing/asm/`` with a TTL; `_http_get_json` is the single
+monkeypatchable seam.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+_EPSS_URL = "https://api.first.org/data/v1/epss?cve="
+_KEV_TTL = 24 * 3600
+_TIMEOUT = 20
+
+
+def _http_get_json(url: str, *, timeout: int = _TIMEOUT) -> object:
+    request = urllib.request.Request(url, headers={"User-Agent": "clearwing-asm/0.5"})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            return json.loads(response.read(16_000_000).decode("utf-8", "replace"))
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError) as exc:
+        logger.debug("threat-intel fetch failed for %s: %s", url, exc)
+        return None
+
+
+def _cache_path() -> Path:
+    from clearwing.core.config import clearwing_home
+
+    return clearwing_home() / "asm" / "kev-cache.json"
+
+
+class ThreatIntel:
+    """Lazily-loaded KEV set + EPSS lookups, with a small on-disk KEV cache."""
+
+    def __init__(self, cache_path: Path | None = None):
+        self._cache_path = cache_path or _cache_path()
+        self._kev: set[str] | None = None
+        self._epss: dict[str, float] = {}
+
+    def _load_kev(self) -> set[str]:
+        if self._kev is not None:
+            return self._kev
+        cached = self._read_cache()
+        if cached is not None:
+            self._kev = cached
+            return cached
+        data = _http_get_json(_KEV_URL)
+        kev: set[str] = set()
+        if isinstance(data, dict):
+            for vuln in data.get("vulnerabilities", []):
+                cve = str(vuln.get("cveID", "")).upper()
+                if cve:
+                    kev.add(cve)
+        self._kev = kev
+        if kev:
+            self._write_cache(kev)
+        return kev
+
+    def is_known_exploited(self, cve: str) -> bool:
+        return cve.upper() in self._load_kev()
+
+    def epss_score(self, cve: str) -> float | None:
+        cve = cve.upper()
+        if cve in self._epss:
+            return self._epss[cve]
+        data = _http_get_json(_EPSS_URL + cve)
+        score: float | None = None
+        if isinstance(data, dict):
+            for row in data.get("data", []):
+                if str(row.get("cve", "")).upper() == cve:
+                    try:
+                        score = float(row.get("epss"))
+                    except (TypeError, ValueError):
+                        score = None
+        if score is not None:
+            self._epss[cve] = score
+        return score
+
+    def enrich(self, findings: list[dict]) -> list[dict]:
+        """Annotate CVE findings with KEV/EPSS and return them priority-sorted."""
+        for finding in findings:
+            cve = str(finding.get("cve") or finding.get("cwe") or "")
+            if cve.upper().startswith("CVE-"):
+                finding["known_exploited"] = self.is_known_exploited(cve)
+                finding["epss"] = self.epss_score(cve)
+            else:
+                finding.setdefault("known_exploited", False)
+                finding.setdefault("epss", None)
+        return sorted(findings, key=_priority_key, reverse=True)
+
+    # -- cache ----------------------------------------------------------
+
+    def _read_cache(self) -> set[str] | None:
+        try:
+            raw = json.loads(self._cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(raw, dict) or time.time() - raw.get("fetched_at", 0) > _KEV_TTL:
+            return None
+        cves = raw.get("cves")
+        return set(cves) if isinstance(cves, list) else None
+
+    def _write_cache(self, kev: set[str]) -> None:
+        try:
+            self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+            self._cache_path.write_text(
+                json.dumps({"fetched_at": time.time(), "cves": sorted(kev)}),
+                encoding="utf-8",
+            )
+        except OSError:
+            logger.debug("Could not write KEV cache", exc_info=True)
+
+
+def _priority_key(finding: dict) -> tuple:
+    severity_rank = {"critical": 4, "high": 3, "medium": 2, "low": 1, "info": 0}
+    return (
+        1 if finding.get("known_exploited") else 0,
+        finding.get("epss") or 0.0,
+        float(finding.get("cvss") or 0.0),
+        severity_rank.get(str(finding.get("severity", "info")).lower(), 0),
+    )
+
+
+__all__ = ["ThreatIntel"]

--- a/clearwing/core/config.py
+++ b/clearwing/core/config.py
@@ -135,6 +135,31 @@ class Config:
             "include_mitigations": True,
         },
         "database": {"path": "clearwing.db", "auto_backup": True},
+        "asm": {
+            # Attack-Surface Management. Named scopes are defined here and
+            # referenced by name (e.g. `clearwing asm scan acme`):
+            #   scopes:
+            #     acme:
+            #       domains: [acme.com, acme.io]
+            #       exclusions: [legacy.acme.com]
+            "scopes": {},
+            # Passive discovery is always available. These enrich it when set;
+            # keys conventionally come from env vars (see below).
+            "shodan_api_key_env": "SHODAN_API_KEY",
+            "censys_api_id_env": "CENSYS_API_ID",
+            "censys_api_secret_env": "CENSYS_API_SECRET",
+            "github_api_key_env": "GITHUB_API_KEY",
+            # Continuous monitor.
+            "poll_interval_seconds": 86400,  # daily
+            "scan_new_assets": True,  # run port/service/vuln scans on new hosts
+            # Outbound notifications (only active when a URL is set). The env
+            # var is checked first, then this literal.
+            "slack_webhook_env": "CLEARWING_SLACK_WEBHOOK",
+            "slack_webhook_url": "",
+            "webhook_url": "",
+            # Threat-intel prioritization (CISA KEV + EPSS, both public feeds).
+            "threat_intel": True,
+        },
     }
 
     #: Default path searched when no explicit config_file is passed.

--- a/clearwing/core/event_payloads.py
+++ b/clearwing/core/event_payloads.py
@@ -59,6 +59,15 @@ class DisclosureUpdatePayload:
 
 
 @dataclass(slots=True, frozen=True)
+class AssetDiscoveredPayload:
+    scope: str
+    asset_type: str
+    value: str
+    source: str
+    parent: str | None
+
+
+@dataclass(slots=True, frozen=True)
 class BenchmarkProgressPayload:
     mode: str
     targets_completed: int

--- a/clearwing/core/events.py
+++ b/clearwing/core/events.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from clearwing.core.event_payloads import (
+        AssetDiscoveredPayload,
         BenchmarkProgressPayload,
         CampaignProgressPayload,
         DisclosureUpdatePayload,
@@ -56,6 +57,7 @@ class EventType(enum.Enum):
     BENCHMARK_PROGRESS = "benchmark_progress"
     EVAL_PROGRESS = "eval_progress"
     FINDING_RECORDED = "finding_recorded"
+    ASSET_DISCOVERED = "asset_discovered"
     HUNTER_STATUS = "hunter_status"
     HUNTER_REASONING = "hunter_reasoning"
     TRACE_STEP = "trace_step"
@@ -169,3 +171,6 @@ class EventBus:
 
     def emit_eval_progress(self, payload: EvalProgressPayload) -> None:
         self.emit(EventType.EVAL_PROGRESS, payload)
+
+    def emit_asset_discovered(self, payload: AssetDiscoveredPayload) -> None:
+        self.emit(EventType.ASSET_DISCOVERED, payload)

--- a/clearwing/data/knowledge/graph.py
+++ b/clearwing/data/knowledge/graph.py
@@ -76,6 +76,11 @@ class KnowledgeGraph:
         "key_material",
         "certificate",
         "kdf_config",
+        # v0.5: attack-surface entities
+        "domain",
+        "subdomain",
+        "url",
+        "technology",
     )
     RELATIONSHIP_TYPES = (
         "HAS_PORT",
@@ -97,6 +102,11 @@ class KnowledgeGraph:
         "AUTHENTICATES_WITH",
         "PRESENTS_CERT",
         "VULNERABLE_TO",
+        # v0.5: attack-surface relationships
+        "HAS_SUBDOMAIN",
+        "RESOLVES_TO",
+        "HAS_URL",
+        "RUNS_TECH",
     )
 
     def __init__(
@@ -361,6 +371,33 @@ class KnowledgeGraph:
     def add_vulnerability(self, service_id: str, cve: str, cvss: float = 0.0, **kwargs) -> Entity:
         entity = self.add_entity("cve", cve, cvss=cvss, **kwargs)
         self.add_relationship(service_id, cve, "AFFECTED_BY")
+        return entity
+
+    # -- attack-surface (v0.5) -----------------------------------------
+
+    def add_domain(self, domain: str, **kwargs) -> Entity:
+        return self.add_entity("domain", domain, **kwargs)
+
+    def add_subdomain(self, domain: str, subdomain: str, **kwargs) -> Entity:
+        entity = self.add_entity("subdomain", subdomain, **kwargs)
+        self.add_relationship(domain, subdomain, "HAS_SUBDOMAIN")
+        return entity
+
+    def add_host_resolution(self, name: str, ip: str, **kwargs) -> Entity:
+        """Record that a name resolves to an IP (added as a `target`)."""
+        entity = self.add_entity("target", ip, **kwargs)
+        self.add_relationship(name, ip, "RESOLVES_TO")
+        return entity
+
+    def add_url(self, host: str, url: str, **kwargs) -> Entity:
+        entity = self.add_entity("url", url, **kwargs)
+        self.add_relationship(host, url, "HAS_URL")
+        return entity
+
+    def add_technology(self, host: str, technology: str, **kwargs) -> Entity:
+        tech_id = f"tech:{technology}"
+        entity = self.add_entity("technology", tech_id, name=technology, **kwargs)
+        self.add_relationship(host, tech_id, "RUNS_TECH")
         return entity
 
     def add_exploit_result(

--- a/clearwing/ui/commands/__init__.py
+++ b/clearwing/ui/commands/__init__.py
@@ -1,6 +1,7 @@
 """CLI subcommand modules."""
 
 from . import (
+    asm,
     bench,
     campaign,
     ci,
@@ -29,6 +30,7 @@ ALL_COMMANDS = [
     setup,
     doctor,
     scan,
+    asm,
     report,
     history,
     config,

--- a/clearwing/ui/commands/asm.py
+++ b/clearwing/ui/commands/asm.py
@@ -1,0 +1,280 @@
+"""`clearwing asm` — attack-surface management.
+
+Sub-actions:
+  asm scan    <scope|domain>   discover the surface, record the delta, report
+  asm monitor <scope|domain>   run discovery continuously (or once with --once)
+  asm sweep   <scope>          port/service/vuln scan every known host
+  asm report  <scope>          (re)render the aggregate report from the store
+  asm list    [scope]          list scopes, or the assets in one
+
+Discovery is passive-first and host-safe; it never exploits and never triggers
+approval-gated actions automatically.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from clearwing.asm.assets import AssetStore
+from clearwing.asm.scope import Scope, ScopeError
+
+
+def add_parser(subparsers):
+    parser = subparsers.add_parser("asm", help="Attack-surface management (discovery + monitoring)")
+    sub = parser.add_subparsers(dest="asm_action")
+
+    p_scan = sub.add_parser("scan", help="Discover the attack surface for a scope or domain")
+    p_scan.add_argument("target", help="A configured asm scope name or a root domain")
+    p_scan.add_argument("--mode", default="recon", help="Workflow mode (recon, stealth, web-assessment, external-sweep)")
+    p_scan.add_argument("--no-scan", action="store_true", help="Do not port/service/vuln-scan new hosts")
+    p_scan.add_argument("--screenshot", action="store_true", help="Screenshot live web hosts into a gallery")
+    p_scan.add_argument("--notify", action="store_true", help="Send configured notifications for new assets")
+    p_scan.add_argument("-o", "--output-dir", help="Report output directory")
+
+    p_mon = sub.add_parser("monitor", help="Continuously monitor a scope for new assets")
+    p_mon.add_argument("target", help="A configured asm scope name or a root domain")
+    p_mon.add_argument("--mode", default="recon", help="Workflow mode")
+    p_mon.add_argument("--interval", type=float, help="Seconds between cycles (default: config)")
+    p_mon.add_argument("--once", action="store_true", help="Run a single cycle and exit")
+    p_mon.add_argument("--no-scan", action="store_true", help="Do not scan new hosts")
+
+    p_sweep = sub.add_parser("sweep", help="Scan every known host in a scope")
+    p_sweep.add_argument("target", help="A configured asm scope name or a root domain")
+    p_sweep.add_argument("--max-parallel", type=int, default=10, help="Concurrent host scans")
+    p_sweep.add_argument("-o", "--output-dir", help="Report output directory")
+
+    p_report = sub.add_parser("report", help="Render the aggregate report for a scope")
+    p_report.add_argument("target", help="A configured asm scope name or a root domain")
+    p_report.add_argument("-o", "--output-dir", help="Report output directory")
+
+    p_list = sub.add_parser("list", help="List known scopes, or assets in one scope")
+    p_list.add_argument("target", nargs="?", help="Scope to list assets for (omit to list scopes)")
+
+    parser.set_defaults(_command_parser=parser)
+    return parser
+
+
+def handle(cli, args):
+    action = getattr(args, "asm_action", None)
+    if action is None:
+        args._command_parser.print_help()
+        return
+    asm_cfg = cli.config.get("asm") or {}
+    try:
+        if action == "scan":
+            _handle_scan(cli, args, asm_cfg)
+        elif action == "monitor":
+            _handle_monitor(cli, args, asm_cfg)
+        elif action == "sweep":
+            _handle_sweep(cli, args, asm_cfg)
+        elif action == "report":
+            _handle_report(cli, args, asm_cfg)
+        elif action == "list":
+            _handle_list(cli, args)
+    except ScopeError as exc:
+        cli.console.print(f"[red]Scope error:[/red] {exc}")
+        sys.exit(2)
+
+
+# -- scan --------------------------------------------------------------------
+
+
+def _handle_scan(cli, args, asm_cfg: dict[str, Any]) -> None:
+    from clearwing.asm import discovery
+    from clearwing.asm.modes import get_mode
+    from clearwing.core.event_payloads import AssetDiscoveredPayload
+    from clearwing.core.events import EventBus
+
+    scope = Scope.resolve(args.target, asm_cfg)
+    mode = get_mode(args.mode)
+    cli.console.print(f"[bold blue]ASM scan[/bold blue] scope=[cyan]{scope.name}[/cyan] mode=[cyan]{mode.name}[/cyan]")
+
+    notifier = _maybe_notifier(cli, args, asm_cfg)
+    store = AssetStore()
+    try:
+        result = discovery.run_discovery(scope, mode.discovery)
+        new_assets = store.record_observations(scope.name, result.assets)
+
+        kg = _load_kg()
+        if kg is not None:
+            discovery.project_to_graph(kg, new_assets)
+            _save_kg(kg)
+
+        bus = EventBus()
+        for asset in new_assets:
+            bus.emit_asset_discovered(
+                AssetDiscoveredPayload(scope.name, asset.asset_type, asset.value, asset.source, asset.parent_id)
+            )
+
+        cli.console.print(f"[green]+[/green] {len(new_assets)} new assets; {sum(store.stats(scope.name).values())} total")
+        for atype, n in sorted(store.stats(scope.name).items()):
+            cli.console.print(f"    {atype}: {n}")
+
+        findings: list[dict] = []
+        if (mode.scan_new_assets or mode.sweep) and not args.no_scan:
+            findings = _sweep(cli, store, scope.name, asm_cfg)
+        if mode.screenshot or args.screenshot:
+            _screenshot(cli, store, scope.name)
+
+        paths = _write_report(store, scope.name, args, findings)
+        for fmt, path in paths.items():
+            cli.console.print(f"[green]Report ({fmt}):[/green] {path}")
+    finally:
+        store.close()
+        if notifier is not None:
+            notifier.unsubscribe()
+
+
+# -- monitor -----------------------------------------------------------------
+
+
+def _handle_monitor(cli, args, asm_cfg: dict[str, Any]) -> None:
+    from clearwing.asm.modes import get_mode
+    from clearwing.asm.monitor import AsmMonitor, AsmMonitorConfig
+
+    scope = Scope.resolve(args.target, asm_cfg)
+    mode = get_mode(args.mode)
+    interval = args.interval if args.interval is not None else float(asm_cfg.get("poll_interval_seconds", 86400))
+    cli.console.print(
+        f"[bold blue]ASM monitor[/bold blue] scope=[cyan]{scope.name}[/cyan] "
+        f"interval={interval:.0f}s {'(single cycle)' if args.once else '(Ctrl-C to stop)'}"
+    )
+
+    notifier = _maybe_notifier(cli, args, asm_cfg, force=True)
+    kg = _load_kg()
+    config = AsmMonitorConfig(
+        scope=scope,
+        poll_interval_seconds=interval,
+        max_iterations=1 if args.once else 0,
+        scan_new_assets=not args.no_scan and asm_cfg.get("scan_new_assets", True),
+        threat_intel=asm_cfg.get("threat_intel", True),
+        discovery_options=mode.discovery,
+        knowledge_graph=kg,
+        on_cycle=lambda new: cli.console.print(f"[green]cycle:[/green] {len(new)} new assets"),
+    )
+    monitor = AsmMonitor(config)
+    try:
+        monitor.run()
+    except KeyboardInterrupt:
+        cli.console.print("\n[yellow]Monitor stopped.[/yellow]")
+        monitor.cancel()
+    finally:
+        if kg is not None:
+            _save_kg(kg)
+        if notifier is not None:
+            notifier.unsubscribe()
+
+
+# -- sweep / report / list ---------------------------------------------------
+
+
+def _handle_sweep(cli, args, asm_cfg: dict[str, Any]) -> None:
+    scope = Scope.resolve(args.target, asm_cfg)
+    store = AssetStore()
+    try:
+        findings = _sweep(cli, store, scope.name, asm_cfg, max_parallel=args.max_parallel)
+        paths = _write_report(store, scope.name, args, findings)
+        for fmt, path in paths.items():
+            cli.console.print(f"[green]Report ({fmt}):[/green] {path}")
+    finally:
+        store.close()
+
+
+def _handle_report(cli, args, asm_cfg: dict[str, Any]) -> None:
+    scope = Scope.resolve(args.target, asm_cfg)
+    store = AssetStore()
+    try:
+        paths = _write_report(store, scope.name, args, [])
+        for fmt, path in paths.items():
+            cli.console.print(f"[green]Report ({fmt}):[/green] {path}")
+    finally:
+        store.close()
+
+
+def _handle_list(cli, args) -> None:
+    store = AssetStore()
+    try:
+        if not args.target:
+            scopes = store.scopes()
+            if not scopes:
+                cli.console.print("[yellow]No scopes yet. Run `clearwing asm scan <domain>`.[/yellow]")
+            for name in scopes:
+                total = sum(store.stats(name).values())
+                cli.console.print(f"  [cyan]{name}[/cyan] — {total} assets")
+        else:
+            for atype, n in sorted(store.stats(args.target).items()):
+                cli.console.print(f"[bold]{atype}[/bold] ({n})")
+                for asset in store.known_assets(args.target, atype):
+                    cli.console.print(f"    {asset.value}")
+    finally:
+        store.close()
+
+
+# -- helpers -----------------------------------------------------------------
+
+
+def _sweep(cli, store, scope_name, asm_cfg, max_parallel: int = 10) -> list[dict]:
+    from clearwing.asm.sweep import sweep_scope
+
+    cli.console.print("[cyan]Sweeping known hosts...[/cyan]")
+    try:
+        result = sweep_scope(
+            store, scope_name, max_parallel=max_parallel, threat_intel=asm_cfg.get("threat_intel", True)
+        )
+    except Exception as exc:  # scanning is best-effort
+        cli.console.print(f"[yellow]Sweep skipped:[/yellow] {exc}")
+        return []
+    cli.console.print(f"[green]+[/green] scanned {len(result.hosts_scanned)} hosts, {len(result.findings)} findings")
+    return result.findings
+
+
+def _screenshot(cli, store, scope_name) -> None:
+    try:
+        from clearwing.agent.tools.recon.discovery_tools import screenshot_surface
+    except ImportError:
+        return
+    urls = [a.value for a in store.known_assets(scope_name, "host")]
+    if not urls:
+        return
+    result = screenshot_surface.func(urls)
+    cli.console.print(f"[green]Gallery:[/green] {result.get('gallery')}")
+
+
+def _write_report(store, scope_name, args, findings) -> dict[str, str]:
+    from clearwing.asm.report import write_report
+
+    return write_report(
+        store, scope_name, out_dir=getattr(args, "output_dir", None), findings=findings, since=0.0
+    )
+
+
+def _maybe_notifier(cli, args, asm_cfg, force: bool = False):
+    if not (force or getattr(args, "notify", False)):
+        return None
+    from clearwing.asm.notify import Notifier
+
+    notifier = Notifier.from_config(asm_cfg)
+    if notifier.enabled:
+        notifier.subscribe()
+        return notifier
+    if getattr(args, "notify", False):
+        cli.console.print("[yellow]--notify set but no webhook configured (asm.slack_webhook_url / env).[/yellow]")
+    return None
+
+
+def _load_kg():
+    try:
+        from clearwing.core.config import clearwing_home
+        from clearwing.data.knowledge import KnowledgeGraph
+
+        return KnowledgeGraph(persist_path=str(clearwing_home() / "knowledge_graph.json"))
+    except Exception:
+        return None
+
+
+def _save_kg(kg) -> None:
+    try:
+        kg.save()
+    except Exception:
+        pass

--- a/clearwing/ui/web/app.py
+++ b/clearwing/ui/web/app.py
@@ -335,6 +335,31 @@ def create_app():
         finally:
             db.close()
 
+    @app.get("/api/asm/scopes")
+    async def asm_scopes():
+        """List ASM scopes with an asset count each."""
+        from clearwing.asm.assets import AssetStore
+
+        store = AssetStore()
+        try:
+            return [
+                {"scope": name, "assets": sum(store.stats(name).values()), "types": store.stats(name)}
+                for name in store.scopes()
+            ]
+        finally:
+            store.close()
+
+    @app.get("/api/asm/scopes/{scope}/assets")
+    async def asm_assets(scope: str, asset_type: str | None = None):
+        """List the assets in a scope (optionally filtered by type)."""
+        from clearwing.asm.assets import AssetStore
+
+        store = AssetStore()
+        try:
+            return [a.to_dict() for a in store.known_assets(scope, asset_type)]
+        finally:
+            store.close()
+
     @app.get("/api/operate/{session_id}", dependencies=[Depends(require_api_key)])
     async def get_operator_status(session_id: str):
         """Get the status of an operator session."""
@@ -408,6 +433,7 @@ def create_app():
                 EventType.DISCLOSURE_UPDATE: "disclosure_update",
                 EventType.BENCHMARK_PROGRESS: "benchmark_progress",
                 EventType.EVAL_PROGRESS: "eval_progress",
+                EventType.ASSET_DISCOVERED: "asset_discovered",
             }
             for et, name in event_map.items():
                 h = on_event(name)

--- a/docs/asm.md
+++ b/docs/asm.md
@@ -1,0 +1,96 @@
+# Attack Surface Management
+
+Clearwing is deep on a target you already have. **ASM** adds the front half of an
+engagement: discovering what's out there, tracking what changes, and feeding new
+assets into Clearwing's existing scanning and verification.
+
+It is passive-first and host-safe — discovery queries public archives (crt.sh,
+the Wayback Machine, CISA KEV, EPSS) the same way the CVE/NVD lookups already do,
+plus light DNS resolution and HTTP liveness probing. **ASM never exploits and
+never triggers approval-gated actions automatically** — it discovers and scans,
+then hands findings to the normal pipeline.
+
+## Quick start
+
+```bash
+# One-shot discovery of a domain's surface (passive recon), writes a report
+clearwing asm scan example.com
+
+# Discover + probe live web hosts + a screenshot gallery for triage
+clearwing asm scan example.com --mode web-assessment --screenshot
+
+# Full discovery, then port/service/vuln-scan every host (threat-intel ranked)
+clearwing asm scan example.com --mode external-sweep
+
+# List what you know, and drill into a scope
+clearwing asm list
+clearwing asm list example_com
+```
+
+Everything is keyed by a **scope** — a named engagement. A bare domain becomes an
+ad-hoc scope (`example.com` → `example_com`); named scopes live in config:
+
+```yaml
+# ~/.clearwing/config.yaml
+asm:
+  scopes:
+    acme:
+      domains: [acme.com, acme.io]
+      exclusions: [legacy.acme.com]
+```
+
+Then `clearwing asm scan acme` operates on the whole engagement.
+
+## Continuous monitoring
+
+```bash
+clearwing asm monitor acme                 # daemon: re-discover on an interval
+clearwing asm monitor acme --once          # a single cycle (for cron / the scheduler)
+clearwing asm monitor acme --interval 3600 # hourly
+```
+
+Each cycle re-runs discovery, records only the **new** assets (delta detection
+against the SQLite asset store), emits an `ASSET_DISCOVERED` event for each, and —
+by default — port/service/vuln-scans new hosts. There is no built-in scheduler;
+run the daemon, or drive `--once` from cron or `clearwing schedule`.
+
+## Notifications
+
+Set a Slack incoming-webhook (or a generic webhook) and ASM posts on new assets
+and new findings:
+
+```yaml
+asm:
+  slack_webhook_url: "https://hooks.slack.com/services/..."   # or env CLEARWING_SLACK_WEBHOOK
+```
+
+`asm monitor` notifies automatically when a webhook is configured; add `--notify`
+to `asm scan`.
+
+## Threat-intel prioritization
+
+Findings are enriched with **CISA KEV** (exploited in the wild) and **EPSS**
+(exploitation probability) and sorted KEV-first, then by EPSS, then CVSS/severity
+— so reports and sweeps lead with what's dangerous. Both feeds are public; the
+KEV catalog is cached under `~/.clearwing/asm/`.
+
+## Where things live
+
+- Asset inventory: `~/.clearwing/asm/assets.db` (scope-keyed SQLite; `first_seen`
+  / `last_seen` give the temporal delta).
+- Reports: `results/asm/<scope>/asm-report.{md,json}`.
+- Discovered assets are also projected into the knowledge graph, so
+  `clearwing graph` and `query_knowledge_graph` see the surface (domain →
+  subdomain → host → port → service).
+
+## Agent tools
+
+The discovery primitives are also agent tools, so an interactive/operator agent
+can drive them directly: `discover_subdomains`, `lookup_cert_transparency`,
+`discover_wayback_urls`, `resolve_hosts`, `probe_liveness`, `screenshot_surface`.
+
+## Optional enrichment sources
+
+Passive discovery works out of the box. These add coverage when their API keys
+are in the environment: `GITHUB_API_KEY` (GitHub code-search subdomains),
+`SHODAN_API_KEY`, `CENSYS_API_ID` / `CENSYS_API_SECRET`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,26 @@ clearwing scan <target>
 Writes to `~/.clearwing/clearwing.db` automatically. Retrieve later
 with `clearwing report` or `clearwing history`.
 
+## `asm` — attack-surface management
+
+Discover an external surface (subdomains, hosts, URLs, technologies), track what
+changes over time, and feed new hosts into the scanners. Passive-first and
+host-safe; never exploits automatically. See [Attack Surface Management](asm.md).
+
+```bash
+clearwing asm scan <scope|domain>     # discover the surface + report
+  [--mode recon|stealth|web-assessment|external-sweep]
+  [--no-scan] [--screenshot] [--notify] [-o DIR]
+clearwing asm monitor <scope> [--once] [--interval S] [--no-scan]  # continuous
+clearwing asm sweep <scope> [--max-parallel N]   # scan every known host
+clearwing asm report <scope> [-o DIR]            # re-render the report
+clearwing asm list [scope]                        # list scopes, or assets in one
+```
+
+A bare domain becomes an ad-hoc scope; named scopes are defined under `asm.scopes`
+in `~/.clearwing/config.yaml`. New assets/findings notify a configured Slack or
+generic webhook, and findings are prioritized with CISA KEV + EPSS.
+
 ## `sourcehunt` — source-code vulnerability hunting
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
   - VVAH pattern review: vvah-integration.md
   - Architecture: architecture.md
   - CLI reference: cli.md
+  - Attack Surface Management: asm.md
   - API reference: api.md
   - Web API (WebSocket): web-api.md
 

--- a/tests/test_asm_assets.py
+++ b/tests/test_asm_assets.py
@@ -1,0 +1,135 @@
+"""Tests for the ASM asset store and scope model."""
+
+from __future__ import annotations
+
+import pytest
+
+from clearwing.asm.assets import ASSET_TYPES, Asset, AssetStore
+from clearwing.asm.scope import Scope, ScopeError
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = AssetStore(tmp_path / "assets.db")
+    yield s
+    s.close()
+
+
+def _sub(scope, value, **kw):
+    return Asset(scope=scope, asset_type="subdomain", value=value, **kw)
+
+
+def test_record_returns_only_new_assets(store):
+    first = store.record_observations("acme", [_sub("acme", "a.acme.com"), _sub("acme", "b.acme.com")])
+    assert sorted(a.value for a in first) == ["a.acme.com", "b.acme.com"]
+
+    # re-observing a known asset plus one new one returns only the new one
+    delta = store.record_observations("acme", [_sub("acme", "a.acme.com"), _sub("acme", "c.acme.com")])
+    assert [a.value for a in delta] == ["c.acme.com"]
+
+
+def test_delta_is_empty_on_a_stable_surface(store):
+    assets = [_sub("acme", "a.acme.com"), _sub("acme", "b.acme.com")]
+    store.record_observations("acme", assets)
+    assert store.record_observations("acme", assets) == []
+
+
+def test_scopes_are_isolated(store):
+    store.record_observations("acme", [_sub("acme", "a.acme.com")])
+    # the same value under a different scope is a different (new) asset
+    delta = store.record_observations("other", [_sub("other", "a.acme.com")])
+    assert [a.value for a in delta] == ["a.acme.com"]
+    assert store.scopes() == ["acme", "other"]
+
+
+def test_first_seen_is_stable_last_seen_advances(store):
+    (a,) = store.record_observations("acme", [_sub("acme", "a.acme.com")])
+    first_seen = a.first_seen
+    # a second observation must not move first_seen but must refresh last_seen
+    store.record_observations("acme", [_sub("acme", "a.acme.com")])
+    known = store.known_assets("acme", "subdomain")[0]
+    assert known.first_seen == first_seen
+    assert known.last_seen >= first_seen
+
+
+def test_is_new(store):
+    asset = _sub("acme", "a.acme.com")
+    assert store.is_new("acme", asset) is True
+    store.record_observations("acme", [asset])
+    assert store.is_new("acme", asset) is False
+
+
+def test_stats_and_known_assets_filter(store):
+    store.record_observations(
+        "acme",
+        [
+            _sub("acme", "a.acme.com"),
+            Asset("acme", "ip", "1.2.3.4"),
+            Asset("acme", "host", "https://a.acme.com"),
+        ],
+    )
+    assert store.stats("acme") == {"subdomain": 1, "ip": 1, "host": 1}
+    assert [a.value for a in store.known_assets("acme", "ip")] == ["1.2.3.4"]
+
+
+def test_unknown_asset_type_is_skipped(store):
+    delta = store.record_observations("acme", [Asset("acme", "bogus", "x")])
+    assert delta == []
+    assert store.stats("acme") == {}
+
+
+def test_deterministic_id_and_value_redaction(tmp_path):
+    a = Asset("acme", "subdomain", "a.acme.com")
+    b = Asset("acme", "subdomain", "a.acme.com")
+    assert a.id == b.id and a.id.startswith("asset-")
+    assert Asset("acme", "ip", "1.1.1.1").id != a.id
+
+
+def test_deltas_since(store):
+    import time
+
+    store.record_observations("acme", [_sub("acme", "old.acme.com")])
+    boundary = time.time()
+    time.sleep(0.01)
+    store.record_observations("acme", [_sub("acme", "new.acme.com")])
+    recent = store.deltas_since("acme", boundary)
+    assert [a.value for a in recent] == ["new.acme.com"]
+
+
+def test_asset_types_constant_covers_the_hierarchy():
+    assert {"domain", "subdomain", "host", "ip", "port", "service", "url", "technology"} == set(ASSET_TYPES)
+
+
+# --- Scope ------------------------------------------------------------------
+
+
+def test_scope_from_domain_and_in_scope():
+    s = Scope.from_domain("Example.com")
+    assert s.name == "example_com"
+    assert s.in_scope("api.example.com") and s.in_scope("example.com")
+    assert not s.in_scope("example.com.evil.com")
+    assert not s.in_scope("notexample.com")
+
+
+def test_scope_exclusions():
+    s = Scope(name="acme", domains=["acme.com"], exclusions=["legacy.acme.com"])
+    assert s.in_scope("api.acme.com")
+    assert not s.in_scope("legacy.acme.com")
+    assert not s.in_scope("db.legacy.acme.com")
+
+
+def test_scope_rejects_bad_name_and_domain():
+    with pytest.raises(ScopeError):
+        Scope(name="bad name")
+    with pytest.raises(ScopeError):
+        Scope(name="ok", domains=["not a domain"])
+
+
+def test_scope_resolve_prefers_configured_scope():
+    section = {"scopes": {"acme": {"domains": ["acme.com", "acme.io"]}}}
+    resolved = Scope.resolve("acme", section)
+    assert resolved.name == "acme" and "acme.io" in resolved.domains
+    # a bare domain with no matching scope becomes an ad-hoc scope
+    assert Scope.resolve("example.com", section).domains == ["example.com"]
+    with pytest.raises(ScopeError):
+        Scope.resolve("not-a-scope-or-domain", section)

--- a/tests/test_asm_cli.py
+++ b/tests/test_asm_cli.py
@@ -1,0 +1,87 @@
+"""Tests for the `clearwing asm` CLI command (parse + dispatch)."""
+
+from __future__ import annotations
+
+import argparse
+import types
+
+import pytest
+
+import clearwing.asm.assets as assets_mod
+import clearwing.asm.discovery as discovery_mod
+import clearwing.ui.commands.asm as asm_cmd
+from clearwing.asm.assets import Asset
+from clearwing.ui.commands import ALL_COMMANDS
+
+
+@pytest.fixture
+def parser():
+    top = argparse.ArgumentParser()
+    sub = top.add_subparsers(dest="command")
+    asm_cmd.add_parser(sub)
+    return top
+
+
+@pytest.fixture
+def cli(capsys):
+    class _Console:
+        def print(self, *a, **k):
+            print(*a)
+
+    class _Config:
+        def get(self, *keys):
+            return {} if keys == ("asm",) else None
+
+    return types.SimpleNamespace(console=_Console(), config=_Config())
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    # point every on-disk store at the tmp dir and skip the knowledge graph
+    monkeypatch.setattr(assets_mod, "_default_db_path", lambda: tmp_path / "assets.db")
+    monkeypatch.setattr("clearwing.core.config.default_results_dir", lambda s: str(tmp_path / "results" / s))
+    monkeypatch.setattr(asm_cmd, "_load_kg", lambda: None)
+    monkeypatch.setattr(
+        discovery_mod,
+        "run_discovery",
+        lambda scope, opts: types.SimpleNamespace(
+            assets=[Asset(scope.name, "domain", "example.com"), Asset(scope.name, "subdomain", "api.example.com")]
+        ),
+    )
+
+
+def test_asm_registered_as_command():
+    assert asm_cmd in ALL_COMMANDS
+
+
+def test_scan_records_and_reports(parser, cli, capsys):
+    args = parser.parse_args(["asm", "scan", "example.com", "--mode", "recon", "--no-scan"])
+    asm_cmd.handle(cli, args)
+    out = capsys.readouterr().out
+    assert "2 new assets" in out
+    assert "Report (json)" in out and "Report (markdown)" in out
+
+    # a second scan finds nothing new (delta)
+    asm_cmd.handle(cli, parser.parse_args(["asm", "scan", "example.com", "--no-scan"]))
+    assert "0 new assets" in capsys.readouterr().out
+
+
+def test_list_scopes_then_assets(parser, cli, capsys):
+    asm_cmd.handle(cli, parser.parse_args(["asm", "scan", "example.com", "--no-scan"]))
+    capsys.readouterr()
+    asm_cmd.handle(cli, parser.parse_args(["asm", "list"]))
+    assert "example_com" in capsys.readouterr().out
+    asm_cmd.handle(cli, parser.parse_args(["asm", "list", "example_com"]))
+    out = capsys.readouterr().out
+    assert "subdomain" in out and "api.example.com" in out
+
+
+def test_bad_target_exits(parser, cli):
+    args = parser.parse_args(["asm", "scan", "not a domain"])
+    with pytest.raises(SystemExit):
+        asm_cmd.handle(cli, args)
+
+
+def test_no_action_prints_help(parser, cli, capsys):
+    args = parser.parse_args(["asm"])
+    asm_cmd.handle(cli, args)  # should print help, not crash

--- a/tests/test_asm_discovery.py
+++ b/tests/test_asm_discovery.py
@@ -1,0 +1,108 @@
+"""Tests for external discovery tools and the ASM discovery orchestrator."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+import clearwing.agent.tools.recon.discovery_tools as dt
+from clearwing.asm import discovery
+from clearwing.asm.scope import Scope
+from clearwing.data.knowledge import KnowledgeGraph
+
+
+@pytest.fixture(autouse=True)
+def _mock_http(monkeypatch):
+    """Mock every outbound source so tests never touch the network."""
+
+    def fake_json(url, timeout=20):
+        if "crt.sh" in url:
+            return [
+                {"name_value": "api.example.com\n*.example.com"},
+                {"name_value": "www.example.com"},
+                {"name_value": "evil.com"},  # out of scope — must be dropped
+            ]
+        if "web.archive.org" in url:
+            return [["original"], ["https://example.com/login"], ["https://example.com/login"]]
+        return None
+
+    monkeypatch.setattr(dt, "_http_get_json", fake_json)
+    monkeypatch.setattr(dt, "github_subdomains", lambda d, env_var="GITHUB_API_KEY": [])
+    monkeypatch.setattr(dt, "resolve_name", lambda n: ["93.184.216.34"] if "example.com" in n else [])
+    monkeypatch.setattr(
+        dt,
+        "probe_url",
+        lambda u, timeout=10: {
+            "url": u,
+            "live": u.startswith("https"),
+            "status": 200,
+            "server": "nginx",
+            "technologies": ["nginx", "WordPress"],
+        },
+    )
+
+
+def test_crtsh_parses_and_strips_wildcards():
+    subs = dt.crtsh_subdomains("example.com")
+    assert "api.example.com" in subs and "example.com" in subs
+    assert "*.example.com" not in subs
+    assert "evil.com" not in subs  # not a subdomain of example.com
+
+
+def test_wayback_dedupes_and_skips_header():
+    assert dt.wayback_urls("example.com") == ["https://example.com/login"]
+
+
+def test_fingerprint_from_headers_and_body():
+    techs = dt._fingerprint({"x-powered-by": "PHP/8.1", "server": "nginx/1.18"}, "<div>wp-content</div>")
+    assert set(techs) == {"PHP", "nginx", "WordPress"}
+
+
+def test_discover_subdomains_tool_shape():
+    out = dt.discover_subdomains.func("example.com")
+    assert out["count"] == len(out["subdomains"]) and "crt.sh" in out["sources"]
+
+
+def test_run_discovery_builds_the_hierarchy_and_respects_scope():
+    scope = Scope.from_domain("example.com", name="acme")
+    result = discovery.run_discovery(scope)
+    counts = Counter(a.asset_type for a in result.assets)
+    assert counts["domain"] == 1
+    assert {a.value for a in result.assets if a.asset_type == "subdomain"} == {
+        "api.example.com",
+        "www.example.com",
+    }
+    assert "evil.com" not in {a.value for a in result.assets}
+    assert counts["ip"] >= 1 and counts["host"] >= 1
+    assert "WordPress" in {a.value for a in result.assets if a.asset_type == "technology"}
+
+
+def test_discovery_options_gate_steps():
+    scope = Scope.from_domain("example.com", name="acme")
+    passive_only = discovery.run_discovery(
+        scope, discovery.DiscoveryOptions(passive=True, resolve=False, probe=False, wayback=False)
+    )
+    types = {a.asset_type for a in passive_only.assets}
+    assert "subdomain" in types
+    assert "ip" not in types and "host" not in types and "url" not in types
+
+
+def test_project_to_graph_mirrors_assets():
+    scope = Scope.from_domain("example.com", name="acme")
+    result = discovery.run_discovery(scope)
+    kg = KnowledgeGraph()
+    discovery.project_to_graph(kg, result.assets)
+    subs = {e.id for e in kg.get_entities_by_type("subdomain")}
+    assert "api.example.com" in subs
+    assert kg.get_entity("example.com") is not None
+    neighbors = {getattr(n, "id", n) for n in kg.get_neighbors("example.com", "HAS_SUBDOMAIN")}
+    assert "api.example.com" in neighbors
+
+
+def test_discovery_never_raises_when_a_source_fails(monkeypatch):
+    monkeypatch.setattr(dt, "crtsh_subdomains", lambda d: (_ for _ in ()).throw(RuntimeError("boom")))
+    scope = Scope.from_domain("example.com", name="acme")
+    # a failing source contributes nothing but does not crash the run
+    result = discovery.run_discovery(scope)
+    assert any(a.asset_type == "domain" for a in result.assets)

--- a/tests/test_asm_monitor.py
+++ b/tests/test_asm_monitor.py
@@ -1,0 +1,101 @@
+"""Tests for the continuous ASM monitor."""
+
+from __future__ import annotations
+
+import pytest
+
+from clearwing.asm.assets import Asset, AssetStore
+from clearwing.asm.monitor import AsmMonitor, AsmMonitorConfig
+from clearwing.asm.scope import Scope
+from clearwing.core.events import EventBus, EventType
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = AssetStore(tmp_path / "assets.db")
+    yield s
+    s.close()
+
+
+@pytest.fixture
+def captured_events():
+    events: list = []
+    handler = events.append
+    EventBus().subscribe(EventType.ASSET_DISCOVERED, handler)
+    yield events
+    EventBus().unsubscribe(EventType.ASSET_DISCOVERED, handler)
+
+
+def _cfg(store, **kw):
+    return AsmMonitorConfig(scope=Scope.from_domain("acme.com", name="acme"), store=store, **kw)
+
+
+def test_cycle_emits_only_for_new_assets(store, captured_events):
+    cycles = iter(
+        [
+            [Asset("acme", "subdomain", "a.acme.com"), Asset("acme", "subdomain", "b.acme.com")],
+            [Asset("acme", "subdomain", "a.acme.com"), Asset("acme", "subdomain", "c.acme.com")],
+        ]
+    )
+    monitor = AsmMonitor(
+        _cfg(store, max_iterations=2, poll_interval_seconds=0, scan_new_assets=False,
+             discover_fn=lambda s, o: next(cycles))
+    )
+    monitor.run()
+    assert monitor.iterations == 2
+    # a.acme.com is only announced once, across both cycles
+    assert sorted(p.value for p in captured_events) == ["a.acme.com", "b.acme.com", "c.acme.com"]
+
+
+def test_scan_runs_only_on_new_ip_and_host_assets(store):
+    scanned: list[str] = []
+    assets = [
+        Asset("acme", "subdomain", "a.acme.com"),
+        Asset("acme", "ip", "1.2.3.4"),
+        Asset("acme", "host", "https://a.acme.com"),
+    ]
+    monitor = AsmMonitor(
+        _cfg(store, max_iterations=1, poll_interval_seconds=0, scan_new_assets=True,
+             threat_intel=False, discover_fn=lambda s, o: assets,
+             scan_fn=lambda a: scanned.append(a.value) or [])
+    )
+    monitor.run()
+    assert sorted(scanned) == ["1.2.3.4", "https://a.acme.com"]  # not the subdomain
+
+
+def test_scan_disabled(store):
+    scanned: list[str] = []
+    monitor = AsmMonitor(
+        _cfg(store, max_iterations=1, poll_interval_seconds=0, scan_new_assets=False,
+             discover_fn=lambda s, o: [Asset("acme", "ip", "1.2.3.4")],
+             scan_fn=lambda a: scanned.append(a.value) or [])
+    )
+    monitor.run()
+    assert scanned == []
+
+
+def test_cancel_stops_an_infinite_monitor(store):
+    calls = {"n": 0}
+
+    def discover(scope, opts):
+        calls["n"] += 1
+        monitor.cancel()  # cancel from inside the first cycle
+        return [Asset("acme", "subdomain", f"h{calls['n']}.acme.com")]
+
+    monitor = AsmMonitor(
+        _cfg(store, max_iterations=0, poll_interval_seconds=999, scan_new_assets=False,
+             discover_fn=discover)
+    )
+    monitor.run()
+    assert calls["n"] == 1  # cancelled before a second cycle / long sleep
+
+
+def test_on_cycle_callback(store):
+    seen: list[int] = []
+    monitor = AsmMonitor(
+        _cfg(store, max_iterations=1, poll_interval_seconds=0, scan_new_assets=False,
+             discover_fn=lambda s, o: [Asset("acme", "subdomain", "a.acme.com")],
+             on_cycle=lambda new: seen.append(len(new)))
+    )
+    monitor.run()
+    assert seen == [1]

--- a/tests/test_asm_notify.py
+++ b/tests/test_asm_notify.py
@@ -1,0 +1,55 @@
+"""Tests for the outbound ASM notifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from clearwing.asm.notify import Notifier
+from clearwing.core.event_payloads import AssetDiscoveredPayload
+from clearwing.core.events import EventBus, EventType
+
+
+@pytest.fixture
+def posts(monkeypatch):
+    sent: list[tuple[str, dict]] = []
+    monkeypatch.setattr(Notifier, "_post", lambda self, url, payload: sent.append((url, payload)))
+    return sent
+
+
+def test_disabled_notifier_subscribes_to_nothing(posts):
+    n = Notifier()  # no urls
+    assert n.enabled is False
+    n.subscribe()
+    EventBus().emit_asset_discovered(AssetDiscoveredPayload("acme", "subdomain", "a.acme.com", "crt.sh", None))
+    assert posts == []
+
+
+def test_notifies_on_new_asset_and_finding(posts):
+    n = Notifier(slack_url="http://sink/slack")
+    with n:
+        EventBus().emit_asset_discovered(
+            AssetDiscoveredPayload("acme", "subdomain", "api.acme.com", "crt.sh", None)
+        )
+        EventBus().emit(EventType.FINDING_RECORDED, {"severity": "high", "finding_type": "sqli", "file": "x.py"})
+    assert len(posts) == 2
+    assert "api.acme.com" in posts[0][1]["text"]
+    assert "sqli" in posts[1][1]["text"]
+
+
+def test_unsubscribe_stops_notifications(posts):
+    n = Notifier(webhook_url="http://sink/hook")
+    n.subscribe()
+    n.unsubscribe()
+    EventBus().emit_asset_discovered(AssetDiscoveredPayload("acme", "subdomain", "a.acme.com", "crt.sh", None))
+    assert posts == []
+
+
+def test_from_config_prefers_env(monkeypatch):
+    monkeypatch.setenv("CLEARWING_SLACK_WEBHOOK", "http://env/slack")
+    n = Notifier.from_config({"slack_webhook_env": "CLEARWING_SLACK_WEBHOOK", "slack_webhook_url": "http://literal"})
+    assert n.slack_url == "http://env/slack"
+
+
+def test_a_failing_post_never_raises():
+    # the real _post swallows transport errors; sending to a bad url must not throw
+    Notifier(slack_url="http://127.0.0.1:1/definitely-not-listening").notify("hi")

--- a/tests/test_asm_report_modes_sweep.py
+++ b/tests/test_asm_report_modes_sweep.py
@@ -1,0 +1,98 @@
+"""Tests for ASM reporting, modes, and the mass sweep."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from clearwing.asm import report as report_mod
+from clearwing.asm import sweep as sweep_mod
+from clearwing.asm.assets import Asset, AssetStore
+from clearwing.asm.modes import DEFAULT_MODE, MODES, get_mode
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = AssetStore(tmp_path / "assets.db")
+    s.record_observations(
+        "acme",
+        [
+            Asset("acme", "domain", "acme.com"),
+            Asset("acme", "subdomain", "api.acme.com"),
+            Asset("acme", "ip", "1.2.3.4"),
+            Asset("acme", "host", "https://api.acme.com"),
+        ],
+    )
+    yield s
+    s.close()
+
+
+# --- report -----------------------------------------------------------------
+
+
+def test_build_report_groups_assets_and_findings(store):
+    findings = [{"cve": "CVE-1", "severity": "high", "known_exploited": True, "target": "1.2.3.4"}]
+    data = report_mod.build_report(store, "acme", since=0.0, findings=findings)
+    assert data["stats"] == {"domain": 1, "subdomain": 1, "ip": 1, "host": 1}
+    assert "api.acme.com" in data["assets"]["subdomain"]
+    assert len(data["new_since_last"]) == 4  # since=0 → all count as delta
+    assert data["findings"] == findings
+
+
+def test_render_markdown_and_json(store):
+    data = report_mod.build_report(store, "acme", since=0.0, findings=[
+        {"cve": "CVE-1", "severity": "critical", "known_exploited": True, "epss": 0.9, "target": "1.2.3.4"}
+    ])
+    md = report_mod.render_markdown(data)
+    assert "# Attack surface — acme" in md and "**KEV**" in md and "api.acme.com" in md
+    assert json.loads(report_mod.render_json(data))["scope"] == "acme"
+
+
+def test_write_report_creates_files(store, tmp_path):
+    paths = report_mod.write_report(store, "acme", out_dir=tmp_path / "out")
+    assert set(paths) == {"markdown", "json"}
+    for path in paths.values():
+        assert (tmp_path / "out").exists()
+        assert path.endswith((".md", ".json"))
+
+
+# --- modes ------------------------------------------------------------------
+
+
+def test_modes_registry():
+    assert set(MODES) == {"recon", "stealth", "web-assessment", "external-sweep"}
+    assert get_mode(None).name == DEFAULT_MODE
+    assert get_mode("STEALTH").discovery.probe is False
+    assert get_mode("external-sweep").sweep is True
+
+
+def test_unknown_mode_raises():
+    with pytest.raises(ValueError, match="Unknown asm mode"):
+        get_mode("nuke")
+
+
+# --- sweep ------------------------------------------------------------------
+
+
+def test_sweep_scans_every_known_host(store):
+    scanned: list[str] = []
+
+    async def fake_scan(host):
+        scanned.append(host)
+        return [{"cve": "CVE-1", "severity": "high"}] if host == "1.2.3.4" else []
+
+    result = sweep_mod.sweep_scope(store, "acme", threat_intel=False, scan_async=fake_scan)
+    assert sorted(scanned) == ["1.2.3.4", "https://api.acme.com"]
+    assert len(result.findings) == 1
+    assert result.hosts_scanned == ["1.2.3.4", "https://api.acme.com"]
+
+
+def test_sweep_tolerates_a_failing_host(store):
+    async def fake_scan(host):
+        if host == "1.2.3.4":
+            raise RuntimeError("scan blew up")
+        return [{"cve": "CVE-2", "severity": "low"}]
+
+    result = sweep_mod.sweep_scope(store, "acme", threat_intel=False, scan_async=fake_scan)
+    assert [f["cve"] for f in result.findings] == ["CVE-2"]

--- a/tests/test_asm_threatintel.py
+++ b/tests/test_asm_threatintel.py
@@ -1,0 +1,65 @@
+"""Tests for threat-intel enrichment and prioritization."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from clearwing.asm import threatintel
+from clearwing.asm.threatintel import ThreatIntel
+
+
+@pytest.fixture
+def ti(tmp_path, monkeypatch):
+    intel = ThreatIntel(cache_path=tmp_path / "kev.json")
+    intel._kev = {"CVE-2021-44228"}
+    intel._epss = {"CVE-2021-44228": 0.97, "CVE-2019-0001": 0.02}
+    return intel
+
+
+def test_enrich_sorts_kev_first_then_epss(ti):
+    findings = [
+        {"cve": "CVE-2019-0001", "severity": "high", "cvss": 7.5},
+        {"cve": "CVE-2021-44228", "severity": "critical", "cvss": 10.0},
+        {"cwe": "CWE-79", "severity": "medium"},
+    ]
+    ordered = ti.enrich(findings)
+    assert [f.get("cve") or f.get("cwe") for f in ordered] == [
+        "CVE-2021-44228",
+        "CVE-2019-0001",
+        "CWE-79",
+    ]
+    assert ordered[0]["known_exploited"] is True and ordered[0]["epss"] == 0.97
+    assert ordered[2]["known_exploited"] is False
+
+
+def test_kev_lookup_case_insensitive(ti):
+    assert ti.is_known_exploited("cve-2021-44228") is True
+    assert ti.is_known_exploited("CVE-0000-0000") is False
+
+
+def test_kev_cache_round_trip(tmp_path, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_json(url, timeout=20):
+        calls["n"] += 1
+        return {"vulnerabilities": [{"cveID": "CVE-2021-44228"}]}
+
+    monkeypatch.setattr(threatintel, "_http_get_json", fake_json)
+    cache = tmp_path / "kev.json"
+    first = ThreatIntel(cache_path=cache)
+    assert first.is_known_exploited("CVE-2021-44228") is True
+    assert calls["n"] == 1
+    # a fresh instance reads the on-disk cache instead of fetching again
+    second = ThreatIntel(cache_path=cache)
+    assert second.is_known_exploited("CVE-2021-44228") is True
+    assert calls["n"] == 1
+
+
+def test_stale_cache_is_ignored(tmp_path):
+    cache = tmp_path / "kev.json"
+    cache.write_text(json.dumps({"fetched_at": time.time() - 10**7, "cves": ["CVE-1"]}))
+    intel = ThreatIntel(cache_path=cache)
+    assert intel._read_cache() is None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -29,6 +29,7 @@ class TestEventType:
             "HUNTER_STATUS",
             "HUNTER_REASONING",
             "FINDING_RECORDED",
+            "ASSET_DISCOVERED",
             "TRACE_STEP",
             "VALIDATION_RESULT",
             "DISCLOSURE_UPDATE",

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -23,7 +23,7 @@ from clearwing.agent.tools import get_all_tools
 
 # Locked baseline as of Phase 4 start. Update this only when deliberately
 # adding or removing a tool from the network-agent registry.
-EXPECTED_TOOL_COUNT = 120
+EXPECTED_TOOL_COUNT = 126
 
 
 EXPECTED_TOOL_NAMES: frozenset[str] = frozenset(


### PR DESCRIPTION
Ports the discovery/continuity/engagement ideas from Sn1per into Clearwing — reimagined agentically and feeding Clearwing's existing deep scanning/verification, **without** copying Sn1per's shallow version-only detection (the false-positive firehose Clearwing exists to avoid).

## Why

Clearwing is deep on a *known* target but had no way to discover what's out there, track what changes over time, or organize a surface across runs. `scanner_tools` only scans a host you already supply. This adds the missing front half.

## What (new `clearwing/asm/` subsystem + `clearwing asm` command)

| Layer | Module | Notes |
|-------|--------|-------|
| Asset inventory | `assets.py` / `scope.py` | Scope-keyed SQLite store modeled on `HistoricalFindingsDB`; `record_observations` returns only the **new** assets (delta detection). |
| Discovery | `discovery.py` + `agent/tools/recon/discovery_tools.py` | Passive-first, host-safe `@tool`s: crt.sh cert transparency, Wayback, optional GitHub/Shodan/Censys, DNS resolution, HTTP liveness + tech fingerprint, screenshot gallery. Projected into the knowledge graph. |
| Continuous monitor | `monitor.py` | Poll loop (modeled on `CommitMonitor`): discover → delta → `ASSET_DISCOVERED` → scan new hosts. Never exploits or triggers approval-gated actions automatically. |
| Notifications | `notify.py` | Outbound Slack/webhook (the missing outbound half), subscribing to `ASSET_DISCOVERED`/`FINDING_RECORDED`, best-effort. |
| Threat intel | `threatintel.py` | CISA KEV + EPSS enrichment; findings sort KEV-first. |
| Mass sweep | `sweep.py` | Parallel port/service/vuln scan across a discovered surface. |
| Modes | `modes.py` | Named playbooks: recon, stealth, web-assessment, external-sweep. |
| Reporting | `report.py` | Per-scope aggregate markdown/json. |

**Wiring** (additive, with baselines updated): an `asm` config section; `EventType.ASSET_DISCOVERED` + payload; knowledge-graph entity/relationship types (`domain`/`subdomain`/`url`/`technology`); the discovery tool category in `get_all_tools()`; the `asm` CLI subcommand (`scan`/`monitor`/`sweep`/`report`/`list`); read-only web endpoints + a WebSocket event.

## Design choices

- **Passive-first / host-safe.** Discovery queries public archives (crt.sh, Wayback, KEV, EPSS) exactly like the existing NVD/CVE lookups; light active steps (DNS, HTTP liveness) match `proxy_request`/`scan_ports`. Heavy active enum is left to the Kali container. **ASM never auto-exploits.**
- **Delta store vs. graph.** The SQLite `AssetStore` is authoritative for "what's new since last run"; the knowledge graph is a queryable/visualizable projection.
- **No new scheduler.** `asm monitor` is a poll loop (daemon or `--once` for cron / `clearwing schedule`) — the repo has no scheduler library.

## Tests / docs

48 focused ASM tests (store delta, discovery, monitor, notifier, threat-intel, sweep, modes, report, CLI) — **all green**, plus shared-file regressions (events, tool registry, knowledge, config, webui, scanner, reporting) pass; ruff clean; two baseline tests updated for the new event + 6 new tools. Docs: `docs/asm.md`, a `docs/cli.md` section, README, mkdocs nav.

## Note

This is a large single PR (~2.8k lines) by request — organized so each layer is an independent module with its own tests. Happy to split if the team prefers.