### PR TITLE
Make SourceHunt sandbox execution pluggable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ clearwing --help
 ```
 
 Requirements: Python 3.10+ and optionally Docker for the Kali container
-and sanitizer-image sandbox features. `genai-pyo3` ships as prebuilt
+and SourceHunt execution environments. `genai-pyo3` ships as prebuilt
 wheels on PyPI (linux x86_64/aarch64, macOS universal2, windows x86_64,
 Python 3.9–3.13), so no Rust toolchain is needed for installation.
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ and sanitizer-image sandbox features. `genai-pyo3` ships as prebuilt
 wheels on PyPI (linux x86_64/aarch64, macOS universal2, windows x86_64,
 Python 3.9–3.13), so no Rust toolchain is needed for installation.
 
+SourceHunt uses Docker by default. Deployments with a trusted external
+sandbox service can set `CLEARWING_SANDBOX_ENDPOINT` to a Unix socket
+(`unix:///run/clearwing/sandbox.sock`) or an inherited full-duplex socket
+(`fd://4`). See the [sandbox backend contract](docs/sandbox-backends.md).
+
 ## Quickstart
 
 ```bash

--- a/clearwing/agent/tools/hunt/sandbox.py
+++ b/clearwing/agent/tools/hunt/sandbox.py
@@ -2,7 +2,7 @@
 
 `HunterContext` is the mutable state passed to every per-hunter tool
 builder (discovery/analysis/reporting). It owns the primary
-SandboxContainer plus a cache of sanitizer-variant containers so that
+SandboxInstance plus a cache of sanitizer-variant sandboxes so that
 an MSan hunter can transparently spawn a second image without the
 caller tracking it.
 
@@ -17,7 +17,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import cast
 
-from clearwing.sandbox.container import SandboxContainer
+from clearwing.sandbox.backend import SandboxInstance
 from clearwing.sourcehunt.state import Finding
 
 logger = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ class HunterContext:
     """Per-hunter mutable context. Closured into every tool for state access."""
 
     repo_path: str  # absolute host path
-    sandbox: SandboxContainer | None = None  # primary sandbox; set by hunt loop
+    sandbox: SandboxInstance | None = None  # primary sandbox; set by hunt loop
     findings: list[Finding] = field(default_factory=list)
     trace_steps: list = field(default_factory=list)  # accumulator for TraceStep dicts
     files_read: set = field(default_factory=set)  # files accessed via read_source_file
@@ -43,7 +43,7 @@ class HunterContext:
     # Variant containers are cached in `variant_sandboxes` and torn down
     # at hunter cleanup time.
     sandbox_manager: object | None = None  # HunterSandbox (avoiding circular import)
-    variant_sandboxes: dict = field(default_factory=dict)  # {variant_key: SandboxContainer}
+    variant_sandboxes: dict = field(default_factory=dict)  # {variant_key: SandboxInstance}
     default_sanitizers: tuple = ("asan", "ubsan")
     findings_pool: object | None = None  # FindingsPool (avoiding circular import)
     trajectory_dir: object | None = None  # Path override for transcript output
@@ -61,8 +61,8 @@ class HunterContext:
     def get_sandbox_for_variant(
         self,
         sanitizer_variant: list[str] | None = None,
-    ) -> SandboxContainer | None:
-        """Return the SandboxContainer for the requested sanitizer variant.
+    ) -> SandboxInstance | None:
+        """Return the sandbox instance for the requested sanitizer variant.
 
         - variant=None or matches default → returns self.sandbox (fast path)
         - different variant → spawns from self.sandbox_manager and caches
@@ -77,7 +77,7 @@ class HunterContext:
         key = "+".join(sorted(chosen))
         cached = self.variant_sandboxes.get(key)
         if cached is not None:
-            return cast(SandboxContainer, cached)
+            return cast(SandboxInstance, cached)
         # Need to spawn a new variant container
         if self.sandbox_manager is None:
             # No manager — degrade to the primary sandbox
@@ -95,7 +95,7 @@ class HunterContext:
             logger.warning("Failed to spawn variant sandbox %s", chosen, exc_info=True)
             return self.sandbox
         self.variant_sandboxes[key] = sb
-        return cast(SandboxContainer, sb)
+        return cast(SandboxInstance, sb)
 
     def cleanup_variants(self) -> None:
         """Stop every cached variant container. Call when the hunter finishes."""

--- a/clearwing/remediation/dynamic.py
+++ b/clearwing/remediation/dynamic.py
@@ -33,7 +33,7 @@ class SandboxPatchValidator:
                 notes="finding has no PoC input for sandbox replay",
             )
         if not self._built:
-            self.manager.build_image()
+            self.manager.prepare_environment()
             self._built = True
         sandbox = self.manager.spawn(runtime=self.runtime)
         try:

--- a/clearwing/sandbox/__init__.py
+++ b/clearwing/sandbox/__init__.py
@@ -6,21 +6,37 @@ primitives here are isolation-focused: no network, read-only mounts, resource
 limits, and sanitizer-instrumented build images.
 """
 
+from .backend import (
+    DockerSandboxBackend,
+    SandboxBackend,
+    SandboxImageBuild,
+    SandboxInstance,
+    sandbox_backend_from_env,
+)
 from .builders import BuildRecipe, BuildSystemDetector
 from .container import ExecResult, SandboxConfig, SandboxContainer
 from .dind import get_docker_client, get_docker_host, get_subprocess_env
 from .hunter_sandbox import HunterSandbox
 from .registry import ContainerRegistry
+from .rpc_backend import JsonRpcConnection, SandboxRpcError, SocketSandboxBackend
 
 __all__ = [
     "ContainerRegistry",
+    "DockerSandboxBackend",
     "ExecResult",
+    "JsonRpcConnection",
+    "SandboxBackend",
     "SandboxConfig",
     "SandboxContainer",
+    "SandboxImageBuild",
+    "SandboxInstance",
+    "SandboxRpcError",
+    "SocketSandboxBackend",
     "BuildRecipe",
     "BuildSystemDetector",
     "HunterSandbox",
     "get_docker_client",
     "get_docker_host",
     "get_subprocess_env",
+    "sandbox_backend_from_env",
 ]

--- a/clearwing/sandbox/__init__.py
+++ b/clearwing/sandbox/__init__.py
@@ -3,14 +3,16 @@
 Distinct from clearwing/agent/tools/kali_docker_tool.py — that tool is
 attack-focused (approval gates, apt-get install, network access). The sandbox
 primitives here are isolation-focused: no network, read-only mounts, resource
-limits, and sanitizer-instrumented build images.
+limits, and sanitizer-capable toolchain environments.
 """
 
 from .backend import (
     DockerSandboxBackend,
     SandboxBackend,
-    SandboxImageBuild,
+    SandboxEnvironment,
+    SandboxEnvironmentSpec,
     SandboxInstance,
+    SandboxRunConfig,
     sandbox_backend_from_env,
 )
 from .builders import BuildRecipe, BuildSystemDetector
@@ -28,9 +30,11 @@ __all__ = [
     "SandboxBackend",
     "SandboxConfig",
     "SandboxContainer",
-    "SandboxImageBuild",
+    "SandboxEnvironment",
+    "SandboxEnvironmentSpec",
     "SandboxInstance",
     "SandboxRpcError",
+    "SandboxRunConfig",
     "SocketSandboxBackend",
     "BuildRecipe",
     "BuildSystemDetector",

--- a/clearwing/sandbox/backend.py
+++ b/clearwing/sandbox/backend.py
@@ -13,6 +13,7 @@ import os
 import platform
 import subprocess
 import tempfile
+import threading
 from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
 from dataclasses import asdict, dataclass, field
@@ -184,6 +185,7 @@ class DockerSandboxBackend:
         ] = tempfile.TemporaryDirectory,
         profile_images: Mapping[str, str] | None = None,
         feature_packages: Mapping[str, tuple[str, ...]] | None = None,
+        enhanced_runtime: str = "runsc",
     ) -> None:
         self._client_factory = client_factory
         self._process = process
@@ -193,6 +195,12 @@ class DockerSandboxBackend:
             **_DOCKER_FEATURE_PACKAGES,
             **(feature_packages or {}),
         }
+        # The concrete container runtime that implements "enhanced" isolation.
+        # This is a Docker-adapter detail that never crosses the neutral
+        # SandboxRunConfig (or the RPC boundary); operators select an installed
+        # gVisor-compatible runtime (e.g. "runsc", "runsc-kvm", "kata-runtime")
+        # and the adapter honors that exact name instead of assuming "runsc".
+        self._enhanced_runtime = enhanced_runtime or "runsc"
 
     def _client(self):
         if self._client_factory is not None:
@@ -252,19 +260,37 @@ class DockerSandboxBackend:
             )
             output_lines: list[str] = []
             assert process.stdout is not None
-            for line in process.stdout:
-                line = line.rstrip()
-                if line:
-                    output_lines.append(line)
-                    if on_output is not None:
-                        on_output(line)
+            # A wall-clock watchdog bounds the *whole* build. Reading stdout to
+            # EOF and only then calling wait(timeout=...) never bounds a build
+            # that hangs with stdout still open (e.g. a stalled base-image
+            # pull): the read blocks until the process exits, so wait() sees an
+            # already-finished process. The timer kills the build after
+            # timeout_seconds regardless of whether it is producing output.
+            timed_out = threading.Event()
+
+            def _kill_on_timeout() -> None:
+                timed_out.set()
+                try:
+                    process.kill()
+                except Exception:  # noqa: BLE001 - process may have already exited
+                    pass
+
+            watchdog = threading.Timer(spec.timeout_seconds, _kill_on_timeout)
+            watchdog.start()
             try:
-                process.wait(timeout=spec.timeout_seconds)
-            except self._process.TimeoutExpired as error:
-                process.kill()
+                for line in process.stdout:
+                    line = line.rstrip()
+                    if line:
+                        output_lines.append(line)
+                        if on_output is not None:
+                            on_output(line)
+                process.wait()
+            finally:
+                watchdog.cancel()
+            if timed_out.is_set():
                 raise RuntimeError(
                     f"Sandbox environment preparation timed out after {spec.timeout_seconds}s"
-                ) from error
+                )
             if process.returncode != 0:
                 raise RuntimeError("\n".join(output_lines[-40:]))
         return SandboxEnvironment(image, cached=False)
@@ -361,7 +387,7 @@ RUN mkdir -p /scratch
                 security_opt=[f"seccomp={seccomp_json}"],
                 cap_drop=["ALL"],
                 cap_add=["SYS_PTRACE"],
-                runtime="runsc" if config.isolation == "enhanced" else None,
+                runtime=self._enhanced_runtime if config.isolation == "enhanced" else None,
             )
         )
 
@@ -374,8 +400,15 @@ def sandbox_backend_from_env(
     *,
     process: ModuleType = subprocess,
     temporary_directory: Callable[..., AbstractContextManager[str]] = tempfile.TemporaryDirectory,
+    enhanced_runtime: str = "runsc",
 ) -> SandboxBackend:
-    """Select the configured backend, defaulting to the original Docker path."""
+    """Select the configured backend, defaulting to the original Docker path.
+
+    ``enhanced_runtime`` is the operator-selected container runtime that
+    implements "enhanced" isolation for the Docker adapter. It is deliberately
+    a Docker-only concern: a remote RPC supervisor decides for itself how to
+    realize "enhanced", so the runtime name never crosses the RPC boundary.
+    """
 
     endpoint = os.environ.get("CLEARWING_SANDBOX_ENDPOINT", "").strip()
     if endpoint:
@@ -386,4 +419,5 @@ def sandbox_backend_from_env(
         docker_client_factory,
         process=process,
         temporary_directory=temporary_directory,
+        enhanced_runtime=enhanced_runtime,
     )

--- a/clearwing/sandbox/backend.py
+++ b/clearwing/sandbox/backend.py
@@ -1,18 +1,21 @@
 """Pluggable execution boundary for SourceHunt sandboxes.
 
-Backends are trusted infrastructure adapters.  Clearwing owns the SourceHunt
-policy and build recipe; a backend owns the runtime-specific image, process,
-filesystem, and cleanup operations used to enforce that policy.
+Backends are trusted infrastructure adapters. Clearwing describes the
+toolchain and tools it needs; a backend owns runtime-specific images,
+processes, filesystems, credentials, and cleanup.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
+import platform
 import subprocess
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from types import ModuleType
 from typing import Protocol, runtime_checkable
 
@@ -20,20 +23,50 @@ from .container import ExecResult, SandboxConfig, SandboxContainer
 
 
 @dataclass(frozen=True)
-class SandboxImageBuild:
-    """One content-addressed OCI image requested by ``HunterSandbox``."""
+class SandboxEnvironmentSpec:
+    """Provider-neutral requirements for one prepared environment.
 
-    image: str
-    dockerfile: str
-    platform: str
+    ``profile`` and ``features`` are logical capability names. They are not
+    image references or package-manager identifiers. ``cache_key`` identifies
+    the complete request and lets a provider reuse an equivalent environment.
+    """
+
+    cache_key: str
+    profile: str
+    features: list[str] = field(default_factory=list)
+    optional_features: list[str] = field(default_factory=list)
+    sanitizers: list[str] = field(default_factory=list)
+    environment: dict[str, str] = field(default_factory=dict)
     timeout_seconds: int = 300
+
+
+@dataclass(frozen=True)
+class SandboxEnvironment:
+    """An opaque provider-owned environment reference."""
+
+    reference: str
+    cached: bool
+
+
+@dataclass
+class SandboxRunConfig:
+    """Isolation and resource policy for one sandbox instance."""
+
+    policy: str = "sourcehunt"
+    isolation: str = "default"
+    mounts: list[tuple[str, str, str]] = field(default_factory=list)
+    memory_mb: int = 2048
+    cpus: float = 0.0
+    timeout_seconds: int = 300
+    env: dict[str, str] = field(default_factory=dict)
+    working_dir: str = "/workspace"
+    pids_limit: int = 512
 
 
 @runtime_checkable
 class SandboxInstance(Protocol):
     """Runtime-neutral sandbox instance consumed by SourceHunt."""
 
-    config: SandboxConfig
     scratch_host_dir: str | None
     variant: list[str] | None
     workspace_baseline_commit: str | None
@@ -61,6 +94,9 @@ class SandboxInstance(Protocol):
     def stop(self) -> None: ...
 
     @property
+    def config(self) -> SandboxRunConfig | SandboxConfig: ...
+
+    @property
     def container_id(self) -> str | None: ...
 
     @property
@@ -74,28 +110,67 @@ class SandboxInstance(Protocol):
 class SandboxBackend(Protocol):
     """Provider contract used by ``HunterSandbox``.
 
-    Implementations may use a local container daemon, a remote service, or a
-    cluster API.  ``ensure_image`` returns ``True`` when the requested image
-    was already cached and ``False`` when it was prepared during the call.
+    Providers may implement an environment with a cached OCI image, a
+    writable rootfs overlay, a preconfigured pod, or another isolation
+    primitive. Those details are deliberately absent from this interface.
     """
 
     name: str
 
     def available_cpus(self) -> tuple[float | None, str]: ...
 
-    def ensure_image(
+    def ensure_environment(
         self,
-        build: SandboxImageBuild,
+        spec: SandboxEnvironmentSpec,
         on_output: Callable[[str], None] | None = None,
-    ) -> bool: ...
+    ) -> SandboxEnvironment: ...
 
-    def create(self, config: SandboxConfig) -> SandboxInstance: ...
+    def create(
+        self,
+        environment_ref: str,
+        config: SandboxRunConfig,
+    ) -> SandboxInstance: ...
 
-    def remove_image(self, image: str) -> None: ...
+    def release_environment(self, environment_ref: str) -> None: ...
+
+
+# These implementation details belong to the zero-configuration Docker
+# adapter. They never appear in SandboxEnvironmentSpec or on the RPC wire.
+_DOCKER_PROFILE_IMAGES: dict[str, str] = {
+    "c-cpp": "gcc:12-bullseye",
+    "rust": "rust:1-slim",
+    "go": "golang:1.22",
+    "python": "python:3.12-slim",
+    "java": "eclipse-temurin:21",
+    "node": "node:20-slim",
+    "generic": "debian:11-slim",
+}
+
+_DOCKER_FEATURE_PACKAGES: dict[str, tuple[str, ...]] = {
+    "source.search": ("ripgrep",),
+    "debug.native": ("gdb",),
+    "trace.syscalls": ("strace",),
+    "trace.library-calls": ("ltrace",),
+    "process.timeout": ("coreutils",),
+    "trust.roots": ("ca-certificates",),
+    "build.native": ("build-essential",),
+    "build.make": (),
+    "build.cmake": ("cmake",),
+    "build.cargo": (),
+    "build.go": (),
+    "build.maven": ("maven",),
+    "build.npm": (),
+    "toolchain.native": ("gcc", "g++"),
+    "toolchain.clang": ("clang",),
+    "runtime.python": ("python3",),
+    "debug.valgrind": ("valgrind",),
+    "build.ccache": ("ccache",),
+    "vcs.git": ("git",),
+}
 
 
 class DockerSandboxBackend:
-    """The original Docker implementation, now behind ``SandboxBackend``."""
+    """Docker default that privately materializes logical environments."""
 
     name = "docker"
 
@@ -107,10 +182,17 @@ class DockerSandboxBackend:
         temporary_directory: Callable[
             ..., AbstractContextManager[str]
         ] = tempfile.TemporaryDirectory,
+        profile_images: Mapping[str, str] | None = None,
+        feature_packages: Mapping[str, tuple[str, ...]] | None = None,
     ) -> None:
         self._client_factory = client_factory
         self._process = process
         self._temporary_directory = temporary_directory
+        self._profile_images = {**_DOCKER_PROFILE_IMAGES, **(profile_images or {})}
+        self._feature_packages = {
+            **_DOCKER_FEATURE_PACKAGES,
+            **(feature_packages or {}),
+        }
 
     def _client(self):
         if self._client_factory is not None:
@@ -128,35 +210,39 @@ class DockerSandboxBackend:
             return float(value), "Docker daemon"
         return None, "Docker daemon"
 
-    def ensure_image(
+    def ensure_environment(
         self,
-        build: SandboxImageBuild,
+        spec: SandboxEnvironmentSpec,
         on_output: Callable[[str], None] | None = None,
-    ) -> bool:
+    ) -> SandboxEnvironment:
         from .dind import get_subprocess_env
 
+        image = self._environment_image(spec)
+        # Resolve and validate every required capability even on a cache hit.
+        # A stale or malicious cache key must not bypass the closed mapping.
+        dockerfile = self._render_dockerfile(spec)
         docker_env = get_subprocess_env()
         check = self._process.run(
-            ["docker", "image", "inspect", build.image],
+            ["docker", "image", "inspect", image],
             capture_output=True,
             timeout=10,
             env=docker_env,
         )
         if check.returncode == 0:
-            return True
+            return SandboxEnvironment(image, cached=True)
 
         with self._temporary_directory(prefix="clearwing-sandbox-build-") as build_dir:
             dockerfile_path = f"{build_dir}/Dockerfile"
             with open(dockerfile_path, "w", encoding="utf-8") as file:
-                file.write(build.dockerfile)
+                file.write(dockerfile)
             process = self._process.Popen(
                 [
                     "docker",
                     "build",
                     "--platform",
-                    build.platform,
+                    self._target_platform(spec.profile),
                     "-t",
-                    build.image,
+                    image,
                     build_dir,
                 ],
                 stdout=self._process.PIPE,
@@ -173,21 +259,114 @@ class DockerSandboxBackend:
                     if on_output is not None:
                         on_output(line)
             try:
-                process.wait(timeout=build.timeout_seconds)
+                process.wait(timeout=spec.timeout_seconds)
             except self._process.TimeoutExpired as error:
                 process.kill()
                 raise RuntimeError(
-                    f"Sandbox image build timed out after {build.timeout_seconds}s"
+                    f"Sandbox environment preparation timed out after {spec.timeout_seconds}s"
                 ) from error
             if process.returncode != 0:
                 raise RuntimeError("\n".join(output_lines[-40:]))
-        return False
+        return SandboxEnvironment(image, cached=False)
 
-    def create(self, config: SandboxConfig) -> SandboxContainer:
-        return SandboxContainer(config)
+    def _environment_image(self, spec: SandboxEnvironmentSpec) -> str:
+        if not spec.cache_key:
+            raise ValueError("sandbox environment cache_key must not be empty")
+        # Include the entire request in the Docker cache identity. This avoids
+        # trusting a caller-supplied cache key while preserving that key for
+        # providers with their own content-addressing scheme.
+        encoded = json.dumps(asdict(spec), sort_keys=True, separators=(",", ":")).encode()
+        digest = hashlib.sha256(encoded).hexdigest()[:20]
+        return f"clearwing-sourcehunt:{digest}"
 
-    def remove_image(self, image: str) -> None:
-        self._client().images.remove(image, force=True)
+    def _render_dockerfile(self, spec: SandboxEnvironmentSpec) -> str:
+        base_image = self._profile_images.get(spec.profile)
+        if base_image is None:
+            raise ValueError(f"Docker sandbox does not support profile {spec.profile!r}")
+
+        required_packages: list[str] = []
+        for feature in spec.features:
+            packages = self._feature_packages.get(feature)
+            if packages is None:
+                raise ValueError(f"Docker sandbox does not support feature {feature!r}")
+            required_packages.extend(packages)
+
+        optional_packages: list[str] = []
+        for feature in spec.optional_features:
+            optional_packages.extend(self._feature_packages.get(feature, ()))
+
+        required_packages = list(dict.fromkeys(required_packages))
+        optional_packages = list(dict.fromkeys(optional_packages))
+        required_block = self._apt_install_block(required_packages, optional=False)
+        optional_block = self._apt_install_block(optional_packages, optional=True)
+        sanitizer_comment = ",".join(spec.sanitizers) or "none"
+        return f"""FROM {base_image}
+
+# Logical profile: {spec.profile}
+# Sanitizer requirements: {sanitizer_comment}
+
+{required_block}
+
+{optional_block}
+
+WORKDIR /workspace
+RUN mkdir -p /scratch
+"""
+
+    @staticmethod
+    def _target_platform(profile: str) -> str:
+        if profile == "c-cpp" and platform.machine() in ("arm64", "aarch64"):
+            return "linux/arm64"
+        return "linux/amd64"
+
+    @staticmethod
+    def _apt_install_block(packages: list[str], *, optional: bool) -> str:
+        if not packages:
+            return "# (no optional features)" if optional else "# (no additional features)"
+        package_list = " ".join(packages)
+        failure = " 2>/dev/null || true ;" if optional else " &&"
+        return (
+            "RUN apt-get update -qq && "
+            "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "
+            f"{package_list}{failure} rm -rf /var/lib/apt/lists/*"
+        )
+
+    def create(
+        self,
+        environment_ref: str,
+        config: SandboxRunConfig,
+    ) -> SandboxContainer:
+        if config.policy != "sourcehunt":
+            raise ValueError(f"Docker sandbox does not support policy {config.policy!r}")
+        if config.isolation not in {"default", "enhanced"}:
+            raise ValueError(
+                f"Docker sandbox does not support isolation level {config.isolation!r}"
+            )
+
+        from .seccomp_profiles import get_seccomp_profile
+
+        seccomp_json = json.dumps(get_seccomp_profile("hunter"))
+        return SandboxContainer(
+            SandboxConfig(
+                image=environment_ref,
+                network_mode="none",
+                mounts=config.mounts,
+                memory_mb=config.memory_mb,
+                cpu_shares=1024,
+                cpus=config.cpus,
+                timeout_seconds=config.timeout_seconds,
+                env=config.env,
+                working_dir=config.working_dir,
+                pids_limit=config.pids_limit,
+                security_opt=[f"seccomp={seccomp_json}"],
+                cap_drop=["ALL"],
+                cap_add=["SYS_PTRACE"],
+                runtime="runsc" if config.isolation == "enhanced" else None,
+            )
+        )
+
+    def release_environment(self, environment_ref: str) -> None:
+        self._client().images.remove(environment_ref, force=True)
 
 
 def sandbox_backend_from_env(

--- a/clearwing/sandbox/backend.py
+++ b/clearwing/sandbox/backend.py
@@ -57,7 +57,7 @@ class SandboxRunConfig:
     isolation: str = "default"
     mounts: list[tuple[str, str, str]] = field(default_factory=list)
     memory_mb: int = 2048
-    cpus: float = 0.0
+    cpus: float | None = None
     timeout_seconds: int = 300
     env: dict[str, str] = field(default_factory=dict)
     working_dir: str = "/workspace"
@@ -350,7 +350,7 @@ RUN mkdir -p /scratch
         if not packages:
             return "# (no optional features)" if optional else "# (no additional features)"
         package_list = " ".join(packages)
-        failure = " 2>/dev/null || true ;" if optional else " &&"
+        failure = " || true ;" if optional else " &&"
         return (
             "RUN apt-get update -qq && "
             "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "
@@ -379,7 +379,9 @@ RUN mkdir -p /scratch
                 mounts=config.mounts,
                 memory_mb=config.memory_mb,
                 cpu_shares=1024,
-                cpus=config.cpus,
+                # The provider-neutral contract uses None for an unspecified
+                # limit. Docker's existing adapter represents that as 0.0.
+                cpus=0.0 if config.cpus is None else config.cpus,
                 timeout_seconds=config.timeout_seconds,
                 env=config.env,
                 working_dir=config.working_dir,

--- a/clearwing/sandbox/backend.py
+++ b/clearwing/sandbox/backend.py
@@ -1,0 +1,210 @@
+"""Pluggable execution boundary for SourceHunt sandboxes.
+
+Backends are trusted infrastructure adapters.  Clearwing owns the SourceHunt
+policy and build recipe; a backend owns the runtime-specific image, process,
+filesystem, and cleanup operations used to enforce that policy.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from types import ModuleType
+from typing import Protocol, runtime_checkable
+
+from .container import ExecResult, SandboxConfig, SandboxContainer
+
+
+@dataclass(frozen=True)
+class SandboxImageBuild:
+    """One content-addressed OCI image requested by ``HunterSandbox``."""
+
+    image: str
+    dockerfile: str
+    platform: str
+    timeout_seconds: int = 300
+
+
+@runtime_checkable
+class SandboxInstance(Protocol):
+    """Runtime-neutral sandbox instance consumed by SourceHunt."""
+
+    config: SandboxConfig
+    scratch_host_dir: str | None
+    variant: list[str] | None
+    workspace_baseline_commit: str | None
+
+    def start(self) -> str: ...
+
+    def exec(
+        self,
+        command: list[str] | str,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
+        workdir: str | None = None,
+    ) -> ExecResult: ...
+
+    def write_file(self, container_path: str, content: bytes) -> None: ...
+
+    def read_file(self, container_path: str) -> bytes: ...
+
+    def copy_tree_into(
+        self,
+        host_path: str,
+        container_path: str = "/workspace",
+    ) -> None: ...
+
+    def stop(self) -> None: ...
+
+    @property
+    def container_id(self) -> str | None: ...
+
+    @property
+    def short_id(self) -> str | None: ...
+
+    @property
+    def is_running(self) -> bool: ...
+
+
+@runtime_checkable
+class SandboxBackend(Protocol):
+    """Provider contract used by ``HunterSandbox``.
+
+    Implementations may use a local container daemon, a remote service, or a
+    cluster API.  ``ensure_image`` returns ``True`` when the requested image
+    was already cached and ``False`` when it was prepared during the call.
+    """
+
+    name: str
+
+    def available_cpus(self) -> tuple[float | None, str]: ...
+
+    def ensure_image(
+        self,
+        build: SandboxImageBuild,
+        on_output: Callable[[str], None] | None = None,
+    ) -> bool: ...
+
+    def create(self, config: SandboxConfig) -> SandboxInstance: ...
+
+    def remove_image(self, image: str) -> None: ...
+
+
+class DockerSandboxBackend:
+    """The original Docker implementation, now behind ``SandboxBackend``."""
+
+    name = "docker"
+
+    def __init__(
+        self,
+        client_factory: Callable[[], object] | None = None,
+        *,
+        process: ModuleType = subprocess,
+        temporary_directory: Callable[
+            ..., AbstractContextManager[str]
+        ] = tempfile.TemporaryDirectory,
+    ) -> None:
+        self._client_factory = client_factory
+        self._process = process
+        self._temporary_directory = temporary_directory
+
+    def _client(self):
+        if self._client_factory is not None:
+            return self._client_factory()
+        from .dind import get_docker_client
+
+        return get_docker_client()
+
+    def available_cpus(self) -> tuple[float | None, str]:
+        try:
+            value = self._client().info().get("NCPU")
+        except Exception:
+            return None, "Docker daemon"
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value), "Docker daemon"
+        return None, "Docker daemon"
+
+    def ensure_image(
+        self,
+        build: SandboxImageBuild,
+        on_output: Callable[[str], None] | None = None,
+    ) -> bool:
+        from .dind import get_subprocess_env
+
+        docker_env = get_subprocess_env()
+        check = self._process.run(
+            ["docker", "image", "inspect", build.image],
+            capture_output=True,
+            timeout=10,
+            env=docker_env,
+        )
+        if check.returncode == 0:
+            return True
+
+        with self._temporary_directory(prefix="clearwing-sandbox-build-") as build_dir:
+            dockerfile_path = f"{build_dir}/Dockerfile"
+            with open(dockerfile_path, "w", encoding="utf-8") as file:
+                file.write(build.dockerfile)
+            process = self._process.Popen(
+                [
+                    "docker",
+                    "build",
+                    "--platform",
+                    build.platform,
+                    "-t",
+                    build.image,
+                    build_dir,
+                ],
+                stdout=self._process.PIPE,
+                stderr=self._process.STDOUT,
+                text=True,
+                env=docker_env,
+            )
+            output_lines: list[str] = []
+            assert process.stdout is not None
+            for line in process.stdout:
+                line = line.rstrip()
+                if line:
+                    output_lines.append(line)
+                    if on_output is not None:
+                        on_output(line)
+            try:
+                process.wait(timeout=build.timeout_seconds)
+            except self._process.TimeoutExpired as error:
+                process.kill()
+                raise RuntimeError(
+                    f"Sandbox image build timed out after {build.timeout_seconds}s"
+                ) from error
+            if process.returncode != 0:
+                raise RuntimeError("\n".join(output_lines[-40:]))
+        return False
+
+    def create(self, config: SandboxConfig) -> SandboxContainer:
+        return SandboxContainer(config)
+
+    def remove_image(self, image: str) -> None:
+        self._client().images.remove(image, force=True)
+
+
+def sandbox_backend_from_env(
+    docker_client_factory: Callable[[], object] | None = None,
+    *,
+    process: ModuleType = subprocess,
+    temporary_directory: Callable[..., AbstractContextManager[str]] = tempfile.TemporaryDirectory,
+) -> SandboxBackend:
+    """Select the configured backend, defaulting to the original Docker path."""
+
+    endpoint = os.environ.get("CLEARWING_SANDBOX_ENDPOINT", "").strip()
+    if endpoint:
+        from .rpc_backend import SocketSandboxBackend
+
+        return SocketSandboxBackend(endpoint)
+    return DockerSandboxBackend(
+        docker_client_factory,
+        process=process,
+        temporary_directory=temporary_directory,
+    )

--- a/clearwing/sandbox/builders.py
+++ b/clearwing/sandbox/builders.py
@@ -1,8 +1,8 @@
-"""Build system detection for source-hunt sandbox image generation.
+"""Build system detection for SourceHunt execution environments.
 
 Inspects a cloned repo and detects make/cmake/cargo/go/maven/npm/python.
-Returns a BuildRecipe that the HunterSandbox uses to write a Dockerfile that
-compiles the project with the requested sanitizers.
+Returns a provider-neutral ``BuildRecipe`` describing the toolchain profile,
+logical tool features, and commands needed to inspect the project.
 """
 
 from __future__ import annotations
@@ -17,12 +17,12 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class BuildRecipe:
-    """Per-language build recipe for the hunter sandbox image."""
+    """Per-language recipe for a SourceHunt execution environment."""
 
     system: str  # "make" | "cmake" | "cargo" | "go" | "maven" | "npm" | "python" | "unknown"
     primary_language: str  # "c" | "cpp" | "rust" | "go" | "java" | "node" | "python" | "unknown"
-    base_image: str  # docker base image
-    apt_packages: list[str] = field(default_factory=list)
+    profile: str  # logical toolchain profile, resolved by the sandbox provider
+    features: list[str] = field(default_factory=list)
     build_cmd: str = ""  # shell command to build the project
     test_cmd: str = ""  # shell command to run tests
     sanitizer_flags: dict[str, str] = field(default_factory=dict)
@@ -34,29 +34,12 @@ class BuildRecipe:
 
         The recipe's default `env` reflects the ASan+UBSan combo. This
         method recomputes CFLAGS/CXXFLAGS/LDFLAGS for any subset, so the
-        HunterSandbox can build an MSan variant image with the right flags.
+        HunterSandbox can prepare an MSan variant with the right flags.
 
         MSan cannot coexist with ASan in the same binary — the caller is
         responsible for not passing both (HunterSandbox validates this).
         """
         return compute_sanitizer_env(self, sanitizers)
-
-
-# Per-language base images. gcc:12-bullseye ships libasan/libubsan on Debian 11
-# (bullseye). gcc:13 is bookworm-based and has no ltrace on amd64 either (the
-# package exists but was removed from the slim image). rust uses the slim image;
-# python doesn't need a build but benefits from gcc for native extensions.
-# unknown uses debian:11-slim.
-DEFAULT_BASE_IMAGES = {
-    "c": "gcc:12-bullseye",
-    "cpp": "gcc:12-bullseye",
-    "rust": "rust:1-slim",
-    "go": "golang:1.22",
-    "python": "python:3.12-slim",
-    "java": "eclipse-temurin:21",
-    "node": "node:20-slim",
-    "unknown": "debian:11-slim",
-}
 
 
 # Per-sanitizer compile flags. MSan's flag set is intentionally different
@@ -148,17 +131,16 @@ def compute_sanitizer_env(recipe: BuildRecipe, sanitizers: list[str]) -> dict[st
     return env
 
 
-# Tools we want available in every hunter sandbox image: ripgrep for grep_source,
-# gdb/strace for debugging, coreutils' `timeout` for exec timeouts. Keep this
-# list portable across base-image architectures; ltrace is useful but is not
-# available everywhere.
-COMMON_APT_PACKAGES = [
-    "ripgrep",
-    "gdb",
-    "strace",
-    "coreutils",
-    "ca-certificates",
-    "build-essential",
+# Logical features requested by native-code hunter profiles. Runtime adapters
+# resolve these names to their own images, rootfs contents, or package manager;
+# distro package names deliberately do not cross the backend boundary.
+COMMON_NATIVE_FEATURES = [
+    "source.search",
+    "debug.native",
+    "trace.syscalls",
+    "process.timeout",
+    "trust.roots",
+    "build.native",
 ]
 
 
@@ -210,8 +192,8 @@ class BuildSystemDetector:
         return BuildRecipe(
             system="make",
             primary_language="c",
-            base_image=DEFAULT_BASE_IMAGES["c"],
-            apt_packages=COMMON_APT_PACKAGES,
+            profile="c-cpp",
+            features=[*COMMON_NATIVE_FEATURES, "build.make"],
             build_cmd="make",
             test_cmd="make test || true",
             sanitizer_flags={
@@ -233,8 +215,8 @@ class BuildSystemDetector:
         return BuildRecipe(
             system="cmake",
             primary_language="cpp",
-            base_image=DEFAULT_BASE_IMAGES["cpp"],
-            apt_packages=COMMON_APT_PACKAGES + ["cmake"],
+            profile="c-cpp",
+            features=[*COMMON_NATIVE_FEATURES, "build.cmake"],
             build_cmd="mkdir -p build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. && make",
             test_cmd="cd build && ctest --output-on-failure || true",
             sanitizer_flags={
@@ -255,8 +237,8 @@ class BuildSystemDetector:
         return BuildRecipe(
             system="cargo",
             primary_language="rust",
-            base_image=DEFAULT_BASE_IMAGES["rust"],
-            apt_packages=COMMON_APT_PACKAGES,
+            profile="rust",
+            features=[*COMMON_NATIVE_FEATURES, "build.cargo"],
             build_cmd="cargo build",
             test_cmd="cargo test || true",
             sanitizer_flags={
@@ -274,8 +256,8 @@ class BuildSystemDetector:
         return BuildRecipe(
             system="go",
             primary_language="go",
-            base_image=DEFAULT_BASE_IMAGES["go"],
-            apt_packages=COMMON_APT_PACKAGES,
+            profile="go",
+            features=[*COMMON_NATIVE_FEATURES, "build.go"],
             build_cmd="go build ./...",
             test_cmd="go test -race ./... || true",
             sanitizer_flags={"race": "-race"},
@@ -287,8 +269,8 @@ class BuildSystemDetector:
         return BuildRecipe(
             system="maven",
             primary_language="java",
-            base_image=DEFAULT_BASE_IMAGES["java"],
-            apt_packages=["maven", "ripgrep", "ca-certificates"],
+            profile="java",
+            features=["build.maven", "source.search", "trust.roots"],
             build_cmd="mvn -B -DskipTests package",
             test_cmd="mvn -B test || true",
         )
@@ -298,8 +280,8 @@ class BuildSystemDetector:
         return BuildRecipe(
             system="npm",
             primary_language="node",
-            base_image=DEFAULT_BASE_IMAGES["node"],
-            apt_packages=["ripgrep", "ca-certificates"],
+            profile="node",
+            features=["build.npm", "source.search", "trust.roots"],
             build_cmd="npm install --no-audit --no-fund || true",
             test_cmd="npm test || true",
         )
@@ -309,8 +291,8 @@ class BuildSystemDetector:
         return BuildRecipe(
             system="python",
             primary_language="python",
-            base_image=DEFAULT_BASE_IMAGES["python"],
-            apt_packages=["ripgrep", "gcc", "g++", "ca-certificates"],
+            profile="python",
+            features=["source.search", "toolchain.native", "trust.roots"],
             build_cmd="pip install --quiet -e . || pip install --quiet . || true",
             test_cmd="pytest -q || true",
         )
@@ -387,6 +369,6 @@ class BuildSystemDetector:
         return BuildRecipe(
             system="unknown",
             primary_language="unknown",
-            base_image=DEFAULT_BASE_IMAGES["unknown"],
-            apt_packages=["ripgrep", "ca-certificates"],
+            profile="generic",
+            features=["source.search", "trust.roots"],
         )

--- a/clearwing/sandbox/hunter_sandbox.py
+++ b/clearwing/sandbox/hunter_sandbox.py
@@ -4,7 +4,7 @@ Lifecycle:
     1. SourceHuntRunner instantiates HunterSandbox(repo_path, languages).
     2. .build_image() runs once after preprocessing — produces a tagged image
        with the toolchain, apt deps, and sanitizer flags pre-baked.
-    3. Each hunter agent calls .spawn(session_id) → SandboxContainer with
+    3. Each hunter agent calls .spawn(session_id) → SandboxInstance with
        /workspace mounted read-only and /scratch as a tmpfs scratch dir.
     4. .cleanup() removes spawned containers and (optionally) the image.
 """
@@ -23,20 +23,26 @@ import time
 
 from clearwing.core.events import EventBus
 
+from .backend import (
+    SandboxBackend,
+    SandboxImageBuild,
+    SandboxInstance,
+    sandbox_backend_from_env,
+)
 from .builders import (
     BuildRecipe,
     BuildSystemDetector,
     compute_sanitizer_env,
     validate_sanitizer_combo,
 )
-from .container import SandboxConfig, SandboxContainer
+from .container import SandboxConfig
 from .seccomp_profiles import get_seccomp_profile
 
 logger = logging.getLogger(__name__)
 
 
 class HunterSandbox:
-    """Per-hunt sanitizer-instrumented Docker image and container manager.
+    """Per-hunt sanitizer image and sandbox-instance manager.
 
     Builds an image with the project's build dependencies and ASan/UBSan
     flags, then spawns no-network containers for hunter agents that mount
@@ -75,6 +81,7 @@ class HunterSandbox:
         deep_agent_mode: bool = False,
         post_install_commands: list[str] | None = None,
         default_cpus: float | None = None,
+        backend: SandboxBackend | None = None,
     ):
         self._validate_cpu_limit(default_cpus, name="default_cpus")
         self.repo_path = os.path.abspath(repo_path)
@@ -99,10 +106,19 @@ class HunterSandbox:
             self._optional_packages.extend(self.DEEP_AGENT_OPTIONAL_PACKAGES)
         self.build_recipe = build_recipe or BuildSystemDetector.detect(self.repo_path)
         self._client = None
+        self.backend = (
+            backend
+            if backend is not None
+            else sandbox_backend_from_env(
+                self._get_client,
+                process=subprocess,
+                temporary_directory=tempfile.TemporaryDirectory,
+            )
+        )
         self._image_tag: str | None = None  # primary variant tag
         # Variant image map — {variant_key: image_tag}
         self._variant_images: dict[str, str] = {}
-        self._spawned: list[SandboxContainer] = []
+        self._spawned: list[SandboxInstance] = []
         self._default_cpus = None if default_cpus is None else float(default_cpus)
         self._resolved_default_cpus: float | None = None
         self._available_cpus: float | None = None
@@ -144,16 +160,16 @@ class HunterSandbox:
 
     def _detect_available_cpus(self) -> tuple[float, str]:
         try:
-            daemon_cpus = self._get_client().info().get("NCPU")
+            daemon_cpus, source = self.backend.available_cpus()
             if (
                 isinstance(daemon_cpus, (int, float))
                 and not isinstance(daemon_cpus, bool)
                 and math.isfinite(daemon_cpus)
                 and daemon_cpus > 0
             ):
-                return float(daemon_cpus), "Docker daemon"
+                return float(daemon_cpus), source
         except Exception:
-            logger.debug("Could not query Docker daemon CPU count", exc_info=True)
+            logger.debug("Could not query sandbox backend CPU count", exc_info=True)
 
         try:
             get_affinity = getattr(os, "sched_getaffinity", None)
@@ -229,78 +245,52 @@ class HunterSandbox:
         return "linux/amd64"
 
     def _build_variant_image(self, sanitizers: list[str]) -> str:
-        """Build one sandbox image for the given sanitizer combo.
+        """Prepare one sandbox image for the given sanitizer combo.
 
-        Uses the `docker build` CLI instead of the Python SDK's images.build()
-        because the SDK eagerly resolves ALL credential helpers configured in
-        ~/.docker/config.json. If any helper errors (e.g. docker-credential-gcloud
-        with an expired token), the entire build fails — even though the base
-        image doesn't need that registry. The CLI only authenticates against
-        registries it actually needs to pull from.
+        The default backend uses the ``docker build`` CLI so it only resolves
+        credentials for registries the build actually contacts. External
+        backends receive the same content-addressed Dockerfile build request.
         """
         dockerfile = self._render_dockerfile(sanitizers=sanitizers)
         tag = self._compute_tag(dockerfile, sanitizers=sanitizers)
 
-        # Check cache via CLI — avoids credential helper issues on cache check too
-        from .dind import get_subprocess_env
-
-        docker_env = get_subprocess_env()
-        check = subprocess.run(
-            ["docker", "image", "inspect", tag],
-            capture_output=True, timeout=10, env=docker_env,
+        build = SandboxImageBuild(
+            image=tag,
+            dockerfile=dockerfile,
+            platform=self._target_platform(),
+            timeout_seconds=300,
         )
-        if check.returncode == 0:
+        san_str = ",".join(sanitizers) if sanitizers else "none"
+        logger.info(
+            "Preparing sourcehunt sandbox image %s (backend=%s, sanitizers=%s, platform=%s)",
+            tag,
+            self.backend.name,
+            san_str,
+            build.platform,
+        )
+        EventBus().emit_message(
+            f"sandbox preparing  backend={self.backend.name}  "
+            f"base={self.build_recipe.base_image}  lang={self.build_recipe.primary_language}"
+            f"  sanitizers={san_str}  tag={tag[:16]}",
+            "info",
+        )
+        _t = time.monotonic()
+        try:
+            cached = self.backend.ensure_image(
+                build,
+                on_output=lambda line: EventBus().emit_message(f"sandbox | {line}", "debug"),
+            )
+        except RuntimeError:
+            raise
+        except Exception as e:
+            logger.warning("Sandbox image preparation failed: %s", e)
+            logger.debug("Sandbox image preparation failed", exc_info=True)
+            raise RuntimeError(f"Failed to prepare sandbox image: {e}") from e
+        if cached:
             logger.debug("Reusing sourcehunt sandbox image %s", tag)
             EventBus().emit_message(f"sandbox cached  tag={tag[:16]}", "info")
             return tag
-
-        with tempfile.TemporaryDirectory(prefix="clearwing-sandbox-build-") as build_dir:
-            dockerfile_path = os.path.join(build_dir, "Dockerfile")
-            with open(dockerfile_path, "w", encoding="utf-8") as f:
-                f.write(dockerfile)
-
-            platform_flag = self._target_platform()
-            san_str = ",".join(sanitizers) if sanitizers else "none"
-            logger.info(
-                "Building sourcehunt sandbox image %s (sanitizers=%s, platform=%s)",
-                tag,
-                san_str,
-                platform_flag,
-            )
-            EventBus().emit_message(
-                f"sandbox building  base={self.build_recipe.base_image}  lang={self.build_recipe.primary_language}"
-                f"  sanitizers={san_str}  tag={tag[:16]}",
-                "info",
-            )
-            _t = time.monotonic()
-            try:
-                proc = subprocess.Popen(
-                    ["docker", "build", "--platform", platform_flag, "-t", tag, build_dir],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    text=True,
-                    env=docker_env,
-                )
-                output_lines: list[str] = []
-                assert proc.stdout is not None
-                for line in proc.stdout:
-                    line = line.rstrip()
-                    if line:
-                        output_lines.append(line)
-                        EventBus().emit_message(f"docker | {line}", "debug")
-                proc.wait(timeout=300)
-                if proc.returncode != 0:
-                    raise RuntimeError("\n".join(output_lines[-40:]))
-            except subprocess.TimeoutExpired as e:
-                proc.kill()
-                raise RuntimeError("Sandbox image build timed out after 300s") from e
-            except RuntimeError:
-                raise
-            except Exception as e:
-                logger.warning("Sandbox image build failed: %s", e)
-                logger.debug("Sandbox image build failed", exc_info=True)
-                raise RuntimeError(f"Failed to build sandbox image: {e}") from e
-
+        logger.debug("Prepared sandbox image %s in %.2fs", tag, time.monotonic() - _t)
         EventBus().emit_message(f"sandbox ready  tag={tag[:16]}", "info")
         return tag
 
@@ -314,7 +304,7 @@ class HunterSandbox:
         writable_workspace: bool = False,
         cpus: float | None = None,
         runtime: str | None = None,
-    ) -> SandboxContainer:
+    ) -> SandboxInstance:
         """Start a fresh container from one of the built variant images.
 
         The container has:
@@ -336,7 +326,7 @@ class HunterSandbox:
             cpus: CPU limit. ``None`` uses the manager default, while 0
                 explicitly disables the limit. Passed to SandboxConfig.
 
-        Returns a SandboxContainer ready for exec/write/read.
+        Returns a SandboxInstance ready for exec/write/read.
         """
         if self._image_tag is None:
             self.build_image()
@@ -396,10 +386,12 @@ class HunterSandbox:
             runtime=runtime,
         )
 
-        sb = SandboxContainer(cfg)
+        sb = self.backend.create(cfg)
         _t = time.monotonic()
         sb.start()
-        logger.debug("Sandbox container started image=%s in %.2fs", image_tag, time.monotonic() - _t)
+        logger.debug(
+            "Sandbox container started image=%s in %.2fs", image_tag, time.monotonic() - _t
+        )
 
         if writable_workspace:
             sb.copy_tree_into(self.repo_path, "/workspace")
@@ -450,8 +442,7 @@ class HunterSandbox:
 
         if remove_image and self._image_tag:
             try:
-                client = self._get_client()
-                client.images.remove(self._image_tag, force=True)
+                self.backend.remove_image(self._image_tag)
             except Exception:
                 logger.debug("HunterSandbox image remove failed", exc_info=True)
 

--- a/clearwing/sandbox/hunter_sandbox.py
+++ b/clearwing/sandbox/hunter_sandbox.py
@@ -78,6 +78,7 @@ class HunterSandbox:
         deep_agent_mode: bool = False,
         default_cpus: float | None = None,
         backend: SandboxBackend | None = None,
+        gvisor_runtime: str | None = None,
     ):
         self._validate_cpu_limit(default_cpus, name="default_cpus")
         self.repo_path = os.path.abspath(repo_path)
@@ -101,6 +102,10 @@ class HunterSandbox:
             self._optional_features.extend(self.DEEP_AGENT_OPTIONAL_FEATURES)
         self.build_recipe = build_recipe or BuildSystemDetector.detect(self.repo_path)
         self._client = None
+        # The operator-selected gVisor-compatible runtime that implements
+        # "enhanced" isolation. Preserved as the exact name so spawn() honors
+        # e.g. "kata-runtime" instead of silently falling back to plain runc.
+        self.gvisor_runtime = gvisor_runtime
         self.backend = (
             backend
             if backend is not None
@@ -108,6 +113,7 @@ class HunterSandbox:
                 self._get_client,
                 process=subprocess,
                 temporary_directory=tempfile.TemporaryDirectory,
+                enhanced_runtime=gvisor_runtime or "runsc",
             )
         )
         self._environment_ref: str | None = None

--- a/clearwing/sandbox/hunter_sandbox.py
+++ b/clearwing/sandbox/hunter_sandbox.py
@@ -1,12 +1,13 @@
-"""HunterSandbox: builds and manages a sanitizer-instrumented container per hunt.
+"""HunterSandbox: prepares and manages isolated SourceHunt environments.
 
 Lifecycle:
     1. SourceHuntRunner instantiates HunterSandbox(repo_path, languages).
-    2. .build_image() runs once after preprocessing — produces a tagged image
-       with the toolchain, apt deps, and sanitizer flags pre-baked.
+    2. .prepare_environment() asks the configured backend for the required
+       toolchain, tools, and sanitizer support.
     3. Each hunter agent calls .spawn(session_id) → SandboxInstance with
        /workspace mounted read-only and /scratch as a tmpfs scratch dir.
-    4. .cleanup() removes spawned containers and (optionally) the image.
+    4. .cleanup() removes spawned instances and optionally releases prepared
+       environments.
 """
 
 from __future__ import annotations
@@ -24,9 +25,11 @@ import time
 from clearwing.core.events import EventBus
 
 from .backend import (
+    DockerSandboxBackend,
     SandboxBackend,
-    SandboxImageBuild,
+    SandboxEnvironmentSpec,
     SandboxInstance,
+    SandboxRunConfig,
     sandbox_backend_from_env,
 )
 from .builders import (
@@ -35,40 +38,34 @@ from .builders import (
     compute_sanitizer_env,
     validate_sanitizer_combo,
 )
-from .container import SandboxConfig
-from .seccomp_profiles import get_seccomp_profile
 
 logger = logging.getLogger(__name__)
 
 
 class HunterSandbox:
-    """Per-hunt sanitizer image and sandbox-instance manager.
+    """Per-hunt environment and sandbox-instance manager.
 
-    Builds an image with the project's build dependencies and ASan/UBSan
-    flags, then spawns no-network containers for hunter agents that mount
-    the source tree read-only.
+    Requests a logical toolchain environment with the project's build tools
+    and sanitizer support, then spawns no-network instances that mount the
+    source tree read-only. Providers decide how environments are materialized.
     """
 
     IMAGE_NAME_PREFIX = "clearwing-sourcehunt"
     AUTO_CPU_CAP = 3.0
     MIN_CPU_LIMIT = 0.5
 
-    # Default "extra" variants to build alongside the primary. These let
-    # a single HunterSandbox own both an ASan+UBSan image and an MSan
-    # image, and spawn containers from either one by name.
+    # Default extra variants to prepare alongside the primary. These let one
+    # HunterSandbox own both ASan+UBSan and MSan environments.
     DEFAULT_EXTRA_VARIANTS: tuple[tuple[str, ...], ...] = ()
 
-    DEEP_AGENT_PACKAGES = ["python3", "valgrind", "ccache", "git"]
-    # Packages that are useful but not available on all architectures.
-    # ltrace is x86_64-only (not packaged for arm64 on any Debian release).
-    # Installed in a separate best-effort layer so their absence doesn't
-    # fail the entire image build.
-    DEEP_AGENT_OPTIONAL_PACKAGES = ["ltrace"]
-    EXPLOIT_AGENT_PACKAGES = ["gdb", "python3-pip", "ruby", "binutils"]
-    EXPLOIT_POST_INSTALL = [
-        "pip3 install --break-system-packages pwntools ROPgadget seccomp-tools 2>/dev/null || true",
-        "gem install one_gadget 2>/dev/null || true",
+    DEEP_AGENT_FEATURES = [
+        "runtime.python",
+        "debug.valgrind",
+        "build.ccache",
+        "vcs.git",
     ]
+    # Library-call tracing is useful but unavailable on some architectures.
+    DEEP_AGENT_OPTIONAL_FEATURES = ["trace.library-calls"]
 
     def __init__(
         self,
@@ -76,10 +73,9 @@ class HunterSandbox:
         languages: list[str] | None = None,
         sanitizers: list[str] | None = None,  # primary combo
         extra_variants: list[list[str]] | None = None,  # e.g. [["msan"]]
-        extra_packages: list[str] | None = None,
+        extra_features: list[str] | None = None,
         build_recipe: BuildRecipe | None = None,
         deep_agent_mode: bool = False,
-        post_install_commands: list[str] | None = None,
         default_cpus: float | None = None,
         backend: SandboxBackend | None = None,
     ):
@@ -95,15 +91,14 @@ class HunterSandbox:
         ]
         for v in self.extra_variants:
             validate_sanitizer_combo(v)
-        self.extra_packages = list(extra_packages or [])
-        self._optional_packages: list[str] = []
-        self.post_install_commands = list(post_install_commands or [])
+        self.extra_features = list(extra_features or [])
+        self._optional_features: list[str] = []
         self.deep_agent_mode = deep_agent_mode
         if deep_agent_mode:
-            for pkg in self.DEEP_AGENT_PACKAGES:
-                if pkg not in self.extra_packages:
-                    self.extra_packages.append(pkg)
-            self._optional_packages.extend(self.DEEP_AGENT_OPTIONAL_PACKAGES)
+            for feature in self.DEEP_AGENT_FEATURES:
+                if feature not in self.extra_features:
+                    self.extra_features.append(feature)
+            self._optional_features.extend(self.DEEP_AGENT_OPTIONAL_FEATURES)
         self.build_recipe = build_recipe or BuildSystemDetector.detect(self.repo_path)
         self._client = None
         self.backend = (
@@ -115,9 +110,11 @@ class HunterSandbox:
                 temporary_directory=tempfile.TemporaryDirectory,
             )
         )
-        self._image_tag: str | None = None  # primary variant tag
-        # Variant image map — {variant_key: image_tag}
-        self._variant_images: dict[str, str] = {}
+        self._environment_ref: str | None = None
+        self._variant_environments: dict[str, str] = {}
+        # Compatibility aliases for callers that predate pluggable backends.
+        self._image_tag: str | None = None
+        self._variant_images = self._variant_environments
         self._spawned: list[SandboxInstance] = []
         self._default_cpus = None if default_cpus is None else float(default_cpus)
         self._resolved_default_cpus: float | None = None
@@ -199,100 +196,115 @@ class HunterSandbox:
             self._client = get_docker_client()
         return self._client
 
-    def build_image(self) -> str:
-        """Build the primary sandbox image. Returns its tag.
+    def prepare_environment(self) -> str:
+        """Prepare the primary environment and return its opaque reference.
 
-        Also builds any declared `extra_variants` so subsequent `spawn(variant=)`
-        calls can pick between them without another build pass. MSan is the
-        motivating case: it can't coexist with ASan in a single binary, so
-        the caller declares it as an extra variant.
+        Also prepares declared ``extra_variants`` so later ``spawn`` calls can
+        select them without another preparation pass. MSan is the motivating
+        case: it cannot coexist with ASan in a single instrumented binary.
         """
         primary_key = self._variant_key(self.sanitizers)
-        primary_tag = self._build_variant_image(self.sanitizers)
-        self._variant_images[primary_key] = primary_tag
-        self._image_tag = primary_tag
+        primary_ref = self._prepare_variant_environment(self.sanitizers)
+        self._variant_environments[primary_key] = primary_ref
+        self._environment_ref = primary_ref
+        self._image_tag = primary_ref
 
         for variant in self.extra_variants:
             key = self._variant_key(variant)
             if key == primary_key:
-                continue  # already built
-            tag = self._build_variant_image(variant)
-            self._variant_images[key] = tag
+                continue
+            environment_ref = self._prepare_variant_environment(variant)
+            self._variant_environments[key] = environment_ref
 
-        return primary_tag
+        return primary_ref
+
+    def build_image(self) -> str:
+        """Compatibility alias for :meth:`prepare_environment`."""
+
+        return self.prepare_environment()
+
+    def prepare_variant_environments(self) -> dict[str, str]:
+        """Prepare every declared variant and return opaque references.
+
+        Providers may satisfy an equivalent request from their own cache.
+        """
+        self.prepare_environment()
+        return dict(self._variant_environments)
 
     def build_variant_images(self) -> dict[str, str]:
-        """Build every declared variant. Returns {variant_key: image_tag}.
+        """Compatibility alias for :meth:`prepare_variant_environments`."""
 
-        Idempotent — variants that are already built (cached by content hash
-        in the docker daemon) just get re-tagged without rebuilding.
-        """
-        self.build_image()
-        return dict(self._variant_images)
+        return self.prepare_variant_environments()
 
-    def _target_platform(self) -> str:
-        """Docker platform string for builds.
-
-        C/C++ toolchains (gcc, valgrind, sanitizers) run painfully slow under
-        qemu on Apple Silicon and occasionally miscompile. Use native arm64 for
-        those languages; pin amd64 for everything else for reproducibility.
-        """
-        import platform as _plat
-
-        lang = (self.build_recipe.primary_language or "").lower()
-        if lang in ("c", "cpp", "c++") and _plat.machine() in ("arm64", "aarch64"):
-            return "linux/arm64"
-        return "linux/amd64"
-
-    def _build_variant_image(self, sanitizers: list[str]) -> str:
-        """Prepare one sandbox image for the given sanitizer combo.
-
-        The default backend uses the ``docker build`` CLI so it only resolves
-        credentials for registries the build actually contacts. External
-        backends receive the same content-addressed Dockerfile build request.
-        """
-        dockerfile = self._render_dockerfile(sanitizers=sanitizers)
-        tag = self._compute_tag(dockerfile, sanitizers=sanitizers)
-
-        build = SandboxImageBuild(
-            image=tag,
-            dockerfile=dockerfile,
-            platform=self._target_platform(),
-            timeout_seconds=300,
+    def _environment_spec(self, sanitizers: list[str]) -> SandboxEnvironmentSpec:
+        environment = compute_sanitizer_env(self.build_recipe, sanitizers)
+        features = list(dict.fromkeys([*self.build_recipe.features, *self.extra_features]))
+        optional_features = list(dict.fromkeys(self._optional_features))
+        identity = {
+            "profile": self.build_recipe.profile,
+            "features": sorted(features),
+            "optional_features": sorted(optional_features),
+            "sanitizers": sorted(sanitizers),
+            "environment": environment,
+        }
+        cache_key = hashlib.sha256(
+            json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        return SandboxEnvironmentSpec(
+            cache_key=cache_key,
+            profile=self.build_recipe.profile,
+            features=features,
+            optional_features=optional_features,
+            sanitizers=list(sanitizers),
+            environment=environment,
         )
+
+    def _prepare_variant_environment(self, sanitizers: list[str]) -> str:
+        """Prepare one logical environment for a sanitizer combination."""
+
+        spec = self._environment_spec(sanitizers)
         san_str = ",".join(sanitizers) if sanitizers else "none"
         logger.info(
-            "Preparing sourcehunt sandbox image %s (backend=%s, sanitizers=%s, platform=%s)",
-            tag,
+            "Preparing SourceHunt environment %s (backend=%s, profile=%s, sanitizers=%s)",
+            spec.cache_key[:16],
             self.backend.name,
+            spec.profile,
             san_str,
-            build.platform,
         )
         EventBus().emit_message(
             f"sandbox preparing  backend={self.backend.name}  "
-            f"base={self.build_recipe.base_image}  lang={self.build_recipe.primary_language}"
-            f"  sanitizers={san_str}  tag={tag[:16]}",
+            f"profile={spec.profile}  lang={self.build_recipe.primary_language}"
+            f"  sanitizers={san_str}  key={spec.cache_key[:16]}",
             "info",
         )
         _t = time.monotonic()
         try:
-            cached = self.backend.ensure_image(
-                build,
+            environment = self.backend.ensure_environment(
+                spec,
                 on_output=lambda line: EventBus().emit_message(f"sandbox | {line}", "debug"),
             )
         except RuntimeError:
             raise
         except Exception as e:
-            logger.warning("Sandbox image preparation failed: %s", e)
-            logger.debug("Sandbox image preparation failed", exc_info=True)
-            raise RuntimeError(f"Failed to prepare sandbox image: {e}") from e
-        if cached:
-            logger.debug("Reusing sourcehunt sandbox image %s", tag)
-            EventBus().emit_message(f"sandbox cached  tag={tag[:16]}", "info")
-            return tag
-        logger.debug("Prepared sandbox image %s in %.2fs", tag, time.monotonic() - _t)
-        EventBus().emit_message(f"sandbox ready  tag={tag[:16]}", "info")
-        return tag
+            logger.warning("Sandbox environment preparation failed: %s", e)
+            logger.debug("Sandbox environment preparation failed", exc_info=True)
+            raise RuntimeError(f"Failed to prepare sandbox environment: {e}") from e
+        if environment.cached:
+            logger.debug("Reusing SourceHunt environment %s", environment.reference)
+            EventBus().emit_message(f"sandbox cached  key={spec.cache_key[:16]}", "info")
+            return environment.reference
+        logger.debug(
+            "Prepared SourceHunt environment %s in %.2fs",
+            environment.reference,
+            time.monotonic() - _t,
+        )
+        EventBus().emit_message(f"sandbox ready  key={spec.cache_key[:16]}", "info")
+        return environment.reference
+
+    def _build_variant_image(self, sanitizers: list[str]) -> str:
+        """Compatibility alias for the pre-provider image implementation."""
+
+        return self._prepare_variant_environment(sanitizers)
 
     def spawn(
         self,
@@ -305,7 +317,7 @@ class HunterSandbox:
         cpus: float | None = None,
         runtime: str | None = None,
     ) -> SandboxInstance:
-        """Start a fresh container from one of the built variant images.
+        """Start a fresh sandbox from one of the prepared environments.
 
         The container has:
             - /workspace mounted read-only from self.repo_path (default),
@@ -318,8 +330,8 @@ class HunterSandbox:
         Args:
             variant: Sanitizer combo for the spawned container. Defaults to
                 self.sanitizers (the primary combo). Must have been built
-                via `build_image()` or listed in `extra_variants`. Pass e.g.
-                `variant=["msan"]` to spawn from the MSan image.
+                via ``prepare_environment()`` or listed in ``extra_variants``.
+                Pass e.g. ``variant=["msan"]`` to select the MSan environment.
             writable_workspace: If True, copy the source tree into the
                 container instead of bind-mounting it read-only. The agent
                 can then modify source, recompile, and use git diff.
@@ -328,21 +340,21 @@ class HunterSandbox:
 
         Returns a SandboxInstance ready for exec/write/read.
         """
-        if self._image_tag is None:
-            self.build_image()
+        if self._environment_ref is None:
+            self.prepare_environment()
 
         chosen = list(variant) if variant is not None else list(self.sanitizers)
         key = self._variant_key(chosen)
-        image_tag = self._variant_images.get(key)
-        if image_tag is None:
-            # Auto-build on demand if the caller asks for a variant that
+        environment_ref = self._variant_environments.get(key)
+        if environment_ref is None:
+            # Prepare on demand if the caller asks for a variant that
             # wasn't declared up front.
             try:
                 validate_sanitizer_combo(chosen)
             except ValueError:
                 raise
-            image_tag = self._build_variant_image(chosen)
-            self._variant_images[key] = image_tag
+            environment_ref = self._prepare_variant_environment(chosen)
+            self._variant_environments[key] = environment_ref
 
         # Build mounts list
         mounts: list[tuple[str, str, str]] = []
@@ -357,40 +369,29 @@ class HunterSandbox:
         env = compute_sanitizer_env(self.build_recipe, chosen)
         if session_id:
             env["CLEARWING_SESSION_ID"] = session_id
-        # Mark the variant so hunter tools can introspect which image is running
+        # Mark the variant so hunter tools can introspect the active instrumentation.
         env["CLEARWING_SANITIZER_VARIANT"] = ",".join(chosen)
 
-        # Docker's Python SDK passes security_opt values directly to the
-        # Engine API, which expects seccomp content to be inline JSON — not
-        # a path (unlike the `docker run` CLI, which reads the file client-
-        # side). Passing a path makes the daemon reject the request with
-        # "Decoding seccomp profile failed: invalid character '/'..."
-        seccomp_json = json.dumps(get_seccomp_profile("hunter"))
-
         resolved_cpus = self._resolve_cpu_limit(cpus)
-        cfg = SandboxConfig(
-            image=image_tag,
-            network_mode="none",
+        cfg = SandboxRunConfig(
+            policy="sourcehunt",
+            isolation="enhanced" if runtime else "default",
             mounts=mounts,
             memory_mb=memory_mb,
-            cpu_shares=1024,
             cpus=resolved_cpus,
             timeout_seconds=timeout_seconds,
             env=env,
             working_dir="/workspace",
-            name=None,
             pids_limit=512,
-            security_opt=[f"seccomp={seccomp_json}"],
-            cap_drop=["ALL"],
-            cap_add=["SYS_PTRACE"],
-            runtime=runtime,
         )
 
-        sb = self.backend.create(cfg)
+        sb = self.backend.create(environment_ref, cfg)
         _t = time.monotonic()
         sb.start()
         logger.debug(
-            "Sandbox container started image=%s in %.2fs", image_tag, time.monotonic() - _t
+            "Sandbox instance started environment=%s in %.2fs",
+            environment_ref,
+            time.monotonic() - _t,
         )
 
         if writable_workspace:
@@ -419,14 +420,19 @@ class HunterSandbox:
 
     @property
     def available_variants(self) -> list[list[str]]:
-        """Return every sanitizer combo that has a built image."""
+        """Return every sanitizer combo that has a prepared environment."""
         out: list[list[str]] = []
-        for key in self._variant_images.keys():
+        for key in self._variant_environments.keys():
             out.append(key.split("+") if key else [])
         return out
 
     def cleanup(self, remove_image: bool = False) -> None:
-        """Stop all spawned containers and optionally remove the image."""
+        """Stop instances and optionally release their environments.
+
+        ``remove_image`` is retained as a compatibility name. A non-Docker
+        provider may release an overlay, pod template, or another cached
+        substrate instead of an OCI image.
+        """
         for sb in self._spawned:
             try:
                 sb.stop()
@@ -440,11 +446,12 @@ class HunterSandbox:
                     pass
         self._spawned.clear()
 
-        if remove_image and self._image_tag:
-            try:
-                self.backend.remove_image(self._image_tag)
-            except Exception:
-                logger.debug("HunterSandbox image remove failed", exc_info=True)
+        if remove_image:
+            for environment_ref in set(self._variant_environments.values()):
+                try:
+                    self.backend.release_environment(environment_ref)
+                except Exception:
+                    logger.debug("HunterSandbox environment release failed", exc_info=True)
 
     # --- Context manager ----------------------------------------------------
 
@@ -455,95 +462,34 @@ class HunterSandbox:
         self.cleanup()
         return False
 
-    # --- Dockerfile rendering -----------------------------------------------
+    # --- Compatibility helpers for the original Docker-only API -------------
 
     def _render_dockerfile(self, sanitizers: list[str] | None = None) -> str:
-        """Render the Dockerfile for a specific sanitizer variant.
+        """Render the default Docker adapter's private materialization."""
 
-        When `sanitizers` is None the primary combo is used — which is what
-        the old single-variant build_image() called.
-        """
-        recipe = self.build_recipe
         variant = sanitizers if sanitizers is not None else self.sanitizers
-        # Compute the env block for THIS variant (not the recipe's default)
-        env_dict = compute_sanitizer_env(recipe, variant)
-
-        apt_packages = " ".join(recipe.apt_packages + self.extra_packages)
-        env_lines = []
-        for k, v in env_dict.items():
-            if " " in v or '"' in v:
-                v_escaped = v.replace('"', '\\"')
-                env_lines.append(f'ENV {k}="{v_escaped}"')
-            else:
-                env_lines.append(f"ENV {k}={v}")
-        env_block = "\n".join(env_lines)
-
-        if apt_packages.strip():
-            apt_block = (
-                "RUN apt-get update -qq && "
-                f"DEBIAN_FRONTEND=noninteractive apt-get install -y -qq {apt_packages} && "
-                "rm -rf /var/lib/apt/lists/*"
-            )
-        else:
-            apt_block = "# (no apt packages)"
-
-        # Optional packages: installed best-effort (e.g. ltrace is missing on
-        # arm64/bookworm). Separate layer so a missing package doesn't fail the
-        # entire build.
-        optional_apt_block = ""
-        if self._optional_packages:
-            opt_list = " ".join(self._optional_packages)
-            optional_apt_block = (
-                f"RUN apt-get update -qq && "
-                f"DEBIAN_FRONTEND=noninteractive apt-get install -y -qq {opt_list} 2>/dev/null || true ; "
-                f"rm -rf /var/lib/apt/lists/*"
-            )
-
-        post_install_block = ""
-        if self.post_install_commands:
-            post_install_block = "\n".join(f"RUN {cmd}" for cmd in self.post_install_commands)
-
-        # Variant header makes the Dockerfile self-documenting so a human
-        # inspecting the built image via `docker history` knows what's in it
-        variant_header = f"# Sanitizer variant: {','.join(variant)}"
-        dockerfile = f"""FROM {recipe.base_image}
-
-{variant_header}
-
-{apt_block}
-
-{optional_apt_block}
-
-{post_install_block}
-
-{env_block}
-
-WORKDIR /workspace
-
-# /scratch is mounted at runtime as a writable tmpfs
-RUN mkdir -p /scratch
-"""
-        return dockerfile
+        docker_backend = (
+            self.backend
+            if isinstance(self.backend, DockerSandboxBackend)
+            else DockerSandboxBackend()
+        )
+        return docker_backend._render_dockerfile(self._environment_spec(variant))
 
     def _compute_tag(
         self,
         dockerfile: str,
         sanitizers: list[str] | None = None,
     ) -> str:
-        """Content-addressed image tag.
+        """Return the default Docker adapter's content-addressed tag."""
 
-        The sanitizer list is baked into the hash so every variant gets a
-        distinct tag — otherwise the daemon would cache-collide when the
-        same repo is built with ASan+UBSan AND MSan variants.
-        """
+        del dockerfile  # Dockerfile content is no longer the logical identity.
         variant = sanitizers if sanitizers is not None else self.sanitizers
-        h = hashlib.sha256()
-        h.update(dockerfile.encode("utf-8"))
-        h.update(",".join(sorted(variant)).encode("utf-8"))
-        h.update(",".join(sorted(self.extra_packages)).encode("utf-8"))
-        h.update("\n".join(self.post_install_commands).encode("utf-8"))
-        digest = h.hexdigest()[:12]
-        return f"{self.IMAGE_NAME_PREFIX}:{digest}"
+        docker_backend = (
+            self.backend
+            if isinstance(self.backend, DockerSandboxBackend)
+            else DockerSandboxBackend()
+        )
+        return docker_backend._environment_image(self._environment_spec(variant))
 
     @staticmethod
     def _variant_key(sanitizers: list[str]) -> str:
@@ -553,6 +499,10 @@ RUN mkdir -p /scratch
     @property
     def image_tag(self) -> str | None:
         return self._image_tag
+
+    @property
+    def environment_ref(self) -> str | None:
+        return self._environment_ref
 
     @property
     def primary_language(self) -> str:

--- a/clearwing/sandbox/registry.py
+++ b/clearwing/sandbox/registry.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 class ContainerRegistry:
-    """Process-wide registry of live SandboxContainer instances."""
+    """Process-wide registry of live sandbox instances."""
 
     _instance: ContainerRegistry | None = None
     _init_lock = threading.Lock()

--- a/clearwing/sandbox/rpc_backend.py
+++ b/clearwing/sandbox/rpc_backend.py
@@ -44,6 +44,16 @@ class _PendingCall:
     failure: BaseException | None = None
 
 
+class _FrameError(Exception):
+    """A single response frame was malformed but the stream stayed in sync.
+
+    Raised while dispatching one complete, newline-terminated frame. Because
+    the frame boundary was intact, the reader can discard just this frame (and
+    fail at most the one matching call) and keep serving every other worker on
+    the shared connection.
+    """
+
+
 class JsonRpcConnection:
     """Thread-safe JSON-RPC 2.0 client over one full-duplex stream.
 
@@ -58,7 +68,10 @@ class JsonRpcConnection:
         self.endpoint = endpoint
         self.max_message_bytes = max_message_bytes
         self._socket = _connect(endpoint)
-        self._reader = self._socket.makefile("rb", buffering=0)
+        # Buffered reader: an unbuffered SocketIO makes readline() issue one
+        # recv() per byte (no peek), so a single large response would pin the
+        # shared reader thread for seconds and stall every concurrent worker.
+        self._reader = self._socket.makefile("rb")
         self._ids = itertools.count(1)
         self._write_lock = threading.Lock()
         self._state_lock = threading.Lock()
@@ -92,6 +105,11 @@ class JsonRpcConnection:
         encoded = json.dumps(request, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
         if len(encoded) + 1 > self.max_message_bytes:
             raise SandboxRpcError("sandbox RPC request exceeds the message limit")
+        # A non-positive timeout can never wait for a response, so report it
+        # before writing the request: otherwise the backend would still run the
+        # method's side effects for a call the caller has already given up on.
+        if timeout is not None and timeout <= 0:
+            raise SandboxRpcError(f"sandbox RPC method {method!r} timed out")
         pending = _PendingCall(threading.Event())
         with self._state_lock:
             if self._closed is not None:
@@ -105,10 +123,6 @@ class JsonRpcConnection:
                 self._pending.pop(request_id, None)
             self._fail_connection(error)
             raise SandboxRpcError("sandbox RPC write failed") from error
-        if timeout is not None and timeout <= 0:
-            with self._state_lock:
-                self._pending.pop(request_id, None)
-            raise SandboxRpcError(f"sandbox RPC method {method!r} timed out")
         if not pending.ready.wait(timeout):
             with self._state_lock:
                 self._pending.pop(request_id, None)
@@ -132,19 +146,13 @@ class JsonRpcConnection:
         return response["result"]
 
     def close(self) -> None:
-        with self._close_lock:
-            if self._resources_closed:
-                return
-            self._resources_closed = True
-            self._fail_connection(ConnectionError("sandbox RPC connection was closed"))
-            try:
-                self._socket.shutdown(socket.SHUT_RDWR)
-            except OSError:
-                pass
-            self._socket.close()
-            if threading.current_thread() is not self._reader_thread:
-                self._reader_thread.join(timeout=1)
-            self._reader.close()
+        self._fail_connection(ConnectionError("sandbox RPC connection was closed"))
+        if threading.current_thread() is not self._reader_thread:
+            # The shutdown() in _fail_connection unblocks the reader; wait for
+            # it to run its teardown so the descriptor is released before we
+            # return (belt-and-suspenders _close_resources below is idempotent).
+            self._reader_thread.join(timeout=1)
+        self._close_resources()
 
     @property
     def is_closed(self) -> bool:
@@ -158,27 +166,70 @@ class JsonRpcConnection:
                 if not encoded:
                     raise ConnectionError("sandbox RPC peer closed the connection")
                 if len(encoded) > self.max_message_bytes or not encoded.endswith(b"\n"):
-                    raise SandboxRpcError("sandbox RPC response exceeds the message limit")
-                try:
-                    response = json.loads(encoded)
-                except (UnicodeDecodeError, json.JSONDecodeError) as error:
-                    raise SandboxRpcError("sandbox RPC response is not valid JSON") from error
-                if not isinstance(response, dict) or response.get("jsonrpc") != "2.0":
-                    raise SandboxRpcError("sandbox RPC response is not JSON-RPC 2.0")
-                request_id = response.get("id")
-                if not isinstance(request_id, int) or isinstance(request_id, bool):
-                    raise SandboxRpcError("sandbox RPC response has an invalid id")
-                if ("result" in response) == ("error" in response):
-                    raise SandboxRpcError("sandbox RPC response must contain result or error")
-                with self._state_lock:
-                    pending = self._pending.pop(request_id, None)
-                if pending is None:
-                    # A late response after a caller timeout is safe to discard.
+                    # Oversized/unterminated frame: the newline-delimited stream
+                    # is desynced. Discard to the next boundary and keep serving
+                    # every other worker instead of tearing down the shared
+                    # connection over one giant response. _drain_to_boundary
+                    # raises on EOF, which does end the connection.
+                    logger.warning(
+                        "sandbox RPC response exceeded %d bytes; discarding and resyncing",
+                        self.max_message_bytes,
+                    )
+                    self._drain_to_boundary()
                     continue
-                pending.response = response
-                pending.ready.set()
+                # A complete, newline-terminated frame keeps the stream in sync
+                # regardless of its contents, so a malformed one fails at most
+                # its matching call — never the connection.
+                try:
+                    self._dispatch_frame(encoded)
+                except _FrameError as error:
+                    logger.warning("discarding malformed sandbox RPC response: %s", error)
         except BaseException as error:  # noqa: BLE001 - wake every blocked caller
             self._fail_connection(error)
+        finally:
+            # The reader thread owns teardown of the reader/socket: doing it
+            # here (rather than from another thread that may race a blocked
+            # readline) frees the descriptor on every failure path, not just
+            # the explicit close() path.
+            self._close_resources()
+
+    def _dispatch_frame(self, encoded: bytes) -> None:
+        try:
+            response = json.loads(encoded)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise _FrameError("response is not valid JSON") from error
+        if not isinstance(response, dict) or response.get("jsonrpc") != "2.0":
+            raise _FrameError("response is not JSON-RPC 2.0")
+        request_id = response.get("id")
+        if not isinstance(request_id, int) or isinstance(request_id, bool):
+            raise _FrameError("response has an invalid id")
+        with self._state_lock:
+            pending = self._pending.pop(request_id, None)
+        if pending is None:
+            # A late response after a caller timeout is safe to discard.
+            return
+        if ("result" in response) == ("error" in response):
+            # Well-framed but invalid: fail just this call so the caller gets a
+            # definitive error rather than blocking until its timeout.
+            pending.failure = SandboxRpcError(
+                "sandbox RPC response must contain result or error"
+            )
+            pending.ready.set()
+            return
+        pending.response = response
+        pending.ready.set()
+
+    def _drain_to_boundary(self) -> None:
+        # Discard the remainder of an oversized frame up to (and including) the
+        # next newline. Reads are bounded per iteration; the total is bounded by
+        # the frame the trusted supervisor actually sent. EOF mid-drain means
+        # the peer is gone, which does fail the connection.
+        while True:
+            chunk = self._reader.readline(self.max_message_bytes + 1)
+            if not chunk:
+                raise ConnectionError("sandbox RPC peer closed the connection")
+            if chunk.endswith(b"\n"):
+                return
 
     def _fail_connection(self, error: BaseException) -> None:
         with self._state_lock:
@@ -189,6 +240,32 @@ class JsonRpcConnection:
         for call in pending:
             call.failure = error
             call.ready.set()
+        # Wake a reader blocked in readline() so it exits and runs its teardown.
+        # Safe from any thread and when the socket is already closed.
+        try:
+            self._socket.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+
+    def _close_resources(self) -> None:
+        with self._close_lock:
+            if self._resources_closed:
+                return
+            self._resources_closed = True
+        # Close the makefile and the socket. makefile() reference-counts the
+        # descriptor, so both must close for the fd to actually be released.
+        try:
+            self._socket.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            self._reader.close()
+        except OSError:
+            pass
+        try:
+            self._socket.close()
+        except OSError:
+            pass
 
 
 def _connect(endpoint: str) -> socket.socket:

--- a/clearwing/sandbox/rpc_backend.py
+++ b/clearwing/sandbox/rpc_backend.py
@@ -7,7 +7,6 @@ import binascii
 import itertools
 import json
 import logging
-import os
 import socket
 import threading
 from collections.abc import Callable
@@ -15,8 +14,13 @@ from dataclasses import asdict, dataclass
 from typing import Any
 from urllib.parse import urlsplit
 
-from .backend import SandboxImageBuild, SandboxInstance
-from .container import ExecResult, SandboxConfig
+from .backend import (
+    SandboxEnvironment,
+    SandboxEnvironmentSpec,
+    SandboxInstance,
+    SandboxRunConfig,
+)
+from .container import ExecResult
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +49,9 @@ class JsonRpcConnection:
 
     Each message is a UTF-8 JSON object followed by a newline.  Calls are
     multiplexed by JSON-RPC id, so parallel SourceHunt workers do not serialize
-    their sandbox commands.  ``fd://N`` must name an already-connected Unix
-    stream socket; a one-way pipe is intentionally rejected.
+    their sandbox commands. ``fd://N`` transfers ownership of an
+    already-connected Unix stream socket to this connection; a one-way pipe is
+    intentionally rejected.
     """
 
     def __init__(self, endpoint: str, *, max_message_bytes: int = _MAX_RPC_BYTES):
@@ -206,12 +211,10 @@ def _connect(endpoint: str) -> socket.socket:
         descriptor_text = parsed.netloc or parsed.path.lstrip("/")
         if not descriptor_text.isdigit() or int(descriptor_text) < 3:
             raise ValueError("fd sandbox endpoint must name a descriptor of at least 3")
-        duplicate = os.dup(int(descriptor_text))
         try:
-            connection = socket.socket(fileno=duplicate)
-        except BaseException:
-            os.close(duplicate)
-            raise
+            connection = socket.socket(fileno=int(descriptor_text))
+        except OSError as error:
+            raise ValueError("fd sandbox endpoint must name a socket") from error
         if (
             connection.family != socket.AF_UNIX
             or connection.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE) != socket.SOCK_STREAM
@@ -279,46 +282,62 @@ class SocketSandboxBackend:
             raise SandboxRpcError("sandbox.capacity returned invalid source")
         return (float(cpus) if cpus is not None else None), source
 
-    def ensure_image(
+    def ensure_environment(
         self,
-        build: SandboxImageBuild,
+        spec: SandboxEnvironmentSpec,
         on_output: Callable[[str], None] | None = None,
-    ) -> bool:
+    ) -> SandboxEnvironment:
         self._check_capabilities()
         result = _object(
             self._connection.call(
-                "sandbox.image.ensure",
-                {"build": asdict(build)},
-                timeout=build.timeout_seconds + 30,
+                "sandbox.environment.ensure",
+                {"spec": asdict(spec)},
+                timeout=spec.timeout_seconds + 30,
             ),
-            "sandbox.image.ensure",
+            "sandbox.environment.ensure",
         )
+        environment_ref = result.get("environment_ref")
+        if not isinstance(environment_ref, str) or not environment_ref:
+            raise SandboxRpcError("sandbox.environment.ensure returned an invalid environment_ref")
         cached = result.get("cached")
         if not isinstance(cached, bool):
-            raise SandboxRpcError("sandbox.image.ensure returned invalid cached state")
+            raise SandboxRpcError("sandbox.environment.ensure returned invalid cached state")
         output = result.get("output", [])
         if not isinstance(output, list) or any(not isinstance(line, str) for line in output):
-            raise SandboxRpcError("sandbox.image.ensure returned invalid output")
+            raise SandboxRpcError("sandbox.environment.ensure returned invalid output")
         if on_output is not None:
             for line in output:
                 on_output(line)
-        return cached
+        return SandboxEnvironment(environment_ref, cached)
 
-    def create(self, config: SandboxConfig) -> SandboxInstance:
+    def create(
+        self,
+        environment_ref: str,
+        config: SandboxRunConfig,
+    ) -> SandboxInstance:
         self._check_capabilities()
-        return SocketSandboxInstance(self._connection, config)
+        return SocketSandboxInstance(self._connection, environment_ref, config)
 
-    def remove_image(self, image: str) -> None:
+    def release_environment(self, environment_ref: str) -> None:
         self._check_capabilities()
-        self._connection.call("sandbox.image.remove", {"image": image})
+        self._connection.call(
+            "sandbox.environment.release",
+            {"environment_ref": environment_ref},
+        )
 
 
 class SocketSandboxInstance:
     """``SandboxInstance`` implemented by the JSON-RPC backend."""
 
-    def __init__(self, connection: JsonRpcConnection, config: SandboxConfig):
+    def __init__(
+        self,
+        connection: JsonRpcConnection,
+        environment_ref: str,
+        config: SandboxRunConfig,
+    ):
         self.config = config
         self._connection = connection
+        self._environment_ref = environment_ref
         self._sandbox_id: str | None = None
         self._short_id: str | None = None
         self.scratch_host_dir: str | None = None
@@ -329,7 +348,13 @@ class SocketSandboxInstance:
         if self._sandbox_id is not None:
             return self._sandbox_id
         result = _object(
-            self._connection.call("sandbox.start", {"config": asdict(self.config)}),
+            self._connection.call(
+                "sandbox.start",
+                {
+                    "environment_ref": self._environment_ref,
+                    "config": asdict(self.config),
+                },
+            ),
             "sandbox.start",
         )
         sandbox_id = result.get("sandbox_id")

--- a/clearwing/sandbox/rpc_backend.py
+++ b/clearwing/sandbox/rpc_backend.py
@@ -1,0 +1,492 @@
+"""JSON-RPC sandbox backend over Unix sockets or inherited descriptors."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import itertools
+import json
+import logging
+import os
+import socket
+import threading
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+from .backend import SandboxImageBuild, SandboxInstance
+from .container import ExecResult, SandboxConfig
+
+logger = logging.getLogger(__name__)
+
+_MAX_RPC_BYTES = 16 * 1024 * 1024
+_DEFAULT_CALL_TIMEOUT = 30.0
+
+
+class SandboxRpcError(RuntimeError):
+    """A transport or remote JSON-RPC failure."""
+
+    def __init__(self, message: str, *, code: int | None = None, data: Any = None):
+        super().__init__(message)
+        self.code = code
+        self.data = data
+
+
+@dataclass
+class _PendingCall:
+    ready: threading.Event
+    response: dict[str, Any] | None = None
+    failure: BaseException | None = None
+
+
+class JsonRpcConnection:
+    """Thread-safe JSON-RPC 2.0 client over one full-duplex stream.
+
+    Each message is a UTF-8 JSON object followed by a newline.  Calls are
+    multiplexed by JSON-RPC id, so parallel SourceHunt workers do not serialize
+    their sandbox commands.  ``fd://N`` must name an already-connected Unix
+    stream socket; a one-way pipe is intentionally rejected.
+    """
+
+    def __init__(self, endpoint: str, *, max_message_bytes: int = _MAX_RPC_BYTES):
+        self.endpoint = endpoint
+        self.max_message_bytes = max_message_bytes
+        self._socket = _connect(endpoint)
+        self._reader = self._socket.makefile("rb", buffering=0)
+        self._ids = itertools.count(1)
+        self._write_lock = threading.Lock()
+        self._state_lock = threading.Lock()
+        self._close_lock = threading.Lock()
+        self._pending: dict[int, _PendingCall] = {}
+        self._closed: BaseException | None = None
+        self._resources_closed = False
+        self._reader_thread = threading.Thread(
+            target=self._read_responses,
+            name="clearwing-sandbox-rpc",
+            daemon=True,
+        )
+        self._reader_thread.start()
+
+    def call(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        *,
+        timeout: float | None = _DEFAULT_CALL_TIMEOUT,
+    ) -> Any:
+        if not method or any(character.isspace() for character in method):
+            raise ValueError("JSON-RPC method must be a non-empty token")
+        request_id = next(self._ids)
+        request = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params or {},
+        }
+        encoded = json.dumps(request, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        if len(encoded) + 1 > self.max_message_bytes:
+            raise SandboxRpcError("sandbox RPC request exceeds the message limit")
+        pending = _PendingCall(threading.Event())
+        with self._state_lock:
+            if self._closed is not None:
+                raise SandboxRpcError("sandbox RPC connection is closed") from self._closed
+            self._pending[request_id] = pending
+        try:
+            with self._write_lock:
+                self._socket.sendall(encoded + b"\n")
+        except OSError as error:
+            with self._state_lock:
+                self._pending.pop(request_id, None)
+            self._fail_connection(error)
+            raise SandboxRpcError("sandbox RPC write failed") from error
+        if timeout is not None and timeout <= 0:
+            with self._state_lock:
+                self._pending.pop(request_id, None)
+            raise SandboxRpcError(f"sandbox RPC method {method!r} timed out")
+        if not pending.ready.wait(timeout):
+            with self._state_lock:
+                self._pending.pop(request_id, None)
+            raise SandboxRpcError(f"sandbox RPC method {method!r} timed out")
+        if pending.failure is not None:
+            raise SandboxRpcError("sandbox RPC connection failed") from pending.failure
+        response = pending.response
+        if response is None:
+            raise SandboxRpcError("sandbox RPC response is missing")
+        remote_error = response.get("error")
+        if remote_error is not None:
+            if not isinstance(remote_error, dict):
+                raise SandboxRpcError("sandbox RPC returned an invalid error")
+            message = remote_error.get("message")
+            code = remote_error.get("code")
+            if not isinstance(message, str) or not isinstance(code, int) or isinstance(code, bool):
+                raise SandboxRpcError("sandbox RPC returned an invalid error")
+            raise SandboxRpcError(message, code=code, data=remote_error.get("data"))
+        if "result" not in response:
+            raise SandboxRpcError("sandbox RPC response has no result")
+        return response["result"]
+
+    def close(self) -> None:
+        with self._close_lock:
+            if self._resources_closed:
+                return
+            self._resources_closed = True
+            self._fail_connection(ConnectionError("sandbox RPC connection was closed"))
+            try:
+                self._socket.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            self._socket.close()
+            if threading.current_thread() is not self._reader_thread:
+                self._reader_thread.join(timeout=1)
+            self._reader.close()
+
+    @property
+    def is_closed(self) -> bool:
+        with self._state_lock:
+            return self._closed is not None
+
+    def _read_responses(self) -> None:
+        try:
+            while True:
+                encoded = self._reader.readline(self.max_message_bytes + 1)
+                if not encoded:
+                    raise ConnectionError("sandbox RPC peer closed the connection")
+                if len(encoded) > self.max_message_bytes or not encoded.endswith(b"\n"):
+                    raise SandboxRpcError("sandbox RPC response exceeds the message limit")
+                try:
+                    response = json.loads(encoded)
+                except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                    raise SandboxRpcError("sandbox RPC response is not valid JSON") from error
+                if not isinstance(response, dict) or response.get("jsonrpc") != "2.0":
+                    raise SandboxRpcError("sandbox RPC response is not JSON-RPC 2.0")
+                request_id = response.get("id")
+                if not isinstance(request_id, int) or isinstance(request_id, bool):
+                    raise SandboxRpcError("sandbox RPC response has an invalid id")
+                if ("result" in response) == ("error" in response):
+                    raise SandboxRpcError("sandbox RPC response must contain result or error")
+                with self._state_lock:
+                    pending = self._pending.pop(request_id, None)
+                if pending is None:
+                    # A late response after a caller timeout is safe to discard.
+                    continue
+                pending.response = response
+                pending.ready.set()
+        except BaseException as error:  # noqa: BLE001 - wake every blocked caller
+            self._fail_connection(error)
+
+    def _fail_connection(self, error: BaseException) -> None:
+        with self._state_lock:
+            if self._closed is None:
+                self._closed = error
+            pending = list(self._pending.values())
+            self._pending.clear()
+        for call in pending:
+            call.failure = error
+            call.ready.set()
+
+
+def _connect(endpoint: str) -> socket.socket:
+    parsed = urlsplit(endpoint)
+    if parsed.scheme == "unix":
+        if parsed.netloc or parsed.query or parsed.fragment or not parsed.path.startswith("/"):
+            raise ValueError("unix sandbox endpoint must contain one absolute socket path")
+        connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            connection.connect(parsed.path)
+        except BaseException:
+            connection.close()
+            raise
+        return connection
+    if parsed.scheme == "fd":
+        if parsed.query or parsed.fragment:
+            raise ValueError("fd sandbox endpoint must use fd://N")
+        if parsed.netloc and parsed.path:
+            raise ValueError("fd sandbox endpoint must use fd://N")
+        descriptor_text = parsed.netloc or parsed.path.lstrip("/")
+        if not descriptor_text.isdigit() or int(descriptor_text) < 3:
+            raise ValueError("fd sandbox endpoint must name a descriptor of at least 3")
+        duplicate = os.dup(int(descriptor_text))
+        try:
+            connection = socket.socket(fileno=duplicate)
+        except BaseException:
+            os.close(duplicate)
+            raise
+        if (
+            connection.family != socket.AF_UNIX
+            or connection.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE) != socket.SOCK_STREAM
+        ):
+            connection.close()
+            raise ValueError("fd sandbox endpoint must be a connected Unix stream socket")
+        try:
+            connection.getpeername()
+        except OSError as error:
+            connection.close()
+            raise ValueError("fd sandbox endpoint must already be connected") from error
+        return connection
+    raise ValueError("sandbox endpoint must use unix:///path or fd://N")
+
+
+class SocketSandboxBackend:
+    """Sandbox backend that delegates trusted operations over JSON-RPC."""
+
+    name = "jsonrpc"
+    _connections: dict[str, JsonRpcConnection] = {}
+    _connections_lock = threading.Lock()
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        connection: JsonRpcConnection | None = None,
+    ) -> None:
+        if not endpoint:
+            raise ValueError("sandbox RPC endpoint is empty")
+        self.endpoint = endpoint
+        self._connection = connection or self._shared_connection(endpoint)
+        self._capabilities_lock = threading.Lock()
+        self._capabilities_checked = False
+
+    @classmethod
+    def _shared_connection(cls, endpoint: str) -> JsonRpcConnection:
+        with cls._connections_lock:
+            connection = cls._connections.get(endpoint)
+            if connection is None or connection.is_closed:
+                connection = JsonRpcConnection(endpoint)
+                cls._connections[endpoint] = connection
+            return connection
+
+    def _check_capabilities(self) -> None:
+        if self._capabilities_checked:
+            return
+        with self._capabilities_lock:
+            if self._capabilities_checked:
+                return
+            result = self._connection.call("sandbox.capabilities", timeout=5)
+            result = _object(result, "sandbox.capabilities")
+            if result.get("protocol_version") != 1:
+                raise SandboxRpcError("sandbox RPC protocol version is unsupported")
+            self._capabilities_checked = True
+
+    def available_cpus(self) -> tuple[float | None, str]:
+        self._check_capabilities()
+        result = _object(self._connection.call("sandbox.capacity"), "sandbox.capacity")
+        cpus = result.get("cpus")
+        source = result.get("source", "sandbox backend")
+        if cpus is not None and (not isinstance(cpus, (int, float)) or isinstance(cpus, bool)):
+            raise SandboxRpcError("sandbox.capacity returned invalid cpus")
+        if not isinstance(source, str):
+            raise SandboxRpcError("sandbox.capacity returned invalid source")
+        return (float(cpus) if cpus is not None else None), source
+
+    def ensure_image(
+        self,
+        build: SandboxImageBuild,
+        on_output: Callable[[str], None] | None = None,
+    ) -> bool:
+        self._check_capabilities()
+        result = _object(
+            self._connection.call(
+                "sandbox.image.ensure",
+                {"build": asdict(build)},
+                timeout=build.timeout_seconds + 30,
+            ),
+            "sandbox.image.ensure",
+        )
+        cached = result.get("cached")
+        if not isinstance(cached, bool):
+            raise SandboxRpcError("sandbox.image.ensure returned invalid cached state")
+        output = result.get("output", [])
+        if not isinstance(output, list) or any(not isinstance(line, str) for line in output):
+            raise SandboxRpcError("sandbox.image.ensure returned invalid output")
+        if on_output is not None:
+            for line in output:
+                on_output(line)
+        return cached
+
+    def create(self, config: SandboxConfig) -> SandboxInstance:
+        self._check_capabilities()
+        return SocketSandboxInstance(self._connection, config)
+
+    def remove_image(self, image: str) -> None:
+        self._check_capabilities()
+        self._connection.call("sandbox.image.remove", {"image": image})
+
+
+class SocketSandboxInstance:
+    """``SandboxInstance`` implemented by the JSON-RPC backend."""
+
+    def __init__(self, connection: JsonRpcConnection, config: SandboxConfig):
+        self.config = config
+        self._connection = connection
+        self._sandbox_id: str | None = None
+        self._short_id: str | None = None
+        self.scratch_host_dir: str | None = None
+        self.variant: list[str] | None = None
+        self.workspace_baseline_commit: str | None = None
+
+    def start(self) -> str:
+        if self._sandbox_id is not None:
+            return self._sandbox_id
+        result = _object(
+            self._connection.call("sandbox.start", {"config": asdict(self.config)}),
+            "sandbox.start",
+        )
+        sandbox_id = result.get("sandbox_id")
+        short_id = result.get("short_id", sandbox_id)
+        if not isinstance(sandbox_id, str) or not sandbox_id:
+            raise SandboxRpcError("sandbox.start returned an invalid sandbox_id")
+        if not isinstance(short_id, str) or not short_id:
+            raise SandboxRpcError("sandbox.start returned an invalid short_id")
+        self._sandbox_id = sandbox_id
+        self._short_id = short_id
+
+        from .registry import ContainerRegistry
+
+        ContainerRegistry.get().register(self)
+        return sandbox_id
+
+    def exec(
+        self,
+        command: list[str] | str,
+        timeout: int | None = None,
+        env: dict[str, str] | None = None,
+        workdir: str | None = None,
+    ) -> ExecResult:
+        sandbox_id = self._require_started("exec")
+        # Match SandboxContainer: an explicit zero falls back to the configured
+        # timeout, while a negative value disables the in-sandbox timeout.
+        effective_timeout = timeout or self.config.timeout_seconds
+        call_timeout = effective_timeout + 10 if effective_timeout > 0 else None
+        result = _object(
+            self._connection.call(
+                "sandbox.exec",
+                {
+                    "sandbox_id": sandbox_id,
+                    "command": command,
+                    "timeout_seconds": effective_timeout,
+                    "env": env or {},
+                    "workdir": workdir,
+                },
+                timeout=call_timeout,
+            ),
+            "sandbox.exec",
+        )
+        exit_code = result.get("exit_code")
+        stdout = result.get("stdout", "")
+        stderr = result.get("stderr", "")
+        duration = result.get("duration_seconds", 0.0)
+        timed_out = result.get("timed_out", False)
+        if (
+            not isinstance(exit_code, int)
+            or isinstance(exit_code, bool)
+            or not isinstance(stdout, str)
+            or not isinstance(stderr, str)
+            or not isinstance(duration, (int, float))
+            or isinstance(duration, bool)
+            or not isinstance(timed_out, bool)
+        ):
+            raise SandboxRpcError("sandbox.exec returned an invalid result")
+        return ExecResult(
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            duration_seconds=float(duration),
+            timed_out=timed_out,
+        )
+
+    def write_file(self, container_path: str, content: bytes) -> None:
+        sandbox_id = self._require_started("write_file")
+        self._connection.call(
+            "sandbox.file.write",
+            {
+                "sandbox_id": sandbox_id,
+                "path": container_path,
+                "content_base64": base64.b64encode(content).decode("ascii"),
+            },
+        )
+
+    def read_file(self, container_path: str) -> bytes:
+        sandbox_id = self._require_started("read_file")
+        result = _object(
+            self._connection.call(
+                "sandbox.file.read",
+                {"sandbox_id": sandbox_id, "path": container_path},
+            ),
+            "sandbox.file.read",
+        )
+        content = result.get("content_base64")
+        if not isinstance(content, str):
+            raise SandboxRpcError("sandbox.file.read returned invalid content")
+        try:
+            return base64.b64decode(content, validate=True)
+        except (ValueError, binascii.Error) as error:
+            raise SandboxRpcError("sandbox.file.read returned invalid base64") from error
+
+    def copy_tree_into(self, host_path: str, container_path: str = "/workspace") -> None:
+        sandbox_id = self._require_started("copy_tree_into")
+        self._connection.call(
+            "sandbox.tree.copy",
+            {
+                "sandbox_id": sandbox_id,
+                "host_path": host_path,
+                "container_path": container_path,
+            },
+            timeout=610,
+        )
+
+    def stop(self) -> None:
+        if self._sandbox_id is None:
+            return
+        sandbox_id = self._sandbox_id
+        try:
+            self._connection.call("sandbox.stop", {"sandbox_id": sandbox_id})
+        except Exception:
+            logger.debug("Remote sandbox stop failed", exc_info=True)
+        finally:
+            from .registry import ContainerRegistry
+
+            ContainerRegistry.get().unregister(self)
+            self._sandbox_id = None
+            self._short_id = None
+
+    def _require_started(self, operation: str) -> str:
+        if self._sandbox_id is None:
+            raise RuntimeError(f"SocketSandboxInstance.{operation} called before start()")
+        return self._sandbox_id
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+        return False
+
+    @property
+    def container_id(self) -> str | None:
+        return self._sandbox_id
+
+    @property
+    def short_id(self) -> str | None:
+        return self._short_id
+
+    @property
+    def is_running(self) -> bool:
+        return self._sandbox_id is not None
+
+    def __del__(self) -> None:
+        if self._sandbox_id is not None:
+            logger.warning(
+                "Remote sandbox %s was not stopped before garbage collection", self._short_id
+            )
+            try:
+                self.stop()
+            except Exception:
+                logger.debug("Remote sandbox __del__ cleanup failed", exc_info=True)
+
+
+def _object(value: Any, method: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SandboxRpcError(f"{method} returned a non-object result")
+    return value

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -38,7 +38,7 @@ from clearwing.llm.budget import spend_metadata
 from clearwing.observability.otel import get_oi_tracer
 from clearwing.observability.telemetry import CostTracker
 from clearwing.reporting.safety import redact_tree
-from clearwing.sandbox.container import SandboxContainer
+from clearwing.sandbox.backend import SandboxInstance
 
 from .instrumentation import stable_run_id
 from .state import FileTarget, Finding, SubsystemTarget
@@ -1443,7 +1443,7 @@ def _build_subsystem_prompt(
 def build_subsystem_hunter_agent(
     subsystem: SubsystemTarget,
     repo_path: str,
-    sandbox: SandboxContainer | None,
+    sandbox: SandboxInstance | None,
     llm: AsyncLLMClient,
     session_id: str,
     project_name: str = "target",
@@ -2693,7 +2693,7 @@ def _estimate_cost_usd(
 def build_hunter_agent(
     file_target: FileTarget,
     repo_path: str,
-    sandbox: SandboxContainer | None,
+    sandbox: SandboxInstance | None,
     llm: AsyncLLMClient,
     session_id: str,
     project_name: str = "target",
@@ -2719,7 +2719,7 @@ def build_hunter_agent(
     Args:
         file_target: The FileTarget to scope the hunter to.
         repo_path: Absolute host path to the cloned repo.
-        sandbox: SandboxContainer for compile/run tools. May be None for tests
+        sandbox: SandboxInstance for compile/run tools. May be None for tests
                  (the tools fall back to host file I/O for read/grep, and
                  return errors for compile/run).
         llm: Native async LLM client.

--- a/clearwing/sourcehunt/poc_runner.py
+++ b/clearwing/sourcehunt/poc_runner.py
@@ -1,6 +1,6 @@
 """PoC replay — the sandbox leg of the verify-by-recompile gate.
 
-Given a finding, a candidate diff, and a running SandboxContainer, this
+Given a finding, a candidate diff, and a running SandboxInstance, this
 module applies the diff, rebuilds the target, re-runs the PoC input, and
 returns True/False for "crash still happens."
 
@@ -26,7 +26,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from clearwing.sandbox.container import SandboxContainer
+from clearwing.sandbox.backend import SandboxInstance
 
 from .paths import safe_repo_relative_path
 from .state import Finding
@@ -66,7 +66,7 @@ class PocRunner:
 
     def __init__(
         self,
-        sandbox: SandboxContainer,
+        sandbox: SandboxInstance,
         repo_path_in_sandbox: str = "/workspace",
         config: PocRunnerConfig | None = None,
     ):
@@ -325,7 +325,7 @@ class PocRunner:
 
 
 def build_rerun_poc_callback(
-    sandbox: SandboxContainer,
+    sandbox: SandboxInstance,
     repo_path_in_sandbox: str = "/workspace",
     config: PocRunnerConfig | None = None,
 ) -> Callable[[Any, Finding, str], bool]:

--- a/clearwing/sourcehunt/proof/engine.py
+++ b/clearwing/sourcehunt/proof/engine.py
@@ -1003,10 +1003,10 @@ class ProofFlowRunner:
             self._sandbox = HunterSandbox(
                 repo_path,
                 languages=languages,
-                extra_packages=["clang"],
+                extra_features=["toolchain.clang"],
                 default_cpus=self.config.sandbox_cpus,
             )
-            self._sandbox.build_image()
+            self._sandbox.prepare_environment()
             container = self._sandbox.spawn(
                 session_id=self.config.session_id or None,
                 runtime=self.config.gvisor_runtime,

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -334,9 +334,7 @@ class SourceHuntRunner:
             local_path = local_path if local_path is not None else t.local_path
             target_files = target_files if target_files is not None else t.target_files
             target_window_lines = (
-                target_window_lines
-                if target_window_lines is not None
-                else t.target_window_lines
+                target_window_lines if target_window_lines is not None else t.target_window_lines
             )
             depth = depth if depth != "standard" else t.depth
             # Budget params
@@ -751,9 +749,7 @@ class SourceHuntRunner:
             if not source_bytes:
                 raise ValueError(f"target file is empty: {relative}")
             if len(source_bytes) > MAX_TARGET_FILE_BYTES:
-                raise ValueError(
-                    f"target file exceeds {MAX_TARGET_FILE_BYTES} bytes: {relative}"
-                )
+                raise ValueError(f"target file exceeds {MAX_TARGET_FILE_BYTES} bytes: {relative}")
 
             lines = split_physical_source_lines(source_bytes)
             line_count = len(lines)
@@ -1326,12 +1322,8 @@ class SourceHuntRunner:
         self._run_started_at = datetime.now(timezone.utc).isoformat()
         self._run_started_monotonic = time.monotonic()
         span_context = otel_trace.get_current_span().get_span_context()
-        self._otel_trace_id = (
-            f"{span_context.trace_id:032x}" if span_context.is_valid else None
-        )
-        self._otel_span_id = (
-            f"{span_context.span_id:016x}" if span_context.is_valid else None
-        )
+        self._otel_trace_id = f"{span_context.trace_id:032x}" if span_context.is_valid else None
+        self._otel_span_id = f"{span_context.span_id:016x}" if span_context.is_valid else None
         if self._flow == "proof":
             try:
                 return await self._arun_proof_flow()
@@ -2441,9 +2433,7 @@ class SourceHuntRunner:
         verifier_llm = (
             None
             if self.no_verify
-            else self._get_native_client(
-                "verifier", self.verifier_llm, budget_stage="verify"
-            )
+            else self._get_native_client("verifier", self.verifier_llm, budget_stage="verify")
         )
         options = {
             "no_verify": self.no_verify,
@@ -2510,8 +2500,7 @@ class SourceHuntRunner:
                         for finding in findings:
                             finding["verified"] = False
                             finding["verifier_tie_breaker"] = (
-                                "Independent verifier model unavailable; "
-                                "finding left unverified"
+                                "Independent verifier model unavailable; finding left unverified"
                             )
                         pipeline_status.record_degraded(
                             "verifier", "Independent verifier model unavailable"
@@ -2589,9 +2578,7 @@ class SourceHuntRunner:
                     file_content=self._load_file_content(repo_path, finding),
                     verification_tools=verification_tools,
                 )
-                outcome = result.outcome or (
-                    "confirmed" if result.is_real else "refuted"
-                )
+                outcome = result.outcome or ("confirmed" if result.is_real else "refuted")
                 if outcome in {"operational_error", "inconclusive"}:
                     self._verification_incomplete = True
                     finding["verified"] = False
@@ -2655,9 +2642,7 @@ class SourceHuntRunner:
                     file_content=self._load_file_content(repo_path, finding),
                     verification_tools=verification_tools,
                 )
-                outcome = verdict.outcome or (
-                    "confirmed" if verdict.advance else "refuted"
-                )
+                outcome = verdict.outcome or ("confirmed" if verdict.advance else "refuted")
                 if outcome in {"operational_error", "inconclusive"}:
                     self._verification_incomplete = True
                     finding["verified"] = False
@@ -3523,7 +3508,7 @@ class SourceHuntRunner:
                 deep_agent_mode=use_deep,
                 default_cpus=self._sandbox_cpus,
             )
-            image_tag = manager.build_image()
+            environment_ref = manager.prepare_environment()
         except Exception as exc:
             logger.error(
                 "HunterSandbox startup failed: %s",
@@ -3540,8 +3525,8 @@ class SourceHuntRunner:
         cpu_limit = manager.default_cpu_limit
         available_cpus = manager.available_cpus
         logger.info(
-            "HunterSandbox ready image=%s cpu_limit=%.2f available_cpus=%.2f",
-            image_tag,
+            "HunterSandbox ready environment=%s cpu_limit=%.2f available_cpus=%.2f",
+            environment_ref,
             cpu_limit,
             available_cpus,
         )
@@ -3786,7 +3771,11 @@ class SourceHuntRunner:
             exit_code=(
                 3
                 if run_status in {"budget_exhausted", "incomplete"}
-                else (0 if self._stop_after else self._exit_code(findings if self.no_verify else verified))
+                else (
+                    0
+                    if self._stop_after
+                    else self._exit_code(findings if self.no_verify else verified)
+                )
             ),
             repo_url=self.repo_url,
             repo_path=repo_path,
@@ -3860,8 +3849,7 @@ class SourceHuntRunner:
     def _finding_set_digest(findings: list[Finding]) -> str:
         """Bind downstream checkpoints to their exact ordered finding input."""
         portable = [
-            dict(finding) if isinstance(finding, dict) else asdict(finding)
-            for finding in findings
+            dict(finding) if isinstance(finding, dict) else asdict(finding) for finding in findings
         ]
         encoded = json.dumps(
             portable,

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -3507,6 +3507,7 @@ class SourceHuntRunner:
                 languages=languages,
                 deep_agent_mode=use_deep,
                 default_cpus=self._sandbox_cpus,
+                gvisor_runtime=self._gvisor_runtime,
             )
             environment_ref = manager.prepare_environment()
         except Exception as exc:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,15 +154,16 @@ dataclass or a plain dict. Test fixtures lean on this heavily.
 
 ## The sandbox layer
 
-`clearwing.sandbox` provides per-hunter disposable sandboxes with
-sanitizer images (ASan+UBSan primary, MSan variant, optional LSan/TSan).
+`clearwing.sandbox` provides per-hunter disposable sandboxes with prepared
+toolchain environments (ASan+UBSan primary, MSan variant, optional LSan/TSan).
 `HunterSandbox` depends on the runtime-neutral `SandboxBackend` and
 `SandboxInstance` protocols. Docker is the default backend; a trusted
 supervisor can instead provide the same lifecycle over the
 [JSON-RPC socket adapter](sandbox-backends.md). Each `HunterContext`
 (`clearwing.agent.tools.hunt.sandbox.HunterContext`) owns:
 
-- A primary `SandboxInstance` attached at hunt start.
+- A primary `SandboxInstance` attached at hunt start from an opaque prepared
+  environment reference.
 - A `sandbox_manager` reference for spawning sanitizer-variant
   containers on demand (e.g., an MSan run for a specific finding).
 - A cache of variant containers that tears down in `cleanup_variants()`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,22 +154,30 @@ dataclass or a plain dict. Test fixtures lean on this heavily.
 
 ## The sandbox layer
 
-`clearwing.sandbox` wraps the Docker SDK to provide per-hunter
-disposable containers with sanitizer images (ASan+UBSan primary,
-MSan variant, optional LSan/TSan). Each `HunterContext`
+`clearwing.sandbox` provides per-hunter disposable sandboxes with
+sanitizer images (ASan+UBSan primary, MSan variant, optional LSan/TSan).
+`HunterSandbox` depends on the runtime-neutral `SandboxBackend` and
+`SandboxInstance` protocols. Docker is the default backend; a trusted
+supervisor can instead provide the same lifecycle over the
+[JSON-RPC socket adapter](sandbox-backends.md). Each `HunterContext`
 (`clearwing.agent.tools.hunt.sandbox.HunterContext`) owns:
 
-- A primary `SandboxContainer` attached at hunt start.
+- A primary `SandboxInstance` attached at hunt start.
 - A `sandbox_manager` reference for spawning sanitizer-variant
   containers on demand (e.g., an MSan run for a specific finding).
 - A cache of variant containers that tears down in `cleanup_variants()`
   when the hunter finishes.
 
-The sandbox is read-only under `/workspace` (the cloned repo is
-mounted there) and read-write under `/scratch` (where the hunter's
+The sandbox is read-only under `/workspace` (the cloned repo is mounted or
+materialized there) and read-write under `/scratch` (where the hunter's
 `write_test_case`, `compile_file`, and `fuzz_harness` tools emit
 artifacts). Exec timeout, memory limit, and the workspace mount are
 all configured per-container.
+
+Backend configuration is deployment-owned. If
+`CLEARWING_SANDBOX_ENDPOINT` is unset, the original local Docker behavior is
+used. See [Sandbox backends](sandbox-backends.md) for the extension contract
+and transport security requirements.
 
 ## The knowledge graph
 

--- a/docs/sandbox-backends.md
+++ b/docs/sandbox-backends.md
@@ -1,0 +1,108 @@
+# Sandbox backends
+
+SourceHunt separates its sandbox policy from the runtime that enforces it.
+`HunterSandbox` renders sanitizer images and chooses resource, mount, and
+security settings. A `SandboxBackend` prepares those images and creates
+`SandboxInstance` objects that execute commands and transfer files.
+
+Docker remains the default and requires no configuration:
+
+```python
+from clearwing.sandbox import HunterSandbox
+
+sandbox = HunterSandbox("/path/to/source")
+```
+
+Applications can inject a backend directly:
+
+```python
+from clearwing.sandbox import HunterSandbox, SocketSandboxBackend
+
+backend = SocketSandboxBackend("unix:///run/my-service/sandbox.sock")
+sandbox = HunterSandbox("/path/to/source", backend=backend)
+```
+
+Alternatively, set `CLEARWING_SANDBOX_ENDPOINT`. When it is absent or empty,
+Clearwing uses `DockerSandboxBackend`. Supported endpoint forms are:
+
+- `unix:///absolute/path.sock` — connect to a Unix stream socket.
+- `fd://N` — duplicate an inherited, already-connected Unix stream socket.
+
+An inherited endpoint is normally a `socketpair`, not an OS pipe: JSON-RPC
+requests and responses need one full-duplex stream. A process supervisor can
+reserve any descriptor of at least 3 and pass, for example,
+`CLEARWING_SANDBOX_ENDPOINT=fd://4` to Clearwing.
+
+## Backend interface
+
+`SandboxBackend` provides four operations:
+
+- Report available CPU capacity.
+- Ensure a content-addressed OCI image exists from a Dockerfile build request.
+- Create a sandbox from `SandboxConfig`.
+- Remove an image during requested cleanup.
+
+The returned `SandboxInstance` provides `start`, `exec`, `write_file`,
+`read_file`, `copy_tree_into`, and `stop`, plus runtime-neutral identity and
+lifecycle properties. Downstream SourceHunt code depends on this protocol,
+not on the Docker SDK implementation.
+
+The current build contract intentionally carries a Dockerfile. Docker,
+BuildKit, Kaniko, and most Kubernetes image-building services can consume it.
+A backend that cannot prepare OCI images should reject `ensure_image` instead
+of silently weakening the requested toolchain.
+
+Version 1 is a local-or-shared-filesystem protocol: mount entries and
+`sandbox.tree.copy` identify host paths. The backend must resolve them inside
+the same filesystem namespace, or translate them to an equivalent approved
+workspace mount. Transporting a workspace to an arbitrary remote host is
+deliberately outside this contract.
+
+## JSON-RPC protocol
+
+The socket adapter uses JSON-RPC 2.0. Each request or response is one UTF-8
+JSON object followed by `\n`; an individual record is limited to 16 MiB.
+Requests may be concurrent and responses may arrive out of order. The client
+correlates them by integer `id`.
+
+| Method | Parameters | Result |
+|---|---|---|
+| `sandbox.capabilities` | `{}` | `{"protocol_version": 1}` |
+| `sandbox.capacity` | `{}` | `{"cpus": number|null, "source": string}` |
+| `sandbox.image.ensure` | `{"build": SandboxImageBuild}` | `{"cached": bool, "output"?: [string]}` |
+| `sandbox.image.remove` | `{"image": string}` | `{}` |
+| `sandbox.start` | `{"config": SandboxConfig}` | `{"sandbox_id": string, "short_id"?: string}` |
+| `sandbox.exec` | sandbox id, command, timeout, environment, working directory | `ExecResult` fields |
+| `sandbox.file.write` | sandbox id, path, base64 content | `{}` |
+| `sandbox.file.read` | sandbox id and path | `{"content_base64": string}` |
+| `sandbox.tree.copy` | sandbox id, host path, container path | `{}` |
+| `sandbox.stop` | `{"sandbox_id": string}` | `{}` |
+
+Binary file bodies use strict standard base64. The v1 API returns buffered
+command output, matching the existing `SandboxContainer.exec` contract.
+For `sandbox.exec`, a command array is direct argv while a string runs through
+`/bin/sh -c`; `env` overlays the instance environment, a null `workdir` uses
+the configured working directory, and a non-positive effective timeout means
+no execution deadline.
+
+JSON-RPC errors use the standard `error.code`, `error.message`, and optional
+`error.data` fields. Clearwing exposes them as `SandboxRpcError`.
+
+## Security responsibilities
+
+A sandbox backend is trusted infrastructure, not an agent tool. A service
+implementing this protocol must independently:
+
+- Authenticate or physically confine access to the endpoint. Inherited
+  socketpairs are preferred; pathname sockets should have restrictive owner
+  and mode settings.
+- Validate every field and bound runtime output, file bodies, and build logs.
+- Constrain host paths to the run's approved workspace. A path received from
+  Clearwing is a request, not authorization to expose arbitrary host files.
+- Enforce the requested no-network mode, read-only source semantics, resource
+  limits, capabilities, seccomp policy, deadlines, and cleanup.
+- Treat sandbox ids as opaque, connection- or run-scoped handles and reconcile
+  leaked workloads when the client disconnects.
+
+The JSON-RPC endpoint carries no cloud, registry, or cluster credentials.
+Those belong to the backend service on the trusted side of the socket.

--- a/docs/sandbox-backends.md
+++ b/docs/sandbox-backends.md
@@ -1,16 +1,24 @@
 # Sandbox backends
 
-SourceHunt separates its sandbox policy from the runtime that enforces it.
-`HunterSandbox` renders sanitizer images and chooses resource, mount, and
-security settings. A `SandboxBackend` prepares those images and creates
-`SandboxInstance` objects that execute commands and transfer files.
+SourceHunt separates the environment it needs from the runtime that provides
+it. `HunterSandbox` selects a logical toolchain profile, tool features,
+sanitizers, resource limits, mounts, and security policy. A trusted
+`SandboxBackend` prepares that environment and creates `SandboxInstance`
+objects that execute commands and transfer files.
 
-Docker remains the default and requires no configuration:
+An environment is not necessarily an OCI image. A Docker backend may build
+and cache an image, Kubernetes may use a configured image plus an ephemeral
+volume, and a local backend may use a rootfs overlay. These choices, including
+base images and package-manager commands, belong to the provider.
+
+Docker remains the zero-configuration default:
 
 ```python
 from clearwing.sandbox import HunterSandbox
 
 sandbox = HunterSandbox("/path/to/source")
+sandbox.prepare_environment()
+instance = sandbox.spawn()
 ```
 
 Applications can inject a backend directly:
@@ -26,37 +34,82 @@ Alternatively, set `CLEARWING_SANDBOX_ENDPOINT`. When it is absent or empty,
 Clearwing uses `DockerSandboxBackend`. Supported endpoint forms are:
 
 - `unix:///absolute/path.sock` — connect to a Unix stream socket.
-- `fd://N` — duplicate an inherited, already-connected Unix stream socket.
+- `fd://N` — adopt an inherited, already-connected Unix stream socket.
 
 An inherited endpoint is normally a `socketpair`, not an OS pipe: JSON-RPC
 requests and responses need one full-duplex stream. A process supervisor can
 reserve any descriptor of at least 3 and pass, for example,
-`CLEARWING_SANDBOX_ENDPOINT=fd://4` to Clearwing.
+`CLEARWING_SANDBOX_ENDPOINT=fd://4` to Clearwing. Clearwing takes ownership of
+the inherited descriptor and closes it with the RPC connection; the supervisor
+retains only its own endpoint of the socketpair.
+
+## Environment contract
+
+`SandboxEnvironmentSpec` contains only logical requirements:
+
+- `cache_key` — SHA-256 identity of the complete logical request.
+- `profile` — one of `c-cpp`, `rust`, `go`, `python`, `java`, `node`, or
+  `generic`.
+- `features` — required capability codes. Unknown or unsupported required
+  codes must fail preparation.
+- `optional_features` — capabilities that may be unavailable without failing
+  preparation.
+- `sanitizers` — the requested instrumentation variants.
+- `environment` — compiler and sanitizer environment variables associated
+  with the variant.
+- `timeout_seconds` — preparation deadline.
+
+The current feature vocabulary is deliberately closed and maintained in
+Clearwing. It includes codes such as `build.make`, `build.cmake`,
+`build.cargo`, `build.go`, `build.maven`, `build.npm`, `build.native`,
+`toolchain.native`, `toolchain.clang`, `source.search`, `debug.native`,
+`debug.valgrind`, `trace.syscalls`, `trace.library-calls`, `process.timeout`,
+`runtime.python`, `trust.roots`, and `vcs.git`.
+
+Build-system detection is deterministic. Repository markers such as
+`CMakeLists.txt`, `Cargo.toml`, `go.mod`, `pom.xml`, `package.json`, and
+`pyproject.toml` select a hardcoded profile and feature set. The hunter model
+does not submit environment codes, package names, setup commands, images, or
+runtime flags.
+
+The environment request intentionally contains no Dockerfile, base-image
+name, registry reference, distro package name, or arbitrary setup command.
+For example, Clearwing requests `source.search`; the default Docker adapter
+privately resolves that code to its Debian package. Another provider may
+satisfy it from a preinstalled tool bundle. Provider-specific resolution must
+not leak back into the logical contract.
+
+`ensure_environment` returns an opaque environment reference. Clearwing only
+passes that reference back to `create`; it does not interpret it as an image,
+pod, path, or provider-native identifier. `release_environment` permits an
+explicit cleanup request, but a provider may retain safe content-addressed
+caches according to deployment policy.
+
+The checked-out repository is separate from environment preparation. It is
+mounted read-only for normal hunts or copied into the sandbox for explicitly
+writable flows. This separation allows environment preparation to use narrowly
+controlled package access without exposing source or mission secrets, while
+actual repository commands run with networking disabled.
+
+Version 1 is a local-or-shared-filesystem protocol: mount entries and
+`sandbox.tree.copy` identify host paths. The backend must resolve them inside
+the same filesystem namespace, or translate them to an equivalent approved
+workspace mount. Transporting a workspace to an arbitrary remote host is
+outside this contract.
 
 ## Backend interface
 
 `SandboxBackend` provides four operations:
 
 - Report available CPU capacity.
-- Ensure a content-addressed OCI image exists from a Dockerfile build request.
-- Create a sandbox from `SandboxConfig`.
-- Remove an image during requested cleanup.
+- Ensure a logical environment exists and return an opaque reference.
+- Create a sandbox from that reference and `SandboxRunConfig`.
+- Release a prepared environment when cleanup is requested.
 
 The returned `SandboxInstance` provides `start`, `exec`, `write_file`,
 `read_file`, `copy_tree_into`, and `stop`, plus runtime-neutral identity and
 lifecycle properties. Downstream SourceHunt code depends on this protocol,
 not on the Docker SDK implementation.
-
-The current build contract intentionally carries a Dockerfile. Docker,
-BuildKit, Kaniko, and most Kubernetes image-building services can consume it.
-A backend that cannot prepare OCI images should reject `ensure_image` instead
-of silently weakening the requested toolchain.
-
-Version 1 is a local-or-shared-filesystem protocol: mount entries and
-`sandbox.tree.copy` identify host paths. The backend must resolve them inside
-the same filesystem namespace, or translate them to an equivalent approved
-workspace mount. Transporting a workspace to an arbitrary remote host is
-deliberately outside this contract.
 
 ## JSON-RPC protocol
 
@@ -69,9 +122,9 @@ correlates them by integer `id`.
 |---|---|---|
 | `sandbox.capabilities` | `{}` | `{"protocol_version": 1}` |
 | `sandbox.capacity` | `{}` | `{"cpus": number|null, "source": string}` |
-| `sandbox.image.ensure` | `{"build": SandboxImageBuild}` | `{"cached": bool, "output"?: [string]}` |
-| `sandbox.image.remove` | `{"image": string}` | `{}` |
-| `sandbox.start` | `{"config": SandboxConfig}` | `{"sandbox_id": string, "short_id"?: string}` |
+| `sandbox.environment.ensure` | `{"spec": SandboxEnvironmentSpec}` | `{"environment_ref": string, "cached": bool, "output"?: [string]}` |
+| `sandbox.environment.release` | `{"environment_ref": string}` | `{}` |
+| `sandbox.start` | `{"environment_ref": string, "config": SandboxRunConfig}` | `{"sandbox_id": string, "short_id"?: string}` |
 | `sandbox.exec` | sandbox id, command, timeout, environment, working directory | `ExecResult` fields |
 | `sandbox.file.write` | sandbox id, path, base64 content | `{}` |
 | `sandbox.file.read` | sandbox id and path | `{"content_base64": string}` |
@@ -79,8 +132,8 @@ correlates them by integer `id`.
 | `sandbox.stop` | `{"sandbox_id": string}` | `{}` |
 
 Binary file bodies use strict standard base64. The v1 API returns buffered
-command output, matching the existing `SandboxContainer.exec` contract.
-For `sandbox.exec`, a command array is direct argv while a string runs through
+command output, matching the existing `SandboxContainer.exec` contract. For
+`sandbox.exec`, a command array is direct argv while a string runs through
 `/bin/sh -c`; `env` overlays the instance environment, a null `workdir` uses
 the configured working directory, and a non-positive effective timeout means
 no execution deadline.
@@ -96,13 +149,18 @@ implementing this protocol must independently:
 - Authenticate or physically confine access to the endpoint. Inherited
   socketpairs are preferred; pathname sockets should have restrictive owner
   and mode settings.
-- Validate every field and bound runtime output, file bodies, and build logs.
+- Validate every code and field and bound runtime output, file bodies, and
+  preparation logs. Unknown required environment codes fail closed.
 - Constrain host paths to the run's approved workspace. A path received from
   Clearwing is a request, not authorization to expose arbitrary host files.
-- Enforce the requested no-network mode, read-only source semantics, resource
+- Enforce requested no-network behavior, read-only source semantics, resource
   limits, capabilities, seccomp policy, deadlines, and cleanup.
-- Treat sandbox ids as opaque, connection- or run-scoped handles and reconcile
-  leaked workloads when the client disconnects.
+- Treat environment references and sandbox ids as opaque, connection- or
+  run-scoped handles and reconcile leaked workloads when the client
+  disconnects.
+- Keep registry, cloud, cluster, and package-repository credentials on the
+  trusted side of the socket and out of prepared execution sandboxes.
 
-The JSON-RPC endpoint carries no cloud, registry, or cluster credentials.
-Those belong to the backend service on the trusted side of the socket.
+Environment preparation should be secretless and isolated from the repository.
+Repository build, test, fuzz, and PoC commands run in the no-network execution
+sandbox because project build systems themselves are untrusted code.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
   - Remediation lifecycle: remediation.md
   - VVAH pattern review: vvah-integration.md
   - Architecture: architecture.md
+  - Sandbox backends: sandbox-backends.md
   - CLI reference: cli.md
   - API reference: api.md
   - Web API (WebSocket): web-api.md

--- a/tests/test_hunter_sandbox.py
+++ b/tests/test_hunter_sandbox.py
@@ -8,10 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from clearwing.sandbox.builders import (
-    DEFAULT_BASE_IMAGES,
-    BuildSystemDetector,
-)
+from clearwing.sandbox.builders import BuildSystemDetector
 from clearwing.sandbox.hunter_sandbox import HunterSandbox
 
 
@@ -37,14 +34,14 @@ class TestBuildSystemDetector:
         recipe = BuildSystemDetector.detect(str(temp_repo))
         assert recipe.system == "cmake"
         assert recipe.primary_language == "cpp"
-        assert "cmake" in " ".join(recipe.apt_packages)
+        assert "build.cmake" in recipe.features
 
     def test_detects_cargo(self, temp_repo: Path):
         (temp_repo / "Cargo.toml").write_text('[package]\nname = "x"\n')
         recipe = BuildSystemDetector.detect(str(temp_repo))
         assert recipe.system == "cargo"
         assert recipe.primary_language == "rust"
-        assert recipe.base_image == DEFAULT_BASE_IMAGES["rust"]
+        assert recipe.profile == "rust"
 
     def test_detects_go(self, temp_repo: Path):
         (temp_repo / "go.mod").write_text("module foo\n")
@@ -101,10 +98,10 @@ class TestBuildSystemDetector:
         recipe = BuildSystemDetector.detect(str(temp_repo))
         assert recipe.primary_language == "c"
 
-    def test_recipe_includes_ripgrep_in_apt(self, temp_repo: Path):
+    def test_recipe_includes_source_search_feature(self, temp_repo: Path):
         (temp_repo / "Makefile").write_text("all:\n")
         recipe = BuildSystemDetector.detect(str(temp_repo))
-        assert "ripgrep" in recipe.apt_packages
+        assert "source.search" in recipe.features
 
 
 # --- HunterSandbox.build_image ---------------------------------------------
@@ -112,8 +109,10 @@ class TestBuildSystemDetector:
 
 @pytest.fixture
 def mock_docker():
-    with patch("clearwing.sandbox.dind.get_docker_host", return_value=None), \
-         patch("docker.from_env") as mock_from_env:
+    with (
+        patch("clearwing.sandbox.dind.get_docker_host", return_value=None),
+        patch("docker.from_env") as mock_from_env,
+    ):
         mock_client = MagicMock()
         mock_from_env.return_value = mock_client
         yield mock_client
@@ -165,13 +164,11 @@ class TestHunterSandboxBuildImage:
         assert "gdb" in df
         assert "ltrace" not in df
 
-    def test_dockerfile_sets_sanitizer_env(self, temp_repo: Path):
+    def test_environment_spec_sets_sanitizer_env(self, temp_repo: Path):
         (temp_repo / "Makefile").write_text("all:\n")
         sb = HunterSandbox(repo_path=str(temp_repo))
-        df = sb._render_dockerfile()
-        # CFLAGS should be set with the sanitizer flags from the recipe
-        assert "CFLAGS=" in df
-        assert "fsanitize=address" in df
+        spec = sb._environment_spec(["asan", "ubsan"])
+        assert "fsanitize=address" in spec.environment["CFLAGS"]
 
     def test_dockerfile_for_python_no_gcc_needed(self, temp_repo: Path):
         (temp_repo / "pyproject.toml").write_text("[project]\nname='x'\n")

--- a/tests/test_remediation_subsystem.py
+++ b/tests/test_remediation_subsystem.py
@@ -322,7 +322,7 @@ def test_sandbox_dynamic_validator_replays_exact_diff(monkeypatch, tmp_path: Pat
             self.builds = 0
             self.spawns = 0
 
-        def build_image(self):
+        def prepare_environment(self):
             self.builds += 1
 
         def spawn(self, **_kwargs):

--- a/tests/test_sandbox_backends.py
+++ b/tests/test_sandbox_backends.py
@@ -287,6 +287,7 @@ def test_socket_backend_implements_complete_sandbox_contract():
         assert peer.requests[3]["params"]["environment_ref"] == "environment:test"
         assert start_config["policy"] == "sourcehunt"
         assert start_config["isolation"] == "default"
+        assert start_config["cpus"] is None
         assert "network_mode" not in start_config
         assert "security_opt" not in start_config
         assert "cap_drop" not in start_config
@@ -336,6 +337,30 @@ def test_docker_package_resolution_stays_inside_adapter():
     assert "gdb" in dockerfile
     assert "cmake" in dockerfile
     assert "ripgrep" not in vars(spec).values()
+
+
+def test_optional_docker_packages_remain_best_effort_without_hiding_stderr():
+    backend = DockerSandboxBackend()
+    dockerfile = backend._render_dockerfile(
+        SandboxEnvironmentSpec(
+            cache_key="a" * 64,
+            profile="c-cpp",
+            optional_features=["debug.valgrind"],
+        )
+    )
+
+    assert "valgrind || true ;" in dockerfile
+    assert "2>/dev/null" not in dockerfile
+
+
+def test_docker_translates_an_unspecified_cpu_limit_to_its_legacy_sentinel():
+    backend = DockerSandboxBackend()
+
+    unspecified = backend.create("image:test", SandboxRunConfig())
+    explicit = backend.create("image:test", SandboxRunConfig(cpus=2.5))
+
+    assert unspecified.config.cpus == 0.0
+    assert explicit.config.cpus == 2.5
 
 
 def test_backend_selection_uses_configured_socket(monkeypatch):

--- a/tests/test_sandbox_backends.py
+++ b/tests/test_sandbox_backends.py
@@ -373,3 +373,197 @@ def test_hunter_sandbox_accepts_an_injected_backend(tmp_path: Path):
     assert backend.create.call_args.args[0] == "environment:test"
     instance.start.assert_called_once_with()
     assert manager.default_cpu_limit == 3.0
+
+
+# --- Regression tests for review findings on PR #200 --------------------------
+
+
+def test_docker_enhanced_isolation_honors_configured_runtime():
+    # Finding #1: "enhanced" isolation must map to the operator-selected runtime
+    # instead of a hardcoded "runsc" (which silently downgraded e.g. kata to
+    # plain runc when the requested runtime was discarded).
+    backend = DockerSandboxBackend(enhanced_runtime="kata-runtime")
+
+    enhanced = backend.create("image:test", SandboxRunConfig(isolation="enhanced"))
+    assert enhanced.config.runtime == "kata-runtime"
+
+    default = backend.create("image:test", SandboxRunConfig(isolation="default"))
+    assert default.config.runtime is None
+
+    # Unset -> the zero-config default remains runsc.
+    fallback = DockerSandboxBackend().create(
+        "image:test", SandboxRunConfig(isolation="enhanced")
+    )
+    assert fallback.config.runtime == "runsc"
+
+
+def test_backend_from_env_threads_enhanced_runtime(monkeypatch):
+    monkeypatch.delenv("CLEARWING_SANDBOX_ENDPOINT", raising=False)
+    backend = sandbox_backend_from_env(enhanced_runtime="runsc-kvm")
+    assert isinstance(backend, DockerSandboxBackend)
+    assert backend._enhanced_runtime == "runsc-kvm"
+
+
+def test_hunter_sandbox_threads_gvisor_runtime_to_backend(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CLEARWING_SANDBOX_ENDPOINT", raising=False)
+    manager = HunterSandbox(repo_path=str(tmp_path), gvisor_runtime="kata-runtime")
+    assert isinstance(manager.backend, DockerSandboxBackend)
+    assert manager.backend._enhanced_runtime == "kata-runtime"
+    assert manager.gvisor_runtime == "kata-runtime"
+
+
+class _HangingBuildProcess:
+    """A docker build that emits one line then hangs with stdout still open."""
+
+    def __init__(self):
+        self._released = threading.Event()
+        self.returncode = None
+        self.killed = False
+        self.stdout = self._stream()
+
+    def _stream(self):
+        yield "Step 1/2 : FROM base-image\n"
+        # Stall here (e.g. a wedged base-image pull) without closing stdout.
+        self._released.wait()
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+        self._released.set()
+
+    def wait(self, timeout=None):
+        self._released.wait(timeout)
+        return self.returncode
+
+
+class _FakeProcessModule:
+    PIPE = -1
+    STDOUT = -2
+
+    def __init__(self, process):
+        self._process = process
+
+    def run(self, *args, **kwargs):
+        result = MagicMock()
+        result.returncode = 1  # cache miss -> force a build
+        return result
+
+    def Popen(self, *args, **kwargs):
+        return self._process
+
+
+def test_build_watchdog_bounds_a_hanging_build():
+    # Finding #3: reading stdout to EOF and only then calling wait(timeout=...)
+    # never bounds a build that hangs with stdout open. The watchdog must kill
+    # it after timeout_seconds regardless.
+    process = _HangingBuildProcess()
+    backend = DockerSandboxBackend(process=_FakeProcessModule(process))
+    spec = SandboxEnvironmentSpec(
+        cache_key="c" * 64,
+        profile="c-cpp",
+        features=["build.make"],
+        timeout_seconds=0.2,
+    )
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        backend.ensure_environment(spec)
+    assert process.killed
+
+
+def test_oversized_response_does_not_tear_down_connection():
+    # Finding #4: one worker's oversized response must not fail every other
+    # concurrent/subsequent call on the shared connection.
+    client_socket, server_socket = socket.socketpair()
+    connection = JsonRpcConnection(f"fd://{client_socket.detach()}", max_message_bytes=4096)
+
+    def serve():
+        reader = server_socket.makefile("rb")
+        first = json.loads(reader.readline())
+        assert first is not None
+        # Oversized, unterminated-within-cap frame, closed by a trailing newline.
+        server_socket.sendall(b"x" * 9000 + b"\n")
+        second = json.loads(reader.readline())
+        response = {"jsonrpc": "2.0", "id": second["id"], "result": second["params"]}
+        server_socket.sendall(json.dumps(response).encode() + b"\n")
+        reader.close()
+
+    server = threading.Thread(target=serve, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(SandboxRpcError):
+            connection.call("test.big", {"value": 1}, timeout=1)
+        assert not connection.is_closed
+        assert connection.call("test.echo", {"value": 2}) == {"value": 2}
+    finally:
+        connection.close()
+        server_socket.close()
+        server.join(timeout=1)
+
+
+def test_malformed_frame_fails_only_its_call():
+    # Finding #4: a well-framed but invalid response fails just its call, not
+    # the whole connection.
+    client_socket, server_socket = socket.socketpair()
+    connection = JsonRpcConnection(f"fd://{client_socket.detach()}")
+
+    def serve():
+        reader = server_socket.makefile("rb")
+        first = json.loads(reader.readline())
+        # Both result and error present: malformed, but the frame is intact.
+        server_socket.sendall(
+            json.dumps(
+                {
+                    "jsonrpc": "2.0",
+                    "id": first["id"],
+                    "result": 1,
+                    "error": {"code": 1, "message": "x"},
+                }
+            ).encode()
+            + b"\n"
+        )
+        second = json.loads(reader.readline())
+        response = {"jsonrpc": "2.0", "id": second["id"], "result": second["params"]}
+        server_socket.sendall(json.dumps(response).encode() + b"\n")
+        reader.close()
+
+    server = threading.Thread(target=serve, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(SandboxRpcError):
+            connection.call("test.bad", {"value": 1})
+        assert not connection.is_closed
+        assert connection.call("test.echo", {"value": 2}) == {"value": 2}
+    finally:
+        connection.close()
+        server_socket.close()
+        server.join(timeout=1)
+
+
+def test_peer_disconnect_releases_descriptor():
+    # Finding #5: a peer disconnect (no explicit close()) must still release the
+    # inherited descriptor via the reader thread's teardown, not leak it.
+    client_socket, server_socket = socket.socketpair()
+    descriptor = client_socket.detach()
+    connection = JsonRpcConnection(f"fd://{descriptor}")
+    try:
+        server_socket.close()
+        connection._reader_thread.join(timeout=2)
+        assert not connection._reader_thread.is_alive()
+        assert connection.is_closed
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+    finally:
+        connection.close()
+
+
+def test_call_with_nonpositive_timeout_sends_nothing():
+    # Finding #7: a non-positive timeout is reported before the request is
+    # written, so the backend never runs the method's side effects.
+    connection, peer = _fd_connection(lambda request: request["params"])
+    try:
+        with pytest.raises(SandboxRpcError, match="timed out"):
+            connection.call("test.echo", {"value": 1}, timeout=0)
+        assert peer.requests == []
+    finally:
+        connection.close()
+        peer.close()

--- a/tests/test_sandbox_backends.py
+++ b/tests/test_sandbox_backends.py
@@ -1,0 +1,309 @@
+"""Contract tests for pluggable and JSON-RPC sandbox backends."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import socket
+import tempfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from clearwing.sandbox.backend import (
+    DockerSandboxBackend,
+    SandboxBackend,
+    SandboxImageBuild,
+    SandboxInstance,
+    sandbox_backend_from_env,
+)
+from clearwing.sandbox.container import ExecResult, SandboxConfig
+from clearwing.sandbox.hunter_sandbox import HunterSandbox
+from clearwing.sandbox.rpc_backend import (
+    JsonRpcConnection,
+    SandboxRpcError,
+    SocketSandboxBackend,
+)
+
+
+class _RpcPeer:
+    def __init__(self, stream: socket.socket, handler):
+        self.stream = stream
+        self.handler = handler
+        self.requests: list[dict] = []
+        self.failure: BaseException | None = None
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+        self.thread.start()
+
+    def _serve(self):
+        reader = self.stream.makefile("rb")
+        try:
+            while encoded := reader.readline():
+                request = json.loads(encoded)
+                self.requests.append(request)
+                result = self.handler(request)
+                if result is None:
+                    continue
+                response = {"jsonrpc": "2.0", "id": request["id"], "result": result}
+                self.stream.sendall(json.dumps(response).encode() + b"\n")
+        except (ConnectionError, OSError):
+            pass
+        except BaseException as error:  # noqa: BLE001 - reported by the test
+            self.failure = error
+        finally:
+            reader.close()
+
+    def close(self):
+        try:
+            self.stream.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        self.stream.close()
+        self.thread.join(timeout=1)
+        if self.failure is not None:
+            raise self.failure
+
+
+def _fd_connection(handler):
+    client_socket, server_socket = socket.socketpair()
+    peer = _RpcPeer(server_socket, handler)
+    connection = JsonRpcConnection(f"fd://{client_socket.fileno()}")
+    client_socket.close()
+    return connection, peer
+
+
+def test_fd_endpoint_uses_connected_duplex_socket():
+    connection, peer = _fd_connection(lambda request: request["params"])
+    try:
+        assert connection.call("test.echo", {"value": 42}) == {"value": 42}
+    finally:
+        connection.close()
+        peer.close()
+
+
+def test_connection_close_is_idempotent_and_stops_reader():
+    connection, peer = _fd_connection(lambda request: request["params"])
+    connection.close()
+    connection.close()
+
+    assert connection.is_closed
+    assert not connection._reader_thread.is_alive()
+    peer.close()
+
+
+def test_fd_endpoint_rejects_a_one_way_pipe():
+    read_fd, write_fd = os.pipe()
+    try:
+        with pytest.raises((OSError, ValueError)):
+            JsonRpcConnection(f"fd://{read_fd}")
+    finally:
+        os.close(read_fd)
+        os.close(write_fd)
+
+
+def test_unix_endpoint_connects_to_socket_path():
+    # Darwin limits AF_UNIX paths to 104 bytes; pytest's normal temp path can
+    # exceed that before the socket filename is appended.
+    with tempfile.TemporaryDirectory(prefix="cw-sb-", dir="/tmp") as directory:
+        path = Path(directory) / "sandbox.sock"
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(str(path))
+        listener.listen(1)
+        accepted: list[_RpcPeer] = []
+
+        def accept():
+            stream, _ = listener.accept()
+            accepted.append(_RpcPeer(stream, lambda request: request["params"]))
+
+        thread = threading.Thread(target=accept, daemon=True)
+        thread.start()
+        connection = JsonRpcConnection(f"unix://{path}")
+        try:
+            assert connection.call("test.echo", {"transport": "unix"}) == {"transport": "unix"}
+        finally:
+            connection.close()
+            thread.join(timeout=1)
+            for peer in accepted:
+                peer.close()
+            listener.close()
+
+
+def test_connection_multiplexes_out_of_order_responses():
+    client_socket, server_socket = socket.socketpair()
+    connection = JsonRpcConnection(f"fd://{client_socket.fileno()}")
+    client_socket.close()
+
+    def serve_reversed():
+        reader = server_socket.makefile("rb")
+        requests = [json.loads(reader.readline()), json.loads(reader.readline())]
+        for request in reversed(requests):
+            response = {
+                "jsonrpc": "2.0",
+                "id": request["id"],
+                "result": request["params"],
+            }
+            server_socket.sendall(json.dumps(response).encode() + b"\n")
+        reader.close()
+
+    server = threading.Thread(target=serve_reversed, daemon=True)
+    server.start()
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            first = pool.submit(connection.call, "test.echo", {"value": "first"})
+            second = pool.submit(connection.call, "test.echo", {"value": "second"})
+            assert first.result() == {"value": "first"}
+            assert second.result() == {"value": "second"}
+    finally:
+        connection.close()
+        server_socket.close()
+        server.join(timeout=1)
+
+
+def test_remote_error_is_exposed_as_typed_exception():
+    client_socket, server_socket = socket.socketpair()
+
+    def serve_error():
+        request = json.loads(server_socket.makefile("rb").readline())
+        response = {
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "error": {"code": -32010, "message": "capacity exhausted"},
+        }
+        server_socket.sendall(json.dumps(response).encode() + b"\n")
+
+    server = threading.Thread(target=serve_error, daemon=True)
+    server.start()
+    connection = JsonRpcConnection(f"fd://{client_socket.fileno()}")
+    client_socket.close()
+    try:
+        with pytest.raises(SandboxRpcError, match="capacity exhausted") as caught:
+            connection.call("sandbox.start")
+        assert caught.value.code == -32010
+    finally:
+        connection.close()
+        server_socket.close()
+        server.join(timeout=1)
+
+
+def test_socket_backend_implements_complete_sandbox_contract():
+    def handle(request):
+        method = request["method"]
+        if method == "sandbox.capabilities":
+            return {"protocol_version": 1}
+        if method == "sandbox.capacity":
+            return {"cpus": 8, "source": "test runtime"}
+        if method == "sandbox.image.ensure":
+            return {"cached": True}
+        if method == "sandbox.start":
+            return {"sandbox_id": "runtime-id", "short_id": "short"}
+        if method == "sandbox.exec":
+            return {
+                "exit_code": 0,
+                "stdout": "ok",
+                "stderr": "",
+                "duration_seconds": 0.25,
+                "timed_out": False,
+            }
+        if method == "sandbox.file.read":
+            return {"content_base64": base64.b64encode(b"result").decode()}
+        if method in {
+            "sandbox.file.write",
+            "sandbox.tree.copy",
+            "sandbox.stop",
+            "sandbox.image.remove",
+        }:
+            return {}
+        raise AssertionError(f"unexpected method {method}")
+
+    connection, peer = _fd_connection(handle)
+    backend = SocketSandboxBackend("fd://99", connection=connection)
+    try:
+        assert isinstance(backend, SandboxBackend)
+        assert backend.available_cpus() == (8.0, "test runtime")
+        assert backend.ensure_image(
+            SandboxImageBuild("image:test", "FROM scratch\n", "linux/amd64")
+        )
+
+        instance = backend.create(SandboxConfig(image="image:test"))
+        assert isinstance(instance, SandboxInstance)
+        assert instance.start() == "runtime-id"
+        assert instance.short_id == "short"
+        assert instance.exec(["true"]) == ExecResult(0, "ok", "", 0.25, False)
+        instance.exec(["true"], timeout=0)
+        instance.config.timeout_seconds = 0
+        instance.exec(["true"])
+        instance.write_file("/scratch/input", b"input")
+        assert instance.read_file("/scratch/output") == b"result"
+        instance.copy_tree_into("/host/source")
+        instance.stop()
+        backend.remove_image("image:test")
+
+        methods = [request["method"] for request in peer.requests]
+        assert methods == [
+            "sandbox.capabilities",
+            "sandbox.capacity",
+            "sandbox.image.ensure",
+            "sandbox.start",
+            "sandbox.exec",
+            "sandbox.exec",
+            "sandbox.exec",
+            "sandbox.file.write",
+            "sandbox.file.read",
+            "sandbox.tree.copy",
+            "sandbox.stop",
+            "sandbox.image.remove",
+        ]
+        start_config = peer.requests[3]["params"]["config"]
+        assert start_config["network_mode"] == "none"
+        assert start_config["cap_drop"] == ["ALL"]
+        assert peer.requests[5]["params"]["timeout_seconds"] == 300
+        assert peer.requests[6]["params"]["timeout_seconds"] == 0
+    finally:
+        connection.close()
+        peer.close()
+
+
+def test_backend_selection_defaults_to_docker(monkeypatch):
+    monkeypatch.delenv("CLEARWING_SANDBOX_ENDPOINT", raising=False)
+    assert isinstance(sandbox_backend_from_env(), DockerSandboxBackend)
+
+
+def test_backend_selection_uses_configured_socket(monkeypatch):
+    client_socket, server_socket = socket.socketpair()
+    endpoint = f"fd://{client_socket.fileno()}"
+    monkeypatch.setenv("CLEARWING_SANDBOX_ENDPOINT", endpoint)
+    backend = None
+    try:
+        backend = sandbox_backend_from_env()
+        assert isinstance(backend, SocketSandboxBackend)
+        assert backend.endpoint == endpoint
+    finally:
+        if backend is not None:
+            backend._connection.close()
+        client_socket.close()
+        server_socket.close()
+
+
+def test_hunter_sandbox_accepts_an_injected_backend(tmp_path: Path):
+    instance = MagicMock()
+    instance.scratch_host_dir = None
+    instance.workspace_baseline_commit = None
+    backend = MagicMock(spec=SandboxBackend)
+    backend.name = "test"
+    backend.ensure_image.return_value = False
+    backend.available_cpus.return_value = (4.0, "test")
+    backend.create.return_value = instance
+
+    manager = HunterSandbox(repo_path=str(tmp_path), backend=backend)
+    manager.build_image()
+    spawned = manager.spawn(scratch_mount=False)
+
+    assert spawned is instance
+    backend.ensure_image.assert_called_once()
+    backend.create.assert_called_once()
+    instance.start.assert_called_once_with()
+    assert manager.default_cpu_limit == 3.0

--- a/tests/test_sandbox_backends.py
+++ b/tests/test_sandbox_backends.py
@@ -17,11 +17,13 @@ import pytest
 from clearwing.sandbox.backend import (
     DockerSandboxBackend,
     SandboxBackend,
-    SandboxImageBuild,
+    SandboxEnvironment,
+    SandboxEnvironmentSpec,
     SandboxInstance,
+    SandboxRunConfig,
     sandbox_backend_from_env,
 )
-from clearwing.sandbox.container import ExecResult, SandboxConfig
+from clearwing.sandbox.container import ExecResult
 from clearwing.sandbox.hunter_sandbox import HunterSandbox
 from clearwing.sandbox.rpc_backend import (
     JsonRpcConnection,
@@ -71,8 +73,7 @@ class _RpcPeer:
 def _fd_connection(handler):
     client_socket, server_socket = socket.socketpair()
     peer = _RpcPeer(server_socket, handler)
-    connection = JsonRpcConnection(f"fd://{client_socket.fileno()}")
-    client_socket.close()
+    connection = JsonRpcConnection(f"fd://{client_socket.detach()}")
     return connection, peer
 
 
@@ -95,14 +96,29 @@ def test_connection_close_is_idempotent_and_stops_reader():
     peer.close()
 
 
+def test_fd_endpoint_takes_ownership_of_descriptor():
+    client_socket, server_socket = socket.socketpair()
+    descriptor = client_socket.detach()
+    connection = JsonRpcConnection(f"fd://{descriptor}")
+
+    connection.close()
+
+    with pytest.raises(OSError):
+        os.fstat(descriptor)
+    server_socket.close()
+
+
 def test_fd_endpoint_rejects_a_one_way_pipe():
     read_fd, write_fd = os.pipe()
     try:
         with pytest.raises((OSError, ValueError)):
             JsonRpcConnection(f"fd://{read_fd}")
     finally:
-        os.close(read_fd)
-        os.close(write_fd)
+        for descriptor in (read_fd, write_fd):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
 
 
 def test_unix_endpoint_connects_to_socket_path():
@@ -134,8 +150,7 @@ def test_unix_endpoint_connects_to_socket_path():
 
 def test_connection_multiplexes_out_of_order_responses():
     client_socket, server_socket = socket.socketpair()
-    connection = JsonRpcConnection(f"fd://{client_socket.fileno()}")
-    client_socket.close()
+    connection = JsonRpcConnection(f"fd://{client_socket.detach()}")
 
     def serve_reversed():
         reader = server_socket.makefile("rb")
@@ -177,8 +192,7 @@ def test_remote_error_is_exposed_as_typed_exception():
 
     server = threading.Thread(target=serve_error, daemon=True)
     server.start()
-    connection = JsonRpcConnection(f"fd://{client_socket.fileno()}")
-    client_socket.close()
+    connection = JsonRpcConnection(f"fd://{client_socket.detach()}")
     try:
         with pytest.raises(SandboxRpcError, match="capacity exhausted") as caught:
             connection.call("sandbox.start")
@@ -196,8 +210,8 @@ def test_socket_backend_implements_complete_sandbox_contract():
             return {"protocol_version": 1}
         if method == "sandbox.capacity":
             return {"cpus": 8, "source": "test runtime"}
-        if method == "sandbox.image.ensure":
-            return {"cached": True}
+        if method == "sandbox.environment.ensure":
+            return {"environment_ref": "environment:test", "cached": True}
         if method == "sandbox.start":
             return {"sandbox_id": "runtime-id", "short_id": "short"}
         if method == "sandbox.exec":
@@ -214,7 +228,7 @@ def test_socket_backend_implements_complete_sandbox_contract():
             "sandbox.file.write",
             "sandbox.tree.copy",
             "sandbox.stop",
-            "sandbox.image.remove",
+            "sandbox.environment.release",
         }:
             return {}
         raise AssertionError(f"unexpected method {method}")
@@ -224,11 +238,17 @@ def test_socket_backend_implements_complete_sandbox_contract():
     try:
         assert isinstance(backend, SandboxBackend)
         assert backend.available_cpus() == (8.0, "test runtime")
-        assert backend.ensure_image(
-            SandboxImageBuild("image:test", "FROM scratch\n", "linux/amd64")
+        environment = backend.ensure_environment(
+            SandboxEnvironmentSpec(
+                cache_key="a" * 64,
+                profile="c-cpp",
+                features=["build.make", "source.search"],
+                sanitizers=["asan"],
+            )
         )
+        assert environment == SandboxEnvironment("environment:test", cached=True)
 
-        instance = backend.create(SandboxConfig(image="image:test"))
+        instance = backend.create(environment.reference, SandboxRunConfig())
         assert isinstance(instance, SandboxInstance)
         assert instance.start() == "runtime-id"
         assert instance.short_id == "short"
@@ -240,13 +260,13 @@ def test_socket_backend_implements_complete_sandbox_contract():
         assert instance.read_file("/scratch/output") == b"result"
         instance.copy_tree_into("/host/source")
         instance.stop()
-        backend.remove_image("image:test")
+        backend.release_environment(environment.reference)
 
         methods = [request["method"] for request in peer.requests]
         assert methods == [
             "sandbox.capabilities",
             "sandbox.capacity",
-            "sandbox.image.ensure",
+            "sandbox.environment.ensure",
             "sandbox.start",
             "sandbox.exec",
             "sandbox.exec",
@@ -255,11 +275,22 @@ def test_socket_backend_implements_complete_sandbox_contract():
             "sandbox.file.read",
             "sandbox.tree.copy",
             "sandbox.stop",
-            "sandbox.image.remove",
+            "sandbox.environment.release",
         ]
+        environment_spec = peer.requests[2]["params"]["spec"]
+        assert environment_spec["profile"] == "c-cpp"
+        assert environment_spec["features"] == ["build.make", "source.search"]
+        assert "image" not in environment_spec
+        assert "dockerfile" not in environment_spec
+        assert "packages" not in environment_spec
         start_config = peer.requests[3]["params"]["config"]
-        assert start_config["network_mode"] == "none"
-        assert start_config["cap_drop"] == ["ALL"]
+        assert peer.requests[3]["params"]["environment_ref"] == "environment:test"
+        assert start_config["policy"] == "sourcehunt"
+        assert start_config["isolation"] == "default"
+        assert "network_mode" not in start_config
+        assert "security_opt" not in start_config
+        assert "cap_drop" not in start_config
+        assert "runtime" not in start_config
         assert peer.requests[5]["params"]["timeout_seconds"] == 300
         assert peer.requests[6]["params"]["timeout_seconds"] == 0
     finally:
@@ -272,9 +303,44 @@ def test_backend_selection_defaults_to_docker(monkeypatch):
     assert isinstance(sandbox_backend_from_env(), DockerSandboxBackend)
 
 
+def test_docker_backend_rejects_unknown_required_environment_codes():
+    process = MagicMock()
+    backend = DockerSandboxBackend(process=process)
+
+    with pytest.raises(ValueError, match="profile"):
+        backend.ensure_environment(SandboxEnvironmentSpec(cache_key="a" * 64, profile="made-up"))
+    with pytest.raises(ValueError, match="feature"):
+        backend.ensure_environment(
+            SandboxEnvironmentSpec(
+                cache_key="b" * 64,
+                profile="c-cpp",
+                features=["package.libssl-dev"],
+            )
+        )
+
+    # Validation happens before even consulting the image cache.
+    process.run.assert_not_called()
+
+
+def test_docker_package_resolution_stays_inside_adapter():
+    backend = DockerSandboxBackend()
+    spec = SandboxEnvironmentSpec(
+        cache_key="a" * 64,
+        profile="c-cpp",
+        features=["source.search", "debug.native", "build.cmake"],
+    )
+
+    dockerfile = backend._render_dockerfile(spec)
+
+    assert "ripgrep" in dockerfile
+    assert "gdb" in dockerfile
+    assert "cmake" in dockerfile
+    assert "ripgrep" not in vars(spec).values()
+
+
 def test_backend_selection_uses_configured_socket(monkeypatch):
     client_socket, server_socket = socket.socketpair()
-    endpoint = f"fd://{client_socket.fileno()}"
+    endpoint = f"fd://{client_socket.detach()}"
     monkeypatch.setenv("CLEARWING_SANDBOX_ENDPOINT", endpoint)
     backend = None
     try:
@@ -284,7 +350,6 @@ def test_backend_selection_uses_configured_socket(monkeypatch):
     finally:
         if backend is not None:
             backend._connection.close()
-        client_socket.close()
         server_socket.close()
 
 
@@ -294,7 +359,7 @@ def test_hunter_sandbox_accepts_an_injected_backend(tmp_path: Path):
     instance.workspace_baseline_commit = None
     backend = MagicMock(spec=SandboxBackend)
     backend.name = "test"
-    backend.ensure_image.return_value = False
+    backend.ensure_environment.return_value = SandboxEnvironment("environment:test", cached=False)
     backend.available_cpus.return_value = (4.0, "test")
     backend.create.return_value = instance
 
@@ -303,7 +368,8 @@ def test_hunter_sandbox_accepts_an_injected_backend(tmp_path: Path):
     spawned = manager.spawn(scratch_mount=False)
 
     assert spawned is instance
-    backend.ensure_image.assert_called_once()
+    backend.ensure_environment.assert_called_once()
     backend.create.assert_called_once()
+    assert backend.create.call_args.args[0] == "environment:test"
     instance.start.assert_called_once_with()
     assert manager.default_cpu_limit == 3.0

--- a/tests/test_sandbox_creation.py
+++ b/tests/test_sandbox_creation.py
@@ -1,7 +1,8 @@
 """Tests for sandbox creation correctness.
 
-Validates that HunterSandbox produces correctly-configured containers:
-- Dockerfile renders with correct base images and sanitizer flags
+Validates that HunterSandbox produces correctly-configured sandboxes:
+- Environment requirements are provider-neutral and content-addressed
+- The default Docker adapter resolves profiles and features privately
 - Workspace mounts are correct (ro vs writable copy)
 - Image tags are deterministic and content-addressed
 - Build failures are surfaced cleanly
@@ -13,22 +14,18 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from clearwing.sandbox.builders import (
-    DEFAULT_BASE_IMAGES,
-    BuildRecipe,
     BuildSystemDetector,
     compute_sanitizer_env,
     validate_sanitizer_combo,
 )
-from clearwing.sandbox.container import SandboxConfig, SandboxContainer
+from clearwing.sandbox.container import SandboxContainer
 from clearwing.sandbox.hunter_sandbox import HunterSandbox
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -58,8 +55,10 @@ def python_repo(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def mock_docker():
-    with patch("clearwing.sandbox.dind.get_docker_host", return_value=None), \
-         patch("docker.from_env") as mock_from_env:
+    with (
+        patch("clearwing.sandbox.dind.get_docker_host", return_value=None),
+        patch("docker.from_env") as mock_from_env,
+    ):
         client = MagicMock()
         mock_from_env.return_value = client
         yield client
@@ -88,43 +87,40 @@ class TestDockerfileRendering:
         # Python doesn't get CFLAGS sanitizer injection
         assert "fsanitize" not in df
 
-    def test_sanitizer_env_in_dockerfile(self, c_repo: Path):
+    def test_sanitizer_requirements_are_in_environment_spec(self, c_repo: Path):
         sb = HunterSandbox(repo_path=str(c_repo), sanitizers=["asan", "ubsan"])
-        df = sb._render_dockerfile()
-        assert "fsanitize=address" in df
-        assert "fsanitize=undefined" in df
-        assert "ASAN_OPTIONS" in df
-        assert "UBSAN_OPTIONS" in df
+        spec = sb._environment_spec(["asan", "ubsan"])
+        assert spec.sanitizers == ["asan", "ubsan"]
+        assert "fsanitize=address" in spec.environment["CFLAGS"]
+        assert "fsanitize=undefined" in spec.environment["CFLAGS"]
+        assert "ASAN_OPTIONS" in spec.environment
+        assert "UBSAN_OPTIONS" in spec.environment
 
-    def test_msan_variant_dockerfile(self, c_repo: Path):
+    def test_msan_variant_environment(self, c_repo: Path):
         sb = HunterSandbox(repo_path=str(c_repo), sanitizers=["msan"])
-        df = sb._render_dockerfile()
-        assert "fsanitize=memory" in df
-        assert "MSAN_OPTIONS" in df
+        spec = sb._environment_spec(["msan"])
+        assert "fsanitize=memory" in spec.environment["CFLAGS"]
+        assert "MSAN_OPTIONS" in spec.environment
         # Must NOT contain asan flags
-        assert "fsanitize=address" not in df
+        assert "fsanitize=address" not in spec.environment["CFLAGS"]
 
-    def test_apt_packages_include_ripgrep_and_gdb(self, c_repo: Path):
+    def test_docker_adapter_maps_search_and_debug_features(self, c_repo: Path):
         sb = HunterSandbox(repo_path=str(c_repo))
         df = sb._render_dockerfile()
         assert "ripgrep" in df
         assert "gdb" in df
 
-    def test_extra_packages_appear_in_dockerfile(self, c_repo: Path):
-        sb = HunterSandbox(
-            repo_path=str(c_repo), extra_packages=["python3-pip", "curl"]
-        )
+    def test_extra_feature_is_resolved_by_docker_adapter(self, c_repo: Path):
+        sb = HunterSandbox(repo_path=str(c_repo), extra_features=["toolchain.clang"])
         df = sb._render_dockerfile()
-        assert "python3-pip" in df
-        assert "curl" in df
+        assert "clang" in df
 
-    def test_post_install_commands_render(self, c_repo: Path):
-        sb = HunterSandbox(
-            repo_path=str(c_repo),
-            post_install_commands=["pip3 install pyjwt || true"],
-        )
-        df = sb._render_dockerfile()
-        assert "RUN pip3 install pyjwt || true" in df
+    def test_environment_spec_exposes_no_build_recipe(self, c_repo: Path):
+        spec = vars(HunterSandbox(repo_path=str(c_repo))._environment_spec(["asan"]))
+        assert "dockerfile" not in spec
+        assert "image" not in spec
+        assert "packages" not in spec
+        assert "setup_commands" not in spec
 
     def test_deep_agent_mode_adds_valgrind_and_ltrace(self, c_repo: Path):
         sb = HunterSandbox(repo_path=str(c_repo), deep_agent_mode=True)
@@ -160,9 +156,9 @@ class TestImageTagDeterminism:
         tag_msan = sb_msan._compute_tag(sb_msan._render_dockerfile())
         assert tag_asan != tag_msan
 
-    def test_different_extra_packages_different_tag(self, c_repo: Path):
+    def test_different_extra_features_different_tag(self, c_repo: Path):
         sb1 = HunterSandbox(repo_path=str(c_repo))
-        sb2 = HunterSandbox(repo_path=str(c_repo), extra_packages=["curl"])
+        sb2 = HunterSandbox(repo_path=str(c_repo), extra_features=["toolchain.clang"])
         tag1 = sb1._compute_tag(sb1._render_dockerfile())
         tag2 = sb2._compute_tag(sb2._render_dockerfile())
         assert tag1 != tag2
@@ -171,9 +167,9 @@ class TestImageTagDeterminism:
         sb = HunterSandbox(repo_path=str(c_repo))
         tag = sb._compute_tag(sb._render_dockerfile())
         assert tag.startswith("clearwing-sourcehunt:")
-        # Hash portion is 12 hex chars
+        # The Docker adapter uses a compact SHA-256-derived tag.
         hash_part = tag.split(":")[1]
-        assert len(hash_part) == 12
+        assert len(hash_part) == 20
         assert all(c in "0123456789abcdef" for c in hash_part)
 
 
@@ -271,7 +267,7 @@ class TestSpawnContainer:
 
         sb = HunterSandbox(repo_path=str(c_repo))
         sb.build_image()
-        container = sb.spawn(session_id="test-ro", scratch_mount=False)
+        sb.spawn(session_id="test-ro", scratch_mount=False)
 
         kwargs = mock_docker.containers.run.call_args.kwargs
         volumes = kwargs["volumes"]
@@ -296,12 +292,13 @@ class TestSpawnContainer:
             patch.object(SandboxContainer, "exec") as mock_exec,
         ):
             mock_exec.return_value = MagicMock(exit_code=0)
-            container = sb.spawn(writable_workspace=True)
+            sb.spawn(writable_workspace=True)
 
         # Must copy, then git init
         mock_copy.assert_called_once_with(str(c_repo), "/workspace")
         git_calls = [
-            c for c in mock_exec.call_args_list
+            c
+            for c in mock_exec.call_args_list
             if isinstance(c[0][0], str) and "git init" in c[0][0]
         ]
         assert len(git_calls) == 1
@@ -313,7 +310,7 @@ class TestSpawnContainer:
         sb = HunterSandbox(repo_path=str(c_repo), deep_agent_mode=True)
 
         with (
-            patch.object(HunterSandbox, "_build_variant_image", return_value="img:test"),
+            patch.object(HunterSandbox, "_prepare_variant_environment", return_value="img:test"),
             patch.object(SandboxContainer, "start", return_value="cid"),
             patch.object(SandboxContainer, "copy_tree_into"),
             patch.object(SandboxContainer, "exec", return_value=MagicMock(exit_code=0)),
@@ -324,8 +321,7 @@ class TestSpawnContainer:
             host, container_path, mode = mount
             if container_path == "/workspace":
                 pytest.fail(
-                    f"Writable workspace should not have a /workspace mount, "
-                    f"found mode={mode}"
+                    f"Writable workspace should not have a /workspace mount, found mode={mode}"
                 )
 
     def test_spawn_network_disabled(self, c_repo: Path, mock_docker):
@@ -358,7 +354,7 @@ class TestSpawnContainer:
         sec_opts = kwargs["security_opt"]
         seccomp_opts = [o for o in sec_opts if o.startswith("seccomp=")]
         assert len(seccomp_opts) == 1
-        value = seccomp_opts[0][len("seccomp="):]
+        value = seccomp_opts[0][len("seccomp=") :]
         # Must not be a path
         assert not value.startswith("/")
         parsed = json.loads(value)
@@ -392,10 +388,7 @@ class TestSpawnContainer:
 
         kwargs = mock_docker.containers.run.call_args.kwargs
         volumes = kwargs["volumes"]
-        rw_mounts = [
-            (host, info) for host, info in volumes.items()
-            if info.get("mode") == "rw"
-        ]
+        rw_mounts = [(host, info) for host, info in volumes.items() if info.get("mode") == "rw"]
         assert len(rw_mounts) == 1
         assert rw_mounts[0][1]["bind"] == "/scratch"
 
@@ -572,11 +565,12 @@ class TestWritableWorkspaceResilience:
         sb = HunterSandbox(repo_path=str(c_repo), deep_agent_mode=True)
 
         with (
-            patch.object(HunterSandbox, "_build_variant_image", return_value="img:t"),
+            patch.object(HunterSandbox, "_prepare_variant_environment", return_value="img:t"),
             patch.object(SandboxContainer, "start", return_value="cid"),
             patch.object(SandboxContainer, "copy_tree_into"),
             patch.object(
-                SandboxContainer, "exec",
+                SandboxContainer,
+                "exec",
                 side_effect=RuntimeError("git not installed"),
             ),
         ):
@@ -591,10 +585,11 @@ class TestWritableWorkspaceResilience:
         sb = HunterSandbox(repo_path=str(c_repo), deep_agent_mode=True)
 
         with (
-            patch.object(HunterSandbox, "_build_variant_image", return_value="img:t"),
+            patch.object(HunterSandbox, "_prepare_variant_environment", return_value="img:t"),
             patch.object(SandboxContainer, "start", return_value="cid"),
             patch.object(
-                SandboxContainer, "copy_tree_into",
+                SandboxContainer,
+                "copy_tree_into",
                 side_effect=RuntimeError("tar failed"),
             ),
         ):
@@ -635,7 +630,9 @@ class TestVariantSpawn:
 
     @patch("clearwing.sandbox.hunter_sandbox.subprocess.Popen")
     @patch("clearwing.sandbox.hunter_sandbox.subprocess.run")
-    def test_spawn_unbuilt_variant_auto_builds(self, mock_run, mock_popen, c_repo: Path, mock_docker):
+    def test_spawn_unbuilt_variant_auto_builds(
+        self, mock_run, mock_popen, c_repo: Path, mock_docker
+    ):
         """Requesting an unbuilt variant auto-builds on demand."""
         # subprocess.run: inspect calls always miss
         mock_run.return_value = MagicMock(returncode=1)

--- a/tests/test_sandbox_integration.py
+++ b/tests/test_sandbox_integration.py
@@ -25,20 +25,18 @@ from __future__ import annotations
 import platform
 import subprocess
 import tempfile
-import time
 from pathlib import Path
 
 import pytest
 
-from clearwing.sandbox.builders import DEFAULT_BASE_IMAGES, BuildSystemDetector
+from clearwing.sandbox.backend import DockerSandboxBackend
+from clearwing.sandbox.builders import BuildSystemDetector
 from clearwing.sandbox.hunter_sandbox import HunterSandbox
 
 
 def _docker_available() -> bool:
     try:
-        result = subprocess.run(
-            ["docker", "info"], capture_output=True, timeout=10
-        )
+        result = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
         return result.returncode == 0
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
@@ -61,12 +59,12 @@ def c_repo(tmp_path: Path) -> Path:
         "CC=gcc\nCFLAGS ?= -Wall\n\nall: main\n\nmain: main.c\n\t$(CC) $(CFLAGS) -o $@ $<\n"
     )
     (tmp_path / "main.c").write_text(
-        '#include <stdio.h>\n#include <string.h>\n\n'
+        "#include <stdio.h>\n#include <string.h>\n\n"
         "int main(int argc, char **argv) {\n"
-        '    char buf[64];\n'
-        '    if (argc > 1) strcpy(buf, argv[1]);\n'
+        "    char buf[64];\n"
+        "    if (argc > 1) strcpy(buf, argv[1]);\n"
         '    printf("ok\\n");\n'
-        '    return 0;\n'
+        "    return 0;\n"
         "}\n"
     )
     return tmp_path
@@ -103,7 +101,9 @@ def go_repo(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def python_repo(tmp_path: Path) -> Path:
-    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test_sandbox'\nversion = '0.1.0'\n")
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'test_sandbox'\nversion = '0.1.0'\n"
+    )
     (tmp_path / "main.py").write_text("print('ok')\n")
     return tmp_path
 
@@ -136,7 +136,7 @@ class TestDockerSdkVsCliBuilds:
         """
         sb = HunterSandbox(repo_path=str(c_repo))
         try:
-            tag = sb.build_image()
+            sb.build_image()
             # If we get here, SDK build works (no cred helper issue)
             sb.cleanup(remove_image=True)
         except RuntimeError as e:
@@ -162,7 +162,9 @@ class TestDockerSdkVsCliBuilds:
 
             result = subprocess.run(
                 ["docker", "build", "--progress=plain", "-t", tag, build_dir],
-                capture_output=True, text=True, timeout=120,
+                capture_output=True,
+                text=True,
+                timeout=120,
             )
 
         assert result.returncode == 0, (
@@ -171,7 +173,8 @@ class TestDockerSdkVsCliBuilds:
         # Verify image exists
         inspect = subprocess.run(
             ["docker", "image", "inspect", tag],
-            capture_output=True, timeout=10,
+            capture_output=True,
+            timeout=10,
         )
         assert inspect.returncode == 0
         subprocess.run(["docker", "rmi", tag], capture_output=True, timeout=10)
@@ -190,7 +193,9 @@ class TestDockerSdkVsCliBuilds:
 
             result = subprocess.run(
                 ["docker", "build", "--progress=plain", "-t", tag, build_dir],
-                capture_output=True, text=True, timeout=120,
+                capture_output=True,
+                text=True,
+                timeout=120,
             )
 
         assert result.returncode == 0, (
@@ -214,12 +219,12 @@ class TestImageBuildActuallyWorks:
             (Path(build_dir) / "Dockerfile").write_text(dockerfile)
             result = subprocess.run(
                 ["docker", "build", "--progress=plain", "-t", tag, build_dir],
-                capture_output=True, text=True, timeout=120,
+                capture_output=True,
+                text=True,
+                timeout=120,
             )
             if result.returncode != 0:
-                raise RuntimeError(
-                    f"docker build failed:\n{result.stderr[-2000:]}"
-                )
+                raise RuntimeError(f"docker build failed:\n{result.stderr[-2000:]}")
         return tag
 
     @pytest.mark.integration
@@ -230,7 +235,8 @@ class TestImageBuildActuallyWorks:
         assert tag.startswith("clearwing-sourcehunt:")
         result = subprocess.run(
             ["docker", "image", "inspect", tag],
-            capture_output=True, timeout=10,
+            capture_output=True,
+            timeout=10,
         )
         assert result.returncode == 0, f"Image {tag} not found after build"
         subprocess.run(["docker", "rmi", tag], capture_output=True, timeout=10)
@@ -243,7 +249,8 @@ class TestImageBuildActuallyWorks:
         assert tag.startswith("clearwing-sourcehunt:")
         result = subprocess.run(
             ["docker", "image", "inspect", tag],
-            capture_output=True, timeout=10,
+            capture_output=True,
+            timeout=10,
         )
         assert result.returncode == 0, f"Image {tag} not found after build"
         subprocess.run(["docker", "rmi", tag], capture_output=True, timeout=10)
@@ -257,7 +264,9 @@ class TestImageBuildActuallyWorks:
         try:
             result = subprocess.run(
                 ["docker", "run", "--rm", tag, "cmake", "--version"],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             assert result.returncode == 0, f"cmake not available: {result.stderr}"
             assert "cmake version" in result.stdout
@@ -273,13 +282,19 @@ class TestImageBuildActuallyWorks:
         try:
             result = subprocess.run(
                 [
-                    "docker", "run", "--rm", tag,
-                    "sh", "-c",
+                    "docker",
+                    "run",
+                    "--rm",
+                    tag,
+                    "sh",
+                    "-c",
                     "echo 'int main(){}' > /tmp/t.c && "
                     "gcc -fsanitize=address -o /tmp/t /tmp/t.c && "
                     "echo SUCCESS",
                 ],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             assert result.returncode == 0, (
                 f"gcc -fsanitize=address failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
@@ -297,7 +312,9 @@ class TestImageBuildActuallyWorks:
         try:
             result = subprocess.run(
                 ["docker", "run", "--rm", tag, "rg", "--version"],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             assert result.returncode == 0, f"ripgrep not available: {result.stderr}"
         finally:
@@ -311,7 +328,9 @@ class TestImageBuildActuallyWorks:
         try:
             result = subprocess.run(
                 ["docker", "run", "--rm", tag, "python3", "--version"],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             assert result.returncode == 0
         finally:
@@ -348,13 +367,10 @@ class TestContainerSpawnAndExec:
             # The important thing is gcc + asan are available.
             # Let's compile in /scratch instead
             result = container.exec(
-                "cp /workspace/main.c /scratch/ && "
-                "cd /scratch && gcc $CFLAGS -o main main.c 2>&1",
+                "cp /workspace/main.c /scratch/ && cd /scratch && gcc $CFLAGS -o main main.c 2>&1",
                 timeout=30,
             )
-            assert result.exit_code == 0, (
-                f"ASan compile failed:\n{result.stdout}\n{result.stderr}"
-            )
+            assert result.exit_code == 0, f"ASan compile failed:\n{result.stdout}\n{result.stderr}"
 
             # Run — should work without crashing
             result = container.exec("/scratch/main", timeout=10)
@@ -392,13 +408,11 @@ class TestContainerSpawnAndExec:
             # Build with cmake
             result = container.exec(
                 "cd /scratch && mkdir -p build && cd build && "
-                "cmake -DCMAKE_C_FLAGS=\"$CFLAGS\" -DCMAKE_CXX_FLAGS=\"$CXXFLAGS\" .. && "
+                'cmake -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS" .. && '
                 "make 2>&1",
                 timeout=60,
             )
-            assert result.exit_code == 0, (
-                f"cmake build failed:\n{result.stdout}\n{result.stderr}"
-            )
+            assert result.exit_code == 0, f"cmake build failed:\n{result.stdout}\n{result.stderr}"
 
             # Run
             result = container.exec("/scratch/build/main", timeout=10)
@@ -480,45 +494,53 @@ class TestPlatformBuild:
     def test_base_image_pullable(self, c_repo: Path):
         """Verify the configured base image can be pulled."""
         recipe = BuildSystemDetector.detect(str(c_repo))
-        base = recipe.base_image
+        base = DockerSandboxBackend()._profile_images[recipe.profile]
         result = subprocess.run(
             ["docker", "pull", base],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
-        assert result.returncode == 0, (
-            f"Cannot pull base image {base}:\n{result.stderr}"
-        )
+        assert result.returncode == 0, f"Cannot pull base image {base}:\n{result.stderr}"
 
     @pytest.mark.integration
     @pytest.mark.timeout(180)
     def test_cpp_base_image_pullable(self, cpp_repo: Path):
         recipe = BuildSystemDetector.detect(str(cpp_repo))
-        base = recipe.base_image
+        base = DockerSandboxBackend()._profile_images[recipe.profile]
         result = subprocess.run(
             ["docker", "pull", base],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
-        assert result.returncode == 0, (
-            f"Cannot pull base image {base}:\n{result.stderr}"
-        )
+        assert result.returncode == 0, f"Cannot pull base image {base}:\n{result.stderr}"
 
     @pytest.mark.integration
     @pytest.mark.timeout(180)
-    def test_apt_install_common_packages_native_arch(self, c_repo: Path):
-        """Verify COMMON_APT_PACKAGES install on native arch."""
+    def test_required_features_resolve_on_native_arch(self, c_repo: Path):
+        """Verify Docker's private feature packages install on native arch."""
         recipe = BuildSystemDetector.detect(str(c_repo))
-        base = recipe.base_image
-        from clearwing.sandbox.builders import COMMON_APT_PACKAGES
-
-        pkg_list = " ".join(COMMON_APT_PACKAGES)
+        backend = DockerSandboxBackend()
+        base = backend._profile_images[recipe.profile]
+        packages = [
+            package for feature in recipe.features for package in backend._feature_packages[feature]
+        ]
+        pkg_list = " ".join(dict.fromkeys(packages))
         result = subprocess.run(
             [
-                "docker", "run", "--rm", base,
-                "sh", "-c",
+                "docker",
+                "run",
+                "--rm",
+                base,
+                "sh",
+                "-c",
                 f"apt-get update -qq && "
                 f"DEBIAN_FRONTEND=noninteractive apt-get install -y -qq {pkg_list} 2>&1",
             ],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
         assert result.returncode == 0, (
             f"apt-get install failed for packages [{pkg_list}] in {base}:\n"
@@ -540,14 +562,18 @@ class TestPlatformBuild:
         2. strace is always available as the portable alternative.
         """
         sandbox = HunterSandbox(
-            str(c_repo), languages=["c"], deep_agent_mode=True,
+            str(c_repo),
+            languages=["c"],
+            deep_agent_mode=True,
         )
         tag = sandbox.build_image()
         try:
             # strace must always be present
             result = subprocess.run(
                 ["docker", "run", "--rm", tag, "strace", "--version"],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             assert result.returncode == 0, (
                 f"strace missing from deep_agent_mode image: {result.stderr}"
@@ -556,7 +582,9 @@ class TestPlatformBuild:
             # ltrace is best-effort — document its presence/absence
             ltrace_result = subprocess.run(
                 ["docker", "run", "--rm", tag, "which", "ltrace"],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             host_arch = platform.machine()
             if host_arch in ("arm64", "aarch64"):
@@ -564,9 +592,7 @@ class TestPlatformBuild:
                 assert True
             else:
                 # On x86_64 we expect ltrace to have installed
-                assert ltrace_result.returncode == 0, (
-                    f"ltrace should be available on {host_arch}"
-                )
+                assert ltrace_result.returncode == 0, f"ltrace should be available on {host_arch}"
         finally:
             sandbox.cleanup(remove_image=True)
 
@@ -579,20 +605,30 @@ class TestPlatformBuild:
         If ANY package is unavailable, the entire Dockerfile build fails because
         apt-get runs as one RUN layer.
         """
-        recipe = BuildSystemDetector.detect(str(c_repo))
-        base = recipe.base_image
-        from clearwing.sandbox.builders import COMMON_APT_PACKAGES
-
-        all_packages = COMMON_APT_PACKAGES + list(HunterSandbox.DEEP_AGENT_PACKAGES)
+        sandbox = HunterSandbox(str(c_repo), deep_agent_mode=True)
+        recipe = sandbox.build_recipe
+        backend = DockerSandboxBackend()
+        base = backend._profile_images[recipe.profile]
+        features = [*recipe.features, *sandbox.extra_features]
+        all_packages = [
+            package for feature in features for package in backend._feature_packages[feature]
+        ]
+        all_packages = list(dict.fromkeys(all_packages))
         pkg_list = " ".join(all_packages)
         result = subprocess.run(
             [
-                "docker", "run", "--rm", base,
-                "sh", "-c",
+                "docker",
+                "run",
+                "--rm",
+                base,
+                "sh",
+                "-c",
                 f"apt-get update -qq && "
                 f"DEBIAN_FRONTEND=noninteractive apt-get install -y -qq {pkg_list} 2>&1",
             ],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
         if result.returncode != 0:
             # Find which package failed
@@ -600,12 +636,18 @@ class TestPlatformBuild:
             for pkg in all_packages:
                 check = subprocess.run(
                     [
-                        "docker", "run", "--rm", base,
-                        "sh", "-c",
+                        "docker",
+                        "run",
+                        "--rm",
+                        base,
+                        "sh",
+                        "-c",
                         f"apt-get update -qq 2>/dev/null && "
                         f"apt-cache show {pkg} >/dev/null 2>&1 && echo FOUND || echo MISSING",
                     ],
-                    capture_output=True, text=True, timeout=30,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
                 )
                 if "MISSING" in check.stdout:
                     missing.append(pkg)
@@ -624,7 +666,9 @@ class TestPlatformBuild:
         """Document what arch Docker uses by default on this host."""
         result = subprocess.run(
             ["docker", "run", "--rm", "alpine:latest", "uname", "-m"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         container_arch = result.stdout.strip()
         host_arch = platform.machine()
@@ -653,7 +697,8 @@ class TestMsanVariant:
         tag = sb.build_image()
         result = subprocess.run(
             ["docker", "image", "inspect", tag],
-            capture_output=True, timeout=10,
+            capture_output=True,
+            timeout=10,
         )
         assert result.returncode == 0
         sb.cleanup(remove_image=True)
@@ -700,11 +745,11 @@ class TestDeepAgentMode:
         for tool in ["valgrind", "python3", "git"]:
             result = subprocess.run(
                 ["docker", "run", "--rm", tag, "which", tool],
-                capture_output=True, text=True, timeout=15,
+                capture_output=True,
+                text=True,
+                timeout=15,
             )
-            assert result.returncode == 0, (
-                f"Deep agent tool {tool!r} not found in image {tag}"
-            )
+            assert result.returncode == 0, f"Deep agent tool {tool!r} not found in image {tag}"
         sb.cleanup(remove_image=True)
 
     @pytest.mark.integration
@@ -755,9 +800,7 @@ class TestDeepAgentMode:
                 "cd /workspace && gcc $CFLAGS -o main main.c 2>&1",
                 timeout=30,
             )
-            assert result.exit_code == 0, (
-                f"Compile failed:\n{result.stdout}\n{result.stderr}"
-            )
+            assert result.exit_code == 0, f"Compile failed:\n{result.stdout}\n{result.stderr}"
 
             # Trigger overflow
             result = container.exec(
@@ -765,8 +808,6 @@ class TestDeepAgentMode:
                 timeout=10,
             )
             combined = (result.stdout or "") + (result.stderr or "")
-            assert "AddressSanitizer" in combined, (
-                f"Expected ASan report, got:\n{combined}"
-            )
+            assert "AddressSanitizer" in combined, f"Expected ASan report, got:\n{combined}"
         finally:
             sb.cleanup(remove_image=True)

--- a/tests/test_sandbox_msan_variants.py
+++ b/tests/test_sandbox_msan_variants.py
@@ -234,25 +234,24 @@ class TestHunterSandboxVariantImages:
         )
         assert asan_tag != msan_tag
 
-    def test_dockerfile_includes_variant_comment(self, temp_c_repo):
+    def test_docker_materialization_records_sanitizer_requirements(self, temp_c_repo):
         sb = HunterSandbox(repo_path=str(temp_c_repo))
         df = sb._render_dockerfile(sanitizers=["msan", "ubsan"])
-        assert "Sanitizer variant: msan,ubsan" in df
+        assert "Sanitizer requirements: msan,ubsan" in df
 
-    def test_msan_dockerfile_has_track_origins(self, temp_c_repo):
+    def test_msan_environment_has_track_origins(self, temp_c_repo):
         sb = HunterSandbox(repo_path=str(temp_c_repo))
-        df = sb._render_dockerfile(sanitizers=["msan"])
-        assert "-fsanitize=memory" in df
-        assert "-fsanitize-memory-track-origins" in df
-        # MSan dockerfile should NOT mention ASan
-        assert "-fsanitize=address" not in df
+        environment = sb._environment_spec(["msan"]).environment
+        assert "-fsanitize=memory" in environment["CFLAGS"]
+        assert "-fsanitize-memory-track-origins" in environment["CFLAGS"]
+        assert "-fsanitize=address" not in environment["CFLAGS"]
 
-    def test_asan_dockerfile_has_no_msan_flags(self, temp_c_repo):
+    def test_asan_environment_has_no_msan_flags(self, temp_c_repo):
         sb = HunterSandbox(repo_path=str(temp_c_repo))
-        df = sb._render_dockerfile(sanitizers=["asan", "ubsan"])
-        assert "-fsanitize=address" in df
-        assert "-fsanitize=undefined" in df
-        assert "-fsanitize=memory" not in df
+        environment = sb._environment_spec(["asan", "ubsan"]).environment
+        assert "-fsanitize=address" in environment["CFLAGS"]
+        assert "-fsanitize=undefined" in environment["CFLAGS"]
+        assert "-fsanitize=memory" not in environment["CFLAGS"]
 
     def test_build_variant_images_returns_map(self, temp_c_repo, mock_docker):
         mock_docker.images.get.side_effect = Exception("not found")

--- a/tests/test_sandbox_writable_workspace.py
+++ b/tests/test_sandbox_writable_workspace.py
@@ -168,6 +168,7 @@ class TestSourceHuntSandboxCpuWiring:
             languages=["c"],
             deep_agent_mode=True,
             default_cpus=1.5,
+            gvisor_runtime=None,
         )
         assert runner.sandbox_factory is not None
         runner.sandbox_factory()

--- a/tests/test_sandbox_writable_workspace.py
+++ b/tests/test_sandbox_writable_workspace.py
@@ -122,7 +122,9 @@ class TestHunterSandboxCpuPolicy:
         manager._client = client
 
         with (
-            patch.object(HunterSandbox, "_build_variant_image", return_value="sandbox:test"),
+            patch.object(
+                HunterSandbox, "_prepare_variant_environment", return_value="sandbox:test"
+            ),
             patch.object(SandboxContainer, "start", return_value="cid"),
         ):
             sandbox = manager.spawn(scratch_mount=False)
@@ -133,7 +135,9 @@ class TestHunterSandboxCpuPolicy:
         manager = HunterSandbox(repo_path=str(tmp_path), default_cpus=1.0)
 
         with (
-            patch.object(HunterSandbox, "_build_variant_image", return_value="sandbox:test"),
+            patch.object(
+                HunterSandbox, "_prepare_variant_environment", return_value="sandbox:test"
+            ),
             patch.object(SandboxContainer, "start", return_value="cid"),
         ):
             sandbox = manager.spawn(scratch_mount=False, cpus=2.5)
@@ -317,7 +321,7 @@ class TestCopyTreeInto:
 
 
 class TestHunterSandboxWritableWorkspace:
-    @patch("clearwing.sandbox.hunter_sandbox.HunterSandbox._build_variant_image")
+    @patch("clearwing.sandbox.hunter_sandbox.HunterSandbox._prepare_variant_environment")
     @patch("clearwing.sandbox.hunter_sandbox.HunterSandbox._get_client")
     def test_spawn_writable_omits_ro_mount(self, mock_client, mock_build):
         from clearwing.sandbox.hunter_sandbox import HunterSandbox
@@ -341,7 +345,7 @@ class TestHunterSandboxWritableWorkspace:
             if container == "/workspace":
                 pytest.fail(f"Found /workspace mount with mode={mode}, expected none")
 
-    @patch("clearwing.sandbox.hunter_sandbox.HunterSandbox._build_variant_image")
+    @patch("clearwing.sandbox.hunter_sandbox.HunterSandbox._prepare_variant_environment")
     @patch("clearwing.sandbox.hunter_sandbox.HunterSandbox._get_client")
     def test_spawn_writable_calls_copy_and_git(self, mock_client, mock_build):
         from clearwing.sandbox.hunter_sandbox import HunterSandbox
@@ -373,7 +377,7 @@ class TestHunterSandboxWritableWorkspace:
         assert "rm -rf /workspace/.git" in git_calls[0][0][0]
         assert "find . -name .git -type f -delete" in git_calls[0][0][0]
 
-    def test_deep_agent_mode_adds_packages(self):
+    def test_deep_agent_mode_adds_features(self):
         from clearwing.sandbox.hunter_sandbox import HunterSandbox
 
         with patch("clearwing.sandbox.hunter_sandbox.BuildSystemDetector.detect"):
@@ -383,10 +387,10 @@ class TestHunterSandboxWritableWorkspace:
                 deep_agent_mode=True,
             )
 
-        for pkg in HunterSandbox.DEEP_AGENT_PACKAGES:
-            assert pkg in manager.extra_packages
+        for feature in HunterSandbox.DEEP_AGENT_FEATURES:
+            assert feature in manager.extra_features
 
-    @patch("clearwing.sandbox.hunter_sandbox.HunterSandbox._build_variant_image")
+    @patch("clearwing.sandbox.hunter_sandbox.HunterSandbox._prepare_variant_environment")
     @patch("clearwing.sandbox.hunter_sandbox.HunterSandbox._get_client")
     def test_spawn_writable_passes_cpus(self, mock_client, mock_build):
         from clearwing.sandbox.hunter_sandbox import HunterSandbox


### PR DESCRIPTION
## Summary

- introduce runtime-neutral sandbox backend and instance boundaries for SourceHunt
- make Clearwing request closed logical environment profiles, features, and sanitizer support instead of images, distro packages, or setup commands
- preserve Docker as the zero-configuration default, with image selection and package mapping private to that adapter
- add a synchronous, concurrent JSON-RPC 2.0 adapter over Unix sockets and inherited Unix stream socket descriptors

The hunter model does not invent environment setup. Build-system detection deterministically maps repository markers to a closed profile and feature vocabulary. Environment preparation is separate from execution: it receives no repository or secrets, while project commands run afterward in a no-network sandbox.

The public start policy is also provider-neutral. It carries SourceHunt policy, semantic isolation level, resource limits, mounts, environment, and working directory; Docker network, seccomp, capability, image, and runtime flags never cross the RPC boundary.

An fd endpoint adopts the inherited connected socket. Clearwing closes that descriptor with the RPC connection, so the supervisor keeps only its side of the socketpair and can reliably observe disconnects.

Version 1 intentionally passes approved host paths and therefore targets local or shared-filesystem supervisors. Arbitrary remote workspace transport remains outside this contract.

## Protocol

The backend prepares an environment and returns an opaque provider reference. Clearwing passes that reference back when starting a sandbox and never interprets it as an image, pod, filesystem path, or provider-native identifier.

JSON-RPC methods cover capabilities, capacity, environment ensure/release, sandbox start/exec/stop, file read/write, and tree copy. A single reader thread multiplexes concurrent synchronous calls by request id.

## Validation

- full non-Docker suite: 3,316 passed, 2 skipped
- focused sandbox/remediation suite: 175 passed
- focused Ruff checks and formatting passed
- Docker integration tests remain unavailable in this environment because no Docker daemon is present

Repository-wide Ruff and mypy have pre-existing failures outside the changed sandbox files, so they are not claimed as clean here.

## Coordination

The repository conflict-check skill was unavailable, so open pull requests were inspected manually. PR #190 has textual overlap in SourceHunt sandbox files for writable-workspace handling, but it does not introduce a competing backend/runtime abstraction.
