### PR TITLE
fix(sourcehunt): anchor rejecting verdicts to a source location

### DIFF
--- a/clearwing/sourcehunt/state.py
+++ b/clearwing/sourcehunt/state.py
@@ -235,6 +235,11 @@ class ValidatorVerdict:
     tie_breaker: str
     duplicate_cve: str | None
     raw_response: str = ""
+    # Optional source anchor for the tie_breaker: the file and 1-indexed line
+    # the verdict rests on. Populated when the model supplies it (asked for on
+    # rejection so a rejection can be located), else None.
+    tie_breaker_file: str | None = None
+    tie_breaker_line: int | None = None
     patch_oracle_attempted: bool = False
     patch_oracle_passed: bool | None = None
     patch_oracle_diff: str = ""

--- a/clearwing/sourcehunt/validator.py
+++ b/clearwing/sourcehunt/validator.py
@@ -17,7 +17,7 @@ from collections.abc import Sequence
 from itertools import islice
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from clearwing.core.event_payloads import ValidationResultPayload
 from clearwing.core.events import EventBus
@@ -106,8 +106,9 @@ If a PoC is provided, you MUST attempt to reproduce it. Report the exact result.
   "duplicate_cve": null
 }
 
-When you reject a finding, set tie_breaker_file and tie_breaker_line to the \
-exact source location your rejection rests on, so the rejection can be located.
+If you reject (advance=false), you MUST set tie_breaker_file and \
+tie_breaker_line to the exact source location your rejection rests on; the \
+response will be rejected otherwise.
 
 A finding advances ONLY if all four axes pass, or if REAL + IMPACTFUL pass \
 and TRIGGERABLE + GENERAL have confidence >= medium with stated assumptions."""
@@ -226,12 +227,28 @@ class _VerdictSchema(BaseModel):
     )
     tie_breaker_line: int | None = Field(
         default=None,
+        ge=1,
         description="1-indexed line of the tie_breaker in tie_breaker_file, or null.",
     )
     duplicate_cve: str | None = Field(
         default=None,
         description="CVE id if this duplicates a known issue, else null.",
     )
+
+    @model_validator(mode="after")
+    def _reject_requires_tie_breaker_location(self) -> _VerdictSchema:
+        # Spec 009 §3.3: a rejection (advance=False) must anchor itself in the
+        # source so the false-reject audit can locate it. Advancing verdicts may
+        # leave the fields null. Legacy verdicts read back via ValidatorVerdict
+        # (dataclass) bypass this validator, so old checkpoints still load.
+        if not self.advance and (
+            self.tie_breaker_file is None or self.tie_breaker_line is None
+        ):
+            raise ValueError(
+                "verdicts with advance=False must set tie_breaker_file "
+                "and tie_breaker_line"
+            )
+        return self
 
     def to_verdict(self, finding_id: str) -> ValidatorVerdict:
         """Map this validated wire object to the domain ValidatorVerdict.

--- a/clearwing/sourcehunt/validator.py
+++ b/clearwing/sourcehunt/validator.py
@@ -101,8 +101,13 @@ If a PoC is provided, you MUST attempt to reproduce it. Report the exact result.
   "pro_argument": "max 200 words — strongest case FOR the vulnerability",
   "counter_argument": "max 200 words — strongest case AGAINST",
   "tie_breaker": "what single piece of evidence resolved it",
+  "tie_breaker_file": "repo-relative file the tie_breaker rests on, or null",
+  "tie_breaker_line": "1-indexed line in that file, or null",
   "duplicate_cve": null
 }
+
+When you reject a finding, set tie_breaker_file and tie_breaker_line to the \
+exact source location your rejection rests on, so the rejection can be located.
 
 A finding advances ONLY if all four axes pass, or if REAL + IMPACTFUL pass \
 and TRIGGERABLE + GENERAL have confidence >= medium with stated assumptions."""
@@ -212,6 +217,17 @@ class _VerdictSchema(BaseModel):
     tie_breaker: str = Field(
         default="", description="The single piece of evidence that resolved it."
     )
+    tie_breaker_file: str | None = Field(
+        default=None,
+        description=(
+            "Repo-relative file the tie_breaker rests on. Required when rejecting "
+            "so the rejection can be located; null otherwise."
+        ),
+    )
+    tie_breaker_line: int | None = Field(
+        default=None,
+        description="1-indexed line of the tie_breaker in tie_breaker_file, or null.",
+    )
     duplicate_cve: str | None = Field(
         default=None,
         description="CVE id if this duplicates a known issue, else null.",
@@ -243,6 +259,8 @@ class _VerdictSchema(BaseModel):
             pro_argument=self.pro_argument,
             counter_argument=self.counter_argument,
             tie_breaker=self.tie_breaker,
+            tie_breaker_file=self.tie_breaker_file,
+            tie_breaker_line=self.tie_breaker_line,
             duplicate_cve=self.duplicate_cve,
             outcome="confirmed" if advance else "refuted",
         )
@@ -509,6 +527,8 @@ def apply_validator_verdict(
     finding["verifier_pro_argument"] = verdict.pro_argument
     finding["verifier_counter_argument"] = verdict.counter_argument
     finding["verifier_tie_breaker"] = verdict.tie_breaker
+    finding["verifier_tie_breaker_file"] = verdict.tie_breaker_file
+    finding["verifier_tie_breaker_line"] = verdict.tie_breaker_line
     finding["verifier_session_id"] = session_id
     finding["validation_mode"] = "v2"
 

--- a/tests/test_sourcehunt_validator.py
+++ b/tests/test_sourcehunt_validator.py
@@ -190,6 +190,8 @@ class TestResponseParsing:
             "advance": False,
             "severity": "high",
             "evidence_level": "static_corroboration",
+            "tie_breaker_file": "src/parse.c",
+            "tie_breaker_line": 42,
         })
         verdict = schema.to_verdict("hunter-abc")
         assert verdict.advance is False
@@ -251,6 +253,90 @@ class TestResponseParsing:
         assert verdict.advance is True
         assert {name for name, _ in verdict.axes.items()} == {"real", "triggerable"}
         assert verdict.axes.impactful is None
+
+    def test_reject_without_tie_breaker_file_is_rejected(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            _VerdictSchema.model_validate({
+                "axes": {
+                    "real": {"passed": False, "confidence": "high", "rationale": "guarded"},
+                    "triggerable": {"passed": True, "confidence": "high", "rationale": "yes"},
+                },
+                "advance": False,
+                "severity": "info",
+                "evidence_level": "static_corroboration",
+                "tie_breaker_line": 42,
+            })
+
+    def test_reject_without_tie_breaker_line_is_rejected(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            _VerdictSchema.model_validate({
+                "axes": {
+                    "real": {"passed": False, "confidence": "high", "rationale": "guarded"},
+                    "triggerable": {"passed": True, "confidence": "high", "rationale": "yes"},
+                },
+                "advance": False,
+                "severity": "info",
+                "evidence_level": "static_corroboration",
+                "tie_breaker_file": "src/parse.c",
+            })
+
+    def test_advance_true_needs_no_tie_breaker(self):
+        schema = _VerdictSchema.model_validate({
+            "axes": {
+                "real": {"passed": True, "confidence": "high", "rationale": "yes"},
+                "triggerable": {"passed": True, "confidence": "high", "rationale": "yes"},
+            },
+            "advance": True,
+            "severity": "low",
+            "evidence_level": "static_corroboration",
+        })
+        assert schema.tie_breaker_file is None
+        assert schema.tie_breaker_line is None
+
+    def test_reject_with_both_fields_succeeds(self):
+        schema = _VerdictSchema.model_validate({
+            "axes": {
+                "real": {"passed": False, "confidence": "high", "rationale": "guarded"},
+                "triggerable": {"passed": True, "confidence": "high", "rationale": "yes"},
+            },
+            "advance": False,
+            "severity": "info",
+            "evidence_level": "static_corroboration",
+            "tie_breaker_file": "src/parse.c",
+            "tie_breaker_line": 142,
+        })
+        assert schema.tie_breaker_file == "src/parse.c"
+        assert schema.tie_breaker_line == 142
+
+    def test_tie_breaker_line_zero_rejected(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            _VerdictSchema.model_validate({
+                "axes": {
+                    "real": {"passed": False, "confidence": "high", "rationale": "guarded"},
+                    "triggerable": {"passed": True, "confidence": "high", "rationale": "yes"},
+                },
+                "advance": False,
+                "severity": "info",
+                "evidence_level": "static_corroboration",
+                "tie_breaker_file": "src/parse.c",
+                "tie_breaker_line": 0,
+            })
+
+    def test_legacy_verdict_without_tie_breaker_still_loads(self):
+        # Legacy checkpoints read back via ValidatorVerdict (dataclass) bypass
+        # the wire-schema validator, so old rejections with no source anchor
+        # still load.
+        v = ValidatorVerdict(
+            finding_id="legacy", axes=Axes(), advance=False,
+            severity_validated=None, evidence_level="suspicion",
+            pro_argument="", counter_argument="", tie_breaker="legacy",
+            duplicate_cve=None,
+        )
+        assert v.tie_breaker_file is None
+        assert v.tie_breaker_line is None
 
     def test_schema_rejects_invalid_enums(self):
         # Constrained decoding can't emit these; assert the schema enforces them
@@ -376,6 +462,8 @@ class TestRejectedFindings:
             "advance": False,
             "severity": "high",
             "evidence_level": "static_corroboration",
+            "tie_breaker_file": "src/parse.c",
+            "tie_breaker_line": 7,
         })
         verdict = schema.to_verdict("hunter-abc")
         assert verdict.severity_validated is None

--- a/tests/test_sourcehunt_validator.py
+++ b/tests/test_sourcehunt_validator.py
@@ -196,6 +196,45 @@ class TestResponseParsing:
         assert verdict.axes.triggerable.passed is False
         assert verdict.severity_validated is None  # cleared when advance is False
 
+    def test_reject_carries_tie_breaker_location(self):
+        # A rejection may cite the source location it rests on; to_verdict and
+        # apply_validator_verdict carry it through. The fields default to None
+        # when the model omits them, so existing verdicts are unaffected.
+        schema = _VerdictSchema.model_validate({
+            "axes": {
+                "real": {"passed": False, "confidence": "high", "rationale": "guarded"},
+                "triggerable": {"passed": True, "confidence": "high", "rationale": "yes"},
+            },
+            "advance": False,
+            "severity": "info",
+            "evidence_level": "static_corroboration",
+            "tie_breaker": "length is checked before the copy",
+            "tie_breaker_file": "src/parse.c",
+            "tie_breaker_line": 142,
+        })
+        verdict = schema.to_verdict("hunter-xyz")
+        assert verdict.tie_breaker_file == "src/parse.c"
+        assert verdict.tie_breaker_line == 142
+
+        finding: dict = {}
+        apply_validator_verdict(finding, verdict)
+        assert finding["verifier_tie_breaker_file"] == "src/parse.c"
+        assert finding["verifier_tie_breaker_line"] == 142
+
+    def test_tie_breaker_location_defaults_to_none(self):
+        schema = _VerdictSchema.model_validate({
+            "axes": {
+                "real": {"passed": True, "confidence": "high", "rationale": "yes"},
+                "triggerable": {"passed": True, "confidence": "high", "rationale": "yes"},
+            },
+            "advance": True,
+            "severity": "low",
+            "evidence_level": "static_corroboration",
+        })
+        verdict = schema.to_verdict("hunter-xyz")
+        assert verdict.tie_breaker_file is None
+        assert verdict.tie_breaker_line is None
+
     def test_quick_pass_two_axes_only(self):
         # impactful/general are optional (quick-pass prompt); to_verdict maps
         # only the axes that are present.


### PR DESCRIPTION
## Summary

- Extend the validator verdict with `tie_breaker_file: str | None` and `tie_breaker_line: int | None` (`ge=1`).
- Require both fields whenever `advance` is false, enforced by a Pydantic `model_validator`.
- Ask the 4-axis prompt to set the two fields on rejection; the response will be rejected otherwise.
- Legacy verdicts without the fields still load (the fields default to `None` on the persisted dataclass).

## Problem

`tie_breaker` is free text. A rejection can cite evidence that no reader can locate, so false-reject audits fall back to reading prose. There is no mechanical way to point at "the single line the rejection rests on".

## Fix

- `_VerdictSchema`: add the two fields plus a `@model_validator(mode="after")` that raises `ValueError` when `advance is False` and either field is missing.
- `ValidatorVerdict` (state.py): mirror the two optional fields; carried through from schema in `to_verdict`.
- Prompt: one added sentence in the 4-axis instructions and two new keys in the JSON template. The 2-axis quick pass is unchanged.
- `apply_validator_verdict`: write to `finding["verifier_tie_breaker_file"]` and `finding["verifier_tie_breaker_line"]`.
- `_error_verdict` bypasses the wire schema by constructing `ValidatorVerdict` directly, so internal error paths do not need to synthesise dummy locations.

## Validation

- `uv run --frozen --extra dev pytest -q tests/test_sourcehunt_validator.py` — 45 passed; new regressions: reject without file / without line raises `ValidationError`; `advance=true` accepts missing fields; `tie_breaker_line=0` rejected; legacy verdicts without the fields still load; `apply_validator_verdict` writes both keys.
- `uv run --frozen --extra dev ruff check clearwing/sourcehunt/validator.py clearwing/sourcehunt/state.py tests/test_sourcehunt_validator.py`
- `git diff --check`

## Backward compatibility

Persisted verdicts without the new fields remain readable (the dataclass defaults to `None`). Only newly produced rejections at the wire boundary must carry a location. Producers that emit valid JSON without the fields on `advance=false` will see a `ValidationError` — this is the intended contract change, exposing silent omissions that previously slipped through as unlocatable rejections.

Independent of the other 4 PRs in this batch; trivial rebase if any lands first.
