### PR TITLE
fix(sourcehunt): make n-day filter and reveng reconstruction batch sizes configurable

### DIFF
--- a/clearwing/sourcehunt/config.py
+++ b/clearwing/sourcehunt/config.py
@@ -101,6 +101,8 @@ class HuntTuning:
     campaign_hint: str | None = None
     gvisor_runtime: str | None = None
     sandbox_cpus: float | None = None  # None = auto, 0 = unlimited
+    nday_filter_batch_size: int = 10
+    reveng_batch_size: int = 8
 
 
 @dataclass(frozen=True)

--- a/clearwing/sourcehunt/nday.py
+++ b/clearwing/sourcehunt/nday.py
@@ -78,6 +78,7 @@ class NdayPipeline:
         budget_band: str = "deep",
         project: str = "",
         output_dir: str | None = None,
+        filter_batch_size: int | None = None,
     ):
         self._llm = llm
         self._repo_path = repo_path
@@ -85,6 +86,13 @@ class NdayPipeline:
         self._sandbox_factory = sandbox_factory
         self._budget_band = budget_band
         self._project = project
+        from .config import HuntTuning
+
+        self._filter_batch_size = (
+            filter_batch_size
+            if filter_batch_size is not None
+            else HuntTuning().nday_filter_batch_size
+        )
         if output_dir is None:
             from clearwing.core.config import default_results_dir
 
@@ -102,7 +110,7 @@ class NdayPipeline:
                 except Exception:
                     logger.debug("Patch fetch failed for %s", c.cve_id, exc_info=True)
 
-        nday_filter = NdayFilter(self._llm)
+        nday_filter = NdayFilter(self._llm, batch_size=self._filter_batch_size)
         filtered = await nday_filter.afilter(candidates)
         pipeline_result.filtered_cves = len(filtered)
 

--- a/clearwing/sourcehunt/nday_filter.py
+++ b/clearwing/sourcehunt/nday_filter.py
@@ -124,15 +124,18 @@ def fetch_recent_cves(repo_path: str, days: int = 90) -> list[NdayCandidate]:
 class NdayFilter:
     """Cheap LLM-based triage to filter CVEs for exploitability."""
 
-    def __init__(self, llm):
+    def __init__(self, llm, batch_size: int = FILTER_BATCH_SIZE):
         self._llm = llm
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+        self._batch_size = batch_size
 
     async def afilter(self, candidates: list[NdayCandidate]) -> list[NdayCandidate]:
         if not candidates:
             return []
 
-        for i in range(0, len(candidates), FILTER_BATCH_SIZE):
-            batch = candidates[i:i + FILTER_BATCH_SIZE]
+        for i in range(0, len(candidates), self._batch_size):
+            batch = candidates[i:i + self._batch_size]
             await self._filter_batch(batch)
 
         return [

--- a/clearwing/sourcehunt/reveng.py
+++ b/clearwing/sourcehunt/reveng.py
@@ -95,6 +95,7 @@ class RevengPipeline:
         output_dir: str | None = None,
         project_name: str = "",
         sandbox_factory: Any = None,
+        reconstruction_batch_size: int | None = None,
     ):
         self._llm = llm
         self._binary_path = binary_path
@@ -107,6 +108,13 @@ class RevengPipeline:
         self._output_dir = output_dir
         self._project_name = project_name or os.path.basename(binary_path)
         self._sandbox_factory = sandbox_factory
+        from .config import HuntTuning
+
+        self._reconstruction_batch_size = (
+            reconstruction_batch_size
+            if reconstruction_batch_size is not None
+            else HuntTuning().reveng_batch_size
+        )
 
     async def arun(self) -> RevengResult:
         start_time = time.monotonic()
@@ -168,7 +176,9 @@ class RevengPipeline:
             result.status = "decompiled"
 
             # 5. LLM source reconstruction
-            reconstructor = RevengReconstructor(self._llm)
+            reconstructor = RevengReconstructor(
+                self._llm, batch_size=self._reconstruction_batch_size,
+            )
             result.reconstruction = await reconstructor.areconstruct(
                 result.decompilation, result.static_analysis,
             )

--- a/clearwing/sourcehunt/reveng_reconstructor.py
+++ b/clearwing/sourcehunt/reveng_reconstructor.py
@@ -74,8 +74,12 @@ class RevengReconstructor:
 
     BATCH_SIZE = RECONSTRUCTION_BATCH_SIZE
 
-    def __init__(self, llm: Any):
+    def __init__(self, llm: Any, batch_size: int | None = None):
         self._llm = llm
+        resolved = batch_size if batch_size is not None else self.BATCH_SIZE
+        if resolved <= 0:
+            raise ValueError(f"batch_size must be >= 1, got {resolved}")
+        self._batch_size = resolved
 
     async def areconstruct(
         self,
@@ -98,8 +102,8 @@ class RevengReconstructor:
         # Build shared context from static analysis
         context = self._build_context(static_info)
 
-        for i in range(0, len(prioritized), self.BATCH_SIZE):
-            batch = prioritized[i:i + self.BATCH_SIZE]
+        for i in range(0, len(prioritized), self._batch_size):
+            batch = prioritized[i:i + self._batch_size]
             reconstructed = await self._reconstruct_batch(batch, context)
             result.sources.extend(reconstructed)
 

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -686,6 +686,22 @@ def add_parser(subparsers):
         help="Budget band for --reveng hunting (default: deep)",
     )
     parser.add_argument(
+        "--nday-filter-batch-size",
+        type=int,
+        default=None,
+        help="Candidates per LLM call in the --nday filter stage "
+        "(default: 10). Shrink for smaller local models whose output "
+        "budget truncates a 10-item batch.",
+    )
+    parser.add_argument(
+        "--reveng-batch-size",
+        type=int,
+        default=None,
+        help="Functions per LLM call in the --reveng reconstruction stage "
+        "(default: 8). Shrink for smaller local models whose output "
+        "budget truncates an 8-item batch.",
+    )
+    parser.add_argument(
         "--model", default=None, help="Override all role models with one model name"
     )
     parser.add_argument(
@@ -917,6 +933,7 @@ def handle(cli, args):
             budget_band=args.nday_budget,
             project=args.repo,
             output_dir=args.output_dir,
+            filter_batch_size=args.nday_filter_batch_size,
         )
         result = asyncio.run(pipeline.arun(candidates))
 
@@ -972,6 +989,7 @@ def handle(cli, args):
             budget_band=args.reveng_budget,
             output_dir=args.output_dir,
             project_name=os.path.basename(binary_path),
+            reconstruction_batch_size=args.reveng_batch_size,
         )
         result = asyncio.run(pipeline.arun())
 

--- a/tests/test_nday.py
+++ b/tests/test_nday.py
@@ -108,6 +108,40 @@ class TestNdayFilter:
         assert len(result) == 1
 
     @pytest.mark.asyncio
+    async def test_filter_default_batch_size_single_call(self):
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.first_text = "[]"
+        mock_llm.aask_text = AsyncMock(return_value=mock_response)
+
+        nf = NdayFilter(mock_llm)
+        candidates = [NdayCandidate(cve_id=f"CVE-2024-{i:04d}") for i in range(10)]
+        await nf.afilter(candidates)
+        # 10 candidates / default batch 10 = 1 LLM call
+        assert mock_llm.aask_text.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_custom_batch_size_respected(self):
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.first_text = "[]"
+        mock_llm.aask_text = AsyncMock(return_value=mock_response)
+
+        nf = NdayFilter(mock_llm, batch_size=3)
+        candidates = [NdayCandidate(cve_id=f"CVE-2024-{i:04d}") for i in range(10)]
+        await nf.afilter(candidates)
+        # 10 candidates / batch 3 = 4 LLM calls (3+3+3+1)
+        assert mock_llm.aask_text.call_count == 4
+
+    def test_batch_size_zero_raises(self):
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            NdayFilter(AsyncMock(), batch_size=0)
+
+    def test_batch_size_negative_raises(self):
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            NdayFilter(AsyncMock(), batch_size=-1)
+
+    @pytest.mark.asyncio
     async def test_filter_llm_failure_defaults_possibly(self):
         mock_llm = AsyncMock()
         mock_llm.aask_text = AsyncMock(side_effect=RuntimeError("LLM down"))

--- a/tests/test_reveng.py
+++ b/tests/test_reveng.py
@@ -266,6 +266,34 @@ class TestRevengReconstructor:
         # 20 functions / batch_size 8 = 3 LLM calls
         assert mock_llm.aask_text.call_count == 3
 
+    @pytest.mark.asyncio
+    async def test_custom_batch_size_respected(self):
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.first_text = "[]"
+        mock_llm.aask_text = AsyncMock(return_value=mock_response)
+
+        reconstructor = RevengReconstructor(mock_llm, batch_size=4)
+        functions = [
+            DecompiledFunction(name=f"FUN_{i:08x}", decompiled_c=f"void f{i}() {{}}")
+            for i in range(10)
+        ]
+        decompilation = DecompilationResult(
+            functions=functions, total_functions=10,
+        )
+
+        await reconstructor.areconstruct(decompilation, StaticAnalysisResult())
+        # 10 functions / batch_size 4 = 3 LLM calls (4+4+2)
+        assert mock_llm.aask_text.call_count == 3
+
+    def test_batch_size_zero_raises(self):
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            RevengReconstructor(AsyncMock(), batch_size=0)
+
+    def test_batch_size_negative_raises(self):
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            RevengReconstructor(AsyncMock(), batch_size=-1)
+
 
 # --- RevengPipeline tests ----------------------------------------------------
 

--- a/tests/test_sourcehunt_config.py
+++ b/tests/test_sourcehunt_config.py
@@ -1,0 +1,54 @@
+"""Tests for SourceHuntConfig field defaults and wiring."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clearwing.sourcehunt.config import HuntTuning, SourceHuntConfig, TargetConfig
+from clearwing.sourcehunt.nday import NdayPipeline
+from clearwing.sourcehunt.nday_filter import NdayCandidate
+from clearwing.sourcehunt.reveng import RevengPipeline
+
+
+def test_hunt_tuning_batch_size_defaults():
+    t = HuntTuning()
+    assert t.nday_filter_batch_size == 10
+    assert t.reveng_batch_size == 8
+
+
+def test_hunt_tuning_batch_size_override():
+    t = HuntTuning(nday_filter_batch_size=3, reveng_batch_size=2)
+    assert t.nday_filter_batch_size == 3
+    assert t.reveng_batch_size == 2
+
+
+def test_source_hunt_config_exposes_batch_sizes_via_tuning():
+    cfg = SourceHuntConfig(target=TargetConfig(repo_url="https://example.com/repo"))
+    assert cfg.tuning.nday_filter_batch_size == 10
+    assert cfg.tuning.reveng_batch_size == 8
+
+
+@pytest.mark.asyncio
+async def test_nday_pipeline_threads_filter_batch_size():
+    mock_llm = MagicMock()
+    mock_response = MagicMock()
+    mock_response.first_text = "[]"
+    mock_llm.aask_text = AsyncMock(return_value=mock_response)
+
+    pipeline = NdayPipeline(llm=mock_llm, filter_batch_size=3)
+    candidates = [NdayCandidate(cve_id=f"CVE-2024-{i:04d}") for i in range(10)]
+    await pipeline.arun(candidates)
+    # 10 candidates / batch 3 = 4 LLM calls
+    assert mock_llm.aask_text.call_count == 4
+
+
+def test_reveng_pipeline_stores_reconstruction_batch_size():
+    pipeline = RevengPipeline(llm=MagicMock(), reconstruction_batch_size=2)
+    assert pipeline._reconstruction_batch_size == 2
+
+
+def test_reveng_pipeline_default_batch_size_from_tuning():
+    pipeline = RevengPipeline(llm=MagicMock())
+    assert pipeline._reconstruction_batch_size == HuntTuning().reveng_batch_size


### PR DESCRIPTION
## Summary

- Promote `FILTER_BATCH_SIZE` (10) and `RECONSTRUCTION_BATCH_SIZE` (8) from module constants to `HuntTuning` fields with matching CLI flags (`--nday-filter-batch-size`, `--reveng-batch-size`).
- Defaults reproduce the current batching exactly.
- Reject `batch_size <= 0` with a clear `ValueError` instead of silently dropping input.

## Problem

Both stages send fixed-size candidate batches to the model. On smaller local models with tight context, the batch can exceed the usable window and candidates at the tail are dropped without an error. Per-item scoring makes the batch size a pure context-fit knob, but it cannot be changed without editing source.

## Fix

- `HuntTuning.nday_filter_batch_size: int = 10`, `HuntTuning.reveng_batch_size: int = 8`.
- `NdayFilter.__init__(self, llm, batch_size=FILTER_BATCH_SIZE)`, `RevengReconstructor.__init__(self, llm, batch_size=None)` (falls back to `self.BATCH_SIZE` class attr for subclass compatibility).
- `NdayPipeline` and `RevengPipeline` accept the batch size and pass it through to the wrapped classes.
- CLI flags thread the value from argparse into `SourceHuntConfig` construction.
- Both `__init__`s reject `batch_size <= 0` with `ValueError("batch_size must be >= 1, got {N}")` — previously `0` raised an uncaught `range(...) step must not be zero` mid-iteration and negatives silently produced an empty loop that dropped all candidates.

## Validation

- `uv run --frozen --extra dev pytest -q tests/test_nday.py tests/test_reveng.py tests/test_sourcehunt_config.py` — 69 passed; new regressions: default batch preserved (10 items -> 1 call for filter, 8 for reveng), custom `batch_size=3` splits into 4 calls, `batch_size=0`/`-1` raise, config-driven threading verified from `HuntTuning`.
- `uv run --frozen --extra dev ruff check clearwing/sourcehunt/nday_filter.py clearwing/sourcehunt/reveng_reconstructor.py clearwing/sourcehunt/nday.py clearwing/sourcehunt/reveng.py clearwing/sourcehunt/config.py clearwing/ui/commands/sourcehunt.py`
- `git diff --check`

## Backward compatibility

Defaults reproduce the previous constants exactly. `RevengReconstructor.BATCH_SIZE` class attribute is retained so subclasses that override it continue to work (resolved at `__init__` time).

Independent of the other 4 PRs in this batch; trivial rebase if any lands first.
