### PR TITLE
fix(sourcehunt): bound machine progress records

### DIFF
--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -1384,6 +1384,7 @@ class SourceHuntRunner:
                     preprocess_result=preprocess_result,
                     files_ranked=files_ranked,
                     pipeline_status=pipeline_status,
+                    skip_detail="Run stopped after preprocess",
                 )
 
             _t = time.monotonic()
@@ -1429,6 +1430,7 @@ class SourceHuntRunner:
                     preprocess_result=preprocess_result,
                     files_ranked=files_ranked,
                     pipeline_status=pipeline_status,
+                    skip_detail="Run stopped after rank",
                 )
 
             # depth=quick exits here with the static_findings as-is
@@ -3583,8 +3585,9 @@ class SourceHuntRunner:
         preprocess_result: PreprocessResult,
         files_ranked: int,
         pipeline_status: PipelineStatus | None = None,
+        skip_detail: str = "Quick depth performs static analysis only",
     ) -> SourceHuntResult:
-        """depth=quick exit — only static findings, no LLM hunters."""
+        """Build a static-only result for quick depth or a staged early exit."""
         all_findings = self._merge_static_findings([], preprocess_result)
         target_files = [str(item.get("path") or "") for item in preprocess_result.file_targets]
         finding_files = [str(finding.file or "") for finding in all_findings]
@@ -3593,7 +3596,7 @@ class SourceHuntRunner:
         self._emit_stage(
             "hunt",
             "skipped",
-            detail="Quick depth performs static analysis only",
+            detail=skip_detail,
             files=target_files,
         )
         for stage in ("verify", "exploit"):
@@ -3601,7 +3604,7 @@ class SourceHuntRunner:
                 stage,
                 "skipped",
                 findings_so_far=len(all_findings),
-                detail="Quick depth performs static analysis only",
+                detail=skip_detail,
                 files=finding_files,
                 symbols=finding_symbols,
                 finding_ids=finding_ids,

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1397,7 +1397,9 @@ def _handle_machine(descriptor: int, *, enable_semgrep: bool = False) -> int:
                 stop_after=parsed.get("stop_after"),
                 enable_semgrep=enable_semgrep or parsed["semgrep"],
                 provider_manager=provider_manager,
-                on_progress=lambda progress: channel.emit("progress", progress),
+                on_progress=lambda progress: channel.emit(
+                    "progress", _public_progress(progress)
+                ),
             ).arun()
         )
         channel.result(_public_result(result))
@@ -1494,6 +1496,47 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
             raise ValueError(f"stop_after must be one of {sorted(valid_stages)}, got {sa!r}")
         parsed["stop_after"] = sa
     return parsed
+
+
+def _public_progress(progress: Any) -> dict[str, Any]:
+    """Project stage progress onto bounded event metadata."""
+    item = asdict(progress) if not isinstance(progress, dict) else dict(progress)
+
+    def text(key: str, maximum_bytes: int) -> str | None:
+        value = item.get(key)
+        if not isinstance(value, str) or not value:
+            return None
+        return value.encode("utf-8")[:maximum_bytes].decode("utf-8", errors="ignore")
+
+    public = {
+        "type": text("type", 64),
+        "stage": text("stage", 128),
+        "status": text("status", 128),
+        "detail": text("detail", 2048),
+        "findings_so_far": item.get("findings_so_far")
+        if isinstance(item.get("findings_so_far"), int)
+        else None,
+        "cost_usd": item.get("cost_usd")
+        if isinstance(item.get("cost_usd"), (int, float))
+        else None,
+    }
+    for source, count in (
+        ("files", "file_count"),
+        ("symbols", "symbol_count"),
+        ("finding_ids", "finding_id_count"),
+    ):
+        values = item.get(source)
+        if isinstance(values, (list, tuple, set)):
+            public[count] = len(values)
+    error = item.get("error")
+    if isinstance(error, dict):
+        for source, target in (("code", "error_code"), ("message", "error_message")):
+            value = error.get(source)
+            if isinstance(value, str) and value:
+                public[target] = value.encode("utf-8")[:1024].decode(
+                    "utf-8", errors="ignore"
+                )
+    return {key: value for key, value in public.items() if value is not None and value != ""}
 
 
 def _public_result(result: Any) -> dict[str, Any]:

--- a/clearwing/ui/machine.py
+++ b/clearwing/ui/machine.py
@@ -11,6 +11,7 @@ from typing import Any
 
 PROTOCOL_VERSION = 1
 MAX_START_BYTES = 1_048_576
+MAX_RECORD_BYTES = 1_048_576
 
 
 class MachineProtocolError(ValueError):
@@ -99,9 +100,105 @@ class MachineChannel:
             **payload,
         }
         encoded = json.dumps(record, separators=(",", ":"), ensure_ascii=False).encode()
+        original_bytes = len(encoded)
+        if len(encoded) >= MAX_RECORD_BYTES:
+            record = (
+                self._compact_terminal(record, original_bytes)
+                if terminal
+                else self._compact_progress(record, original_bytes)
+            )
+            encoded = json.dumps(
+                record, separators=(",", ":"), ensure_ascii=False
+            ).encode()
+        if len(encoded) >= MAX_RECORD_BYTES:
+            record = {
+                "v": record["v"],
+                "type": record["type"],
+                "seq": record["seq"],
+                "data": {
+                    "truncated": True,
+                    "original_bytes": original_bytes,
+                },
+            }
+            encoded = json.dumps(
+                record, separators=(",", ":"), ensure_ascii=False
+            ).encode()
         self._writer.write(encoded + b"\n")
         if terminal:
             self._terminal = True
+
+    @staticmethod
+    def _compact_progress(
+        record: dict[str, Any], original_bytes: int
+    ) -> dict[str, Any]:
+        """Keep routing fields from an oversized progress event."""
+        data = record.get("data")
+        summary: dict[str, Any] = {
+            "truncated": True,
+            "original_bytes": original_bytes,
+        }
+        if isinstance(data, dict):
+            for key in (
+                "event",
+                "stage",
+                "status",
+                "tool",
+                "finding_id",
+                "hunter_target",
+            ):
+                value = data.get(key)
+                if isinstance(value, str):
+                    summary[key] = _bounded_utf8(value, 512)
+                elif isinstance(value, (int, float, bool)) or value is None:
+                    summary[key] = value
+        record["data"] = summary
+        return record
+
+    @staticmethod
+    def _compact_terminal(
+        record: dict[str, Any], original_bytes: int
+    ) -> dict[str, Any]:
+        """Project an oversized result onto a bounded workflow-safe summary.
+
+        Large checkpoint objects are intentionally omitted here. Managed
+        SourceHunt runs persist them in their workspace, where later stages
+        reload them without crossing the machine-protocol boundary.
+        """
+        if "error" in record:
+            record["error"] = _bounded_utf8(str(record["error"]), 2048)
+            record["truncated"] = True
+            record["original_bytes"] = original_bytes
+            return record
+
+        data = record.get("data")
+        if not isinstance(data, dict):
+            record["data"] = {
+                "truncated": True,
+                "original_bytes": original_bytes,
+            }
+            return record
+
+        summary: dict[str, Any] = {
+            "truncated": True,
+            "original_bytes": original_bytes,
+        }
+        for key, value in data.items():
+            if isinstance(value, str):
+                summary[key] = _bounded_utf8(value, 2048)
+            elif isinstance(value, (int, float, bool)) or value is None:
+                summary[key] = value
+            elif isinstance(value, list):
+                summary[f"{key}_count"] = len(value)
+            elif isinstance(value, dict):
+                nested = json.dumps(
+                    value, separators=(",", ":"), ensure_ascii=False
+                ).encode()
+                if len(nested) < 4096:
+                    summary[key] = value
+                else:
+                    summary[f"{key}_keys"] = sorted(value)[:20]
+        record["data"] = summary
+        return record
 
 
 def _decode_provider_routing(value: Any, *, required: bool) -> dict[str, Any] | None:
@@ -137,3 +234,10 @@ def _jsonable(value: Any) -> Any:
     if isinstance(value, (str, int, float, bool)) or value is None:
         return value
     return str(value)
+
+
+def _bounded_utf8(value: str, maximum_bytes: int) -> str:
+    encoded = value.encode()
+    if len(encoded) <= maximum_bytes:
+        return value
+    return encoded[:maximum_bytes].decode(errors="ignore")

--- a/tests/test_machine_cli.py
+++ b/tests/test_machine_cli.py
@@ -24,7 +24,7 @@ from clearwing.providers import (
 )
 from clearwing.providers import runtime as provider_runtime
 from clearwing.ui.commands import operate, sourcehunt, tool
-from clearwing.ui.machine import MachineChannel, MachineProtocolError
+from clearwing.ui.machine import MAX_RECORD_BYTES, MachineChannel, MachineProtocolError
 
 
 def _routing(value: dict | None = None) -> dict:
@@ -304,6 +304,53 @@ def test_operate_machine_uses_host_routing_and_emits_typed_records():
     assert records[-1]["data"]["status"] == "completed"
 
 
+def test_machine_channel_compacts_oversized_progress_records():
+    parent, channel = _channel("sourcehunt", {"repo_url": "https://example.test/repo"})
+    channel.read_start()
+    channel.emit(
+        "progress",
+        {
+            "event": "hunter_status",
+            "hunter_target": "app.py",
+            "text": "x" * MAX_RECORD_BYTES,
+        },
+    )
+    channel.result({"status": "completed"})
+    channel.close()
+
+    records = _records(parent)
+    compacted = records[0]["data"]
+    assert compacted["event"] == "hunter_status"
+    assert compacted["hunter_target"] == "app.py"
+    assert compacted["truncated"] is True
+    assert compacted["original_bytes"] > MAX_RECORD_BYTES
+    assert len(json.dumps(records[0], separators=(",", ":")).encode()) < MAX_RECORD_BYTES
+
+
+def test_machine_channel_compacts_oversized_terminal_and_keeps_summary():
+    parent, channel = _channel("sourcehunt", {"repo_url": "https://example.test/repo"})
+    channel.read_start()
+    channel.result(
+        {
+            "status": "completed",
+            "files_ranked": 120,
+            "findings": [{"description": "x" * MAX_RECORD_BYTES}],
+            "checkpoint": {"result": {"files": "y" * MAX_RECORD_BYTES}},
+        }
+    )
+    channel.close()
+
+    record = _records(parent)[0]
+    compacted = record["data"]
+    assert compacted["status"] == "completed"
+    assert compacted["files_ranked"] == 120
+    assert compacted["findings_count"] == 1
+    assert compacted["checkpoint_keys"] == ["result"]
+    assert compacted["truncated"] is True
+    assert compacted["original_bytes"] > MAX_RECORD_BYTES
+    assert len(json.dumps(record, separators=(",", ":")).encode()) < MAX_RECORD_BYTES
+
+
 @dataclass
 class _Stage:
     outcome: object
@@ -404,6 +451,46 @@ def test_sourcehunt_public_result_is_bounded_and_removes_workspace_state():
     assert "session_id" not in result
     assert "repo_url" not in result
     assert "/private" not in repr(result)
+
+
+def test_sourcehunt_public_progress_keeps_counts_out_of_bulk_event_state():
+    result = sourcehunt._public_progress(
+        {
+            "type": "stage",
+            "stage": "preprocess",
+            "status": "completed",
+            "detail": "x" * 10_000,
+            "findings_so_far": 3,
+            "cost_usd": 1.25,
+            "files": [f"file-{index}.py" for index in range(1000)],
+            "symbols": [f"symbol-{index}" for index in range(500)],
+            "finding_ids": [f"finding-{index}" for index in range(25)],
+            "error": {"code": "partial", "message": "bounded message", "raw": "private"},
+            "checkpoint": {"bulk": "must not cross progress"},
+        }
+    )
+
+    assert result == {
+        "type": "stage",
+        "stage": "preprocess",
+        "status": "completed",
+        "detail": "x" * 2048,
+        "findings_so_far": 3,
+        "cost_usd": 1.25,
+        "file_count": 1000,
+        "symbol_count": 500,
+        "finding_id_count": 25,
+        "error_code": "partial",
+        "error_message": "bounded message",
+    }
+
+
+def test_sourcehunt_machine_request_preserves_deep_depth():
+    result = sourcehunt._machine_request(
+        {"repo_url": "https://example.test/repo", "depth": "deep"}
+    )
+
+    assert result["depth"] == "deep"
 
 
 def test_machine_fd_is_not_secret_bearing_argv(monkeypatch):

--- a/tests/test_sourcehunt_checkpoints.py
+++ b/tests/test_sourcehunt_checkpoints.py
@@ -698,6 +698,34 @@ def test_stop_after_hunt_returns_accumulated_hunt_result(tmp_path: Path, monkeyp
     assert result.spent_per_tier == {"A": 1.25, "B": 0.0, "C": 0.0}
 
 
+def test_stop_after_preprocess_does_not_report_quick_depth(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "sample.c").write_text("int sample(void);\n", encoding="utf-8")
+    progress = []
+    runner = SourceHuntRunner(
+        repo_url=str(repo),
+        local_path=str(repo),
+        output_dir=str(tmp_path / "results"),
+        depth="deep",
+        stop_after="preprocess",
+        enable_mechanism_memory=False,
+        enable_calibration=False,
+        enable_knowledge_graph=False,
+        on_progress=progress.append,
+    )
+    runner._preprocess_restored = False
+    monkeypatch.setattr(runner, "_preprocess", lambda: _result(repo))
+
+    result = runner.run()
+
+    skipped = [event for event in progress if event.status == "skipped"]
+    assert result.status == "completed"
+    assert skipped
+    assert {event.detail for event in skipped} == {"Run stopped after preprocess"}
+    assert "Quick depth" not in repr(progress)
+
+
 def test_stop_after_verify_returns_accumulated_verification_result(tmp_path: Path, monkeypatch):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary

- enforce the machine protocol 1 MiB outgoing-record ceiling
- project SourceHunt progress onto bounded metadata and counts instead of transporting bulk file, symbol, and finding-ID arrays
- retain bounded terminal compaction as a final safety net
- report staged early exits accurately instead of labeling deep runs as quick depth

Checkpoints remain workspace artifacts and do not cross the machine protocol.

## Why

Machine-protocol records must remain bounded regardless of repository size. SourceHunt could complete preprocessing successfully and then fail while emitting an oversized progress or result record across FD3.

Progress is observability metadata, not artifact transport. This change makes that boundary explicit and keeps progress and terminal records within the protocol ceiling.

## Validation

- 49 passed, 1 deselected in focused machine and checkpoint tests
- Ruff passed
- git diff --check passed
- live deep jq preprocess completed with a 378,808-byte filesystem checkpoint, a 1,291-byte maximum machine record, and no checkpoint in the terminal payload
- verified depth remained deep and the staged-exit detail was Run stopped after preprocess

## Open PR overlap

Reviewed the open SourceHunt PRs that touch runner.py or sourcehunt.py. They cover hunter progress limits, batch sizing, trace persistence, sandbox setup, and hunt/resume behavior; none owns the machine-record boundary or progress-event projection.