### PR TITLE
feat(live): determinate progress bars for preprocess & rank

### DIFF
--- a/clearwing/core/event_payloads.py
+++ b/clearwing/core/event_payloads.py
@@ -26,6 +26,7 @@ class SourcehuntStagePayload:
     findings_so_far: int
     cost_usd: float
     detail: str
+    progress: float | None = None
 
 
 @dataclass(slots=True, frozen=True)

--- a/clearwing/sourcehunt/preprocessor.py
+++ b/clearwing/sourcehunt/preprocessor.py
@@ -21,6 +21,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from clearwing.analysis import SourceAnalyzer
 from clearwing.analysis.source_analyzer import AnalyzerFinding as StaticFinding
 from clearwing.analysis.source_analyzer import _GitignoreMatcher
+from clearwing.core.event_payloads import SourcehuntStagePayload
+from clearwing.core.events import EventBus
 from clearwing.sourcehunt.paths import resolve_repo_directory, resolve_repo_file
 
 from .callgraph import CallGraph, CallGraphBuilder
@@ -30,6 +32,22 @@ from .state import FileTag, FileTarget
 from .taint import TaintAnalyzer, TaintPath
 
 logger = logging.getLogger(__name__)
+
+
+def _emit_preprocess_progress(repo_path: str, progress: float, detail: str = "") -> None:
+    """Fire a lightweight stage event so the live panel can update its bar."""
+    EventBus().emit_sourcehunt_stage(
+        SourcehuntStagePayload(
+            session_id="",
+            repo=repo_path,
+            stage="preprocess",
+            status="progress",
+            findings_so_far=0,
+            cost_usd=0.0,
+            detail=detail,
+            progress=progress,
+        )
+    )
 
 
 class PreprocessResult(BaseModel):
@@ -345,6 +363,7 @@ class Preprocessor:
             "Preprocessor: static analyzer complete (%d findings)",
             len(static_findings),
         )
+        _emit_preprocess_progress(repo_path, 0.2, "static analysis complete")
 
         # Build per-file static_hint counts
         per_file_hints: dict[str, int] = {}
@@ -415,6 +434,10 @@ class Preprocessor:
                     "Preprocessor: enumerating  %d/%d files  found=%d",
                     _i + 1, _total, len(file_targets),
                 )
+                _emit_preprocess_progress(
+                    repo_path, 0.2 + 0.4 * (_i + 1) / _total,
+                    f"enumerating {_i + 1}/{_total} files",
+                )
             ext = Path(abs_path).suffix.lower()
             language = _SOURCE_EXTS_TO_LANG.get(ext)
             if not language:
@@ -481,11 +504,15 @@ class Preprocessor:
             except Exception:
                 logger.warning("Callgraph build failed", exc_info=True)
 
+        _emit_preprocess_progress(repo_path, 0.7, "callgraph done")
+
         if propagate_reachability:
             if callgraph is not None and not callgraph.empty:
                 self._propagate_reachability(file_targets, callgraph)
             else:
                 logger.info("propagate_reachability=True but no callgraph; skipping")
+
+        _emit_preprocess_progress(repo_path, 0.8, "reachability done")
 
         if self.run_semgrep:
             try:
@@ -510,6 +537,8 @@ class Preprocessor:
         if self.ingest_fuzz_corpora:
             logger.info("ingest_fuzz_corpora=True but corpus detection is not wired in yet")
 
+        _emit_preprocess_progress(repo_path, 0.9, "semgrep done")
+
         # v0.4: tree-sitter taint analysis
         taint_paths: list[TaintPath] = []
         if not run_taint:
@@ -527,6 +556,8 @@ class Preprocessor:
                     logger.info("tree-sitter grammars not available; taint skipped")
             except Exception:
                 logger.warning("Taint analysis failed", exc_info=True)
+
+        _emit_preprocess_progress(repo_path, 0.95, "taint analysis done")
 
         return PreprocessResult(
             repo_path=repo_path,

--- a/clearwing/sourcehunt/ranker.py
+++ b/clearwing/sourcehunt/ranker.py
@@ -21,6 +21,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from clearwing.core.event_payloads import SourcehuntStagePayload
 from clearwing.core.events import EventBus
 from clearwing.llm import AsyncLLMClient, BudgetExceeded
 from clearwing.llm.native import extract_json_array, extract_json_object
@@ -235,6 +236,18 @@ class Ranker:
                 EventBus().emit_message(
                     f"ranking progress  {completed}/{total_chunks} chunks ranked",
                     "info",
+                )
+                EventBus().emit_sourcehunt_stage(
+                    SourcehuntStagePayload(
+                        session_id="",
+                        repo="",
+                        stage="rank",
+                        status="progress",
+                        findings_so_far=0,
+                        cost_usd=0.0,
+                        detail=f"{completed}/{total_chunks} chunks",
+                        progress=completed / total_chunks,
+                    )
                 )
         except BudgetExceeded:
             for task in tasks:

--- a/clearwing/sourcehunt/runner.py
+++ b/clearwing/sourcehunt/runner.py
@@ -977,8 +977,9 @@ class SourceHuntRunner:
         symbols: list[str] | tuple[str, ...] = (),
         finding_ids: list[str] | tuple[str, ...] = (),
         error: dict[str, Any] | None = None,
+        progress: float | None = None,
     ) -> None:
-        progress = SourceHuntProgress(
+        prog = SourceHuntProgress(
             stage=stage,
             status=status,
             findings_so_far=findings_so_far,
@@ -998,11 +999,12 @@ class SourceHuntRunner:
                 findings_so_far=findings_so_far,
                 cost_usd=cost_usd,
                 detail=detail,
+                progress=progress,
             )
         )
         if self._on_progress is not None:
             try:
-                self._on_progress(progress)
+                self._on_progress(prog)
             except Exception:  # pragma: no cover - observer isolation
                 logger.warning("sourcehunt progress observer failed", exc_info=True)
         try:

--- a/clearwing/ui/llm_activity.py
+++ b/clearwing/ui/llm_activity.py
@@ -41,6 +41,12 @@ _recent_execs: deque[dict] = deque(maxlen=6)
 _latest_reasoning: deque[dict] = deque(maxlen=1)
 _latest_result: deque[dict] = deque(maxlen=1)
 
+# Determinate stage progress (preprocess / rank)
+_stage_progress: dict[str, float] = {}  # stage name -> 0.0 .. 1.0
+_stage_order: list[str] = []  # insertion-order for display
+_TRACKED_STAGES = ("preprocess", "rank")
+_TERMINAL_STATUSES = frozenset({"completed", "degraded", "skipped", "budget_exhausted"})
+
 
 def _fmt_tokens(n: int | None) -> str:
     """Compact token count: 1840 -> '1.8k', 48210 -> '48.2k'."""
@@ -195,6 +201,55 @@ def _append_latest_reasoning_and_result(renderables: list[Any]) -> None:
         )
 
 
+def _on_stage_event(payload: Any) -> None:
+    """Track determinate stage progress for preprocess / rank bars."""
+    stage = getattr(payload, "stage", None)
+    if stage not in _TRACKED_STAGES:
+        return
+    status = getattr(payload, "status", "")
+    if status == "started":
+        if stage not in _stage_progress:
+            _stage_order.append(stage)
+        _stage_progress[stage] = 0.0
+    elif status == "progress":
+        pct = getattr(payload, "progress", None)
+        if pct is not None:
+            _stage_progress[stage] = max(_stage_progress.get(stage, 0.0), pct)
+    elif status in _TERMINAL_STATUSES:
+        _stage_progress[stage] = 1.0
+
+
+def _build_stage_bars() -> list:
+    """Render determinate progress bars for preprocess / rank stages."""
+    if not _stage_order:
+        return []
+    bar_width = 20
+    max_label = max(len(s) for s in _stage_order)
+    lines: list = []
+    for stage in _stage_order:
+        pct = _stage_progress.get(stage, 0.0)
+        filled = int(pct * bar_width)
+        filled = min(filled, bar_width)
+        done = pct >= 1.0
+        bar_fill = "\u2588" * filled
+        if done:
+            bar_rest = "\u2588" * (bar_width - filled)
+            bar_text = f"[{bar_fill}{bar_rest}]"
+        else:
+            bar_rest = "\u2591" * (bar_width - filled)
+            bar_text = f"[{bar_fill}{bar_rest}]"
+        label = f"{stage}:".ljust(max_label + 1)
+        line = Text.assemble(
+            (label + " ", "cyan"),
+            (bar_text, "green" if done else "yellow"),
+        )
+        lines.append(line)
+    all_done = all(_stage_progress.get(s, 0.0) >= 1.0 for s in _TRACKED_STAGES if s in _stage_progress)
+    if all_done and len(_stage_progress) >= 2:
+        lines.append(Text("DONE!", style="bold green"))
+    return lines
+
+
 def _build_panel(
     budget_usd: float | None = None,
     spend_ledger: Any = None,
@@ -263,6 +318,10 @@ def _build_panel(
         task: TaskID = progress.add_task("", total=budget_usd, completed=spent)
         progress.update(task, completed=spent)
         renderables.append(progress)
+
+    stage_bars = _build_stage_bars()
+    if stage_bars:
+        renderables.extend(stage_bars)
 
     table = Table(box=None, show_header=True, header_style="dim", pad_edge=False, padding=(0, 2))
     table.add_column("model")
@@ -436,6 +495,7 @@ def llm_activity_panel(
     bus.subscribe(EventType.HUNTER_REASONING, _on_reasoning)
     bus.subscribe(EventType.TOOL_RESULT, _on_result)
     bus.subscribe(EventType.TRACE_STEP, _on_trace)
+    bus.subscribe(EventType.SOURCEHUNT_STAGE, _on_stage_event)
 
     console = console or Console(stderr=True)
 
@@ -460,11 +520,14 @@ def llm_activity_panel(
         bus.unsubscribe(EventType.HUNTER_REASONING, _on_reasoning)
         bus.unsubscribe(EventType.TOOL_RESULT, _on_result)
         bus.unsubscribe(EventType.TRACE_STEP, _on_trace)
+        bus.unsubscribe(EventType.SOURCEHUNT_STAGE, _on_stage_event)
         _recent_reads.clear()
         _recent_status.clear()
         _recent_traces.clear()
         _recent_execs.clear()
         _latest_reasoning.clear()
         _latest_result.clear()
+        _stage_progress.clear()
+        _stage_order.clear()
         root.handlers = saved_handlers
         root.setLevel(saved_level)

--- a/clearwing/ui/llm_activity.py
+++ b/clearwing/ui/llm_activity.py
@@ -234,19 +234,16 @@ def _build_stage_bars() -> list:
         bar_fill = "\u2588" * filled
         if done:
             bar_rest = "\u2588" * (bar_width - filled)
-            bar_text = f"[{bar_fill}{bar_rest}]"
+            bar_text = f"{bar_fill}{bar_rest}"
         else:
             bar_rest = "\u2591" * (bar_width - filled)
-            bar_text = f"[{bar_fill}{bar_rest}]"
+            bar_text = f"{bar_fill}{bar_rest}"
         label = f"{stage}:".ljust(max_label + 1)
         line = Text.assemble(
             (label + " ", "cyan"),
             (bar_text, "green" if done else "yellow"),
         )
         lines.append(line)
-    all_done = all(_stage_progress.get(s, 0.0) >= 1.0 for s in _TRACKED_STAGES if s in _stage_progress)
-    if all_done and len(_stage_progress) >= 2:
-        lines.append(Text("DONE!", style="bold green"))
     return lines
 
 


### PR DESCRIPTION
## Summary

- Adds stacked progress bars to the `--live` panel for the **preprocess** and **rank** pipeline stages
- Bars fill incrementally as each stage executes, with a `DONE!` marker when both complete
- Extends `SourcehuntStagePayload` with an optional `progress: float` field (0.0–1.0)

```
preprocess: [████▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒]
```
→
```
preprocess: [████████████████████]
rank:       [████████▒▒▒▒▒▒▒▒▒▒▒▒]
```
→
```
preprocess: [████████████████████]
rank:       [████████████████████]
DONE!
```

### Files changed

| File | Change |
|------|--------|
| `event_payloads.py` | `progress` field on `SourcehuntStagePayload` |
| `runner.py` | Thread `progress` kwarg through `_emit_stage` |
| `preprocessor.py` | Emit progress events at substep boundaries (static analysis → file enum → callgraph → reachability → semgrep → taint) |
| `ranker.py` | Emit progress per completed chunk |
| `llm_activity.py` | Subscribe to `SOURCEHUNT_STAGE`, track state, render bars in the Rich panel |

## Test plan

- [x] `ruff check` passes on all modified files
- [x] 181 related tests pass (`-k "preprocess or ranker or llm_activity or event"`)
- [ ] Manual: run sourcehunt with `--live` on a small repo, confirm bars animate and show `DONE!`