### PR TITLE
Fix SourceHunt managed-run handoffs

### DIFF
--- a/clearwing/agent/tools/hunt/reporting.py
+++ b/clearwing/agent/tools/hunt/reporting.py
@@ -164,7 +164,7 @@ class RecordFindingInput(ToolInputModel):
     algorithm: str = ""
     crypto_attack_class: str = ""
     key_material_exposed: str = ""
-    trace: CompatibilityTraceInput | None = Field(
+    trace: CompatibilityTraceInput | str | None = Field(
         default=None,
         description=(
             "Optional compatibility dataflow trace. Steps streamed via "
@@ -264,7 +264,7 @@ def build_reporting_tools(ctx: HunterContext) -> list:
         algorithm: str = "",
         crypto_attack_class: str = "",
         key_material_exposed: str = "",
-        trace: dict | None = None,
+        trace: dict | str | None = None,
         **_: object,
     ) -> str:
         """Record a finding into the hunter's state.
@@ -300,12 +300,15 @@ def build_reporting_tools(ctx: HunterContext) -> list:
             trace: Optional compatibility trace or summary. Streamed trace
                 steps take precedence when present.
         """
+        normalized_trace: dict | None
         if isinstance(trace, str):
             try:
-                trace = json.loads(trace)
+                normalized_trace = json.loads(trace)
             except json.JSONDecodeError as exc:
                 return _tool_error("INVALID_TRACE_JSON", f"Invalid trace JSON ({exc}).")
-        explicit_steps = trace.get("steps", []) if trace else []
+        else:
+            normalized_trace = trace
+        explicit_steps = normalized_trace.get("steps", []) if normalized_trace else []
         try:
             authoritative_steps = (
                 list(ctx.trace_steps)
@@ -333,7 +336,7 @@ def build_reporting_tools(ctx: HunterContext) -> list:
                 )
             vuln_trace = VulnerabilityTrace(
                 steps=authoritative_steps,
-                summary=(trace or {}).get("summary", ""),
+                summary=(normalized_trace or {}).get("summary", ""),
             )
         except Exception as exc:
             return _tool_error(

--- a/clearwing/sourcehunt/hunter.py
+++ b/clearwing/sourcehunt/hunter.py
@@ -1614,9 +1614,22 @@ class NativeHunter:
                             "findings now. For each lead you investigated, either record_finding "
                             "if it is source-backed, or discard it only if the source affirmatively "
                             "disproves it. Do not drop leads merely because you ran out of time "
-                            "to fully verify them — record them with the evidence you have.",
+                            "to fully verify them — record them with the evidence you have. After "
+                            "any needed reporting calls complete, end the hunt with a concise final "
+                            "response containing no tool calls; that tool-free response is required "
+                            "before the step limit.",
                         )
                     )
+            final_synthesis_turn = step == self.max_steps
+            if final_synthesis_turn:
+                messages.append(
+                    ChatMessage(
+                        "user",
+                        "This is the final synthesis turn. Do not call any tools. Briefly "
+                        "summarize the completed investigation and the findings already "
+                        "recorded. If no finding was recorded, state that plainly.",
+                    )
+                )
             stop_reason = self._should_stop(step, total_cost_usd)
             if stop_reason:
                 logger.warning(
@@ -1726,8 +1739,8 @@ class NativeHunter:
                     logger.info("Hunter context summarized: %d → %d messages", pre, len(messages))
 
                 provider_name = getattr(self.llm, "provider_name", None)
-                active_tools = self.tools
-                if not self.ctx.potentials:
+                active_tools = [] if final_synthesis_turn else self.tools
+                if active_tools and not self.ctx.potentials:
                     inactive_potential_tools = {
                         "update_potential",
                         "dismiss_potential",

--- a/clearwing/ui/commands/sourcehunt.py
+++ b/clearwing/ui/commands/sourcehunt.py
@@ -1382,6 +1382,7 @@ def _handle_machine(descriptor: int, *, enable_semgrep: bool = False) -> int:
                 no_exploit=not parsed["exploit"],
                 flow=parsed["flow"],
                 agent_mode=parsed["agent_mode"],
+                campaign_hint=parsed.get("campaign_hint"),
                 no_rank=parsed["no_rank"],
                 target_files=parsed.get("target_files"),
                 target_window_lines=parsed.get("target_window_lines"),
@@ -1422,6 +1423,7 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         "exploit",
         "flow",
         "agent_mode",
+        "campaign_hint",
         "no_rank",
         "target_files",
         "target_window_lines",
@@ -1469,6 +1471,8 @@ def _machine_request(value: dict[str, Any]) -> dict[str, Any]:
         parsed["target_files"] = [
             _bounded_text(path, "target_files entry", 1024) for path in target_files
         ]
+    if "campaign_hint" in value:
+        parsed["campaign_hint"] = _bounded_text(value["campaign_hint"], "campaign_hint", 4096)
     if "target_window_lines" in value:
         parsed["target_window_lines"] = _bounded_integer(
             value["target_window_lines"], "target_window_lines", 40, 500

--- a/tests/test_deep_agent_loop.py
+++ b/tests/test_deep_agent_loop.py
@@ -73,6 +73,37 @@ def _make_hunter(agent_mode="constrained", max_steps=20, budget_usd=0.0):
 
 
 @pytest.mark.asyncio
+async def test_near_limit_synthesis_requires_a_tool_free_final_response():
+    hunter, llm = _make_hunter(agent_mode="constrained", max_steps=3)
+    llm.achat.side_effect = [
+        FakeResponse(tool_calls_list=[_make_tool_call("think", {"notes": "inspect"})]),
+        FakeResponse(tool_calls_list=[_make_tool_call("think", {"notes": "report"})]),
+        FakeResponse(text="Investigation complete."),
+    ]
+
+    with patch("clearwing.sourcehunt.hunter.HunterTrajectoryLogger") as mock_traj:
+        mock_traj.for_hunter.return_value = MagicMock()
+        result = await hunter.arun()
+
+    assert result.stop_reason == "completed"
+    second_messages = llm.achat.call_args_list[1].kwargs["messages"]
+    synthesis = next(
+        str(message.to_dict().get("content", ""))
+        for message in second_messages
+        if "approaching the end of your budget" in str(message.to_dict().get("content", ""))
+    )
+    assert "final response containing no tool calls" in synthesis
+    assert "required before the step limit" in synthesis
+    final_call = llm.achat.call_args_list[2]
+    assert final_call.kwargs["tools"] == []
+    final_messages = [message.to_dict() for message in final_call.kwargs["messages"]]
+    assert any(
+        "This is the final synthesis turn" in str(message.get("content", ""))
+        for message in final_messages
+    )
+
+
+@pytest.mark.asyncio
 async def test_hunter_reminds_model_to_preserve_articulated_potential():
     hunter, llm = _make_hunter(agent_mode="deep", max_steps=5)
     llm.achat.side_effect = [

--- a/tests/test_machine_cli.py
+++ b/tests/test_machine_cli.py
@@ -198,7 +198,11 @@ def test_sourcehunt_machine_handler_propagates_semgrep(monkeypatch):
 
         def read_start(self):
             return (
-                {"repo_url": "https://example.test/repo", "semgrep": True},
+                {
+                    "repo_url": "https://example.test/repo",
+                    "semgrep": True,
+                    "campaign_hint": "Audit the parser's length arithmetic.",
+                },
                 {"provider": {"model": "test-model"}},
             )
 
@@ -231,6 +235,22 @@ def test_sourcehunt_machine_handler_propagates_semgrep(monkeypatch):
 
     assert sourcehunt._handle_machine(7) == 0
     assert captured["runner"]["enable_semgrep"] is True
+    assert captured["runner"]["campaign_hint"] == "Audit the parser's length arithmetic."
+
+
+def test_sourcehunt_machine_request_bounds_campaign_hint():
+    parsed = sourcehunt._machine_request(
+        {
+            "repo_url": "https://example.test/repo",
+            "campaign_hint": "Audit the parser's length arithmetic.",
+        }
+    )
+    assert parsed["campaign_hint"] == "Audit the parser's length arithmetic."
+
+    with pytest.raises(ValueError, match="campaign_hint"):
+        sourcehunt._machine_request(
+            {"repo_url": "https://example.test/repo", "campaign_hint": "x" * 4097}
+        )
 
 
 def test_sourcehunt_machine_handler_honors_visible_cli_semgrep(monkeypatch):

--- a/tests/test_sourcehunt_hunter.py
+++ b/tests/test_sourcehunt_hunter.py
@@ -870,6 +870,36 @@ class TestRecordFinding:
         assert f["vulnerability_trace"]["summary"] == "input flows to memcpy unchecked"
         assert len(f["vulnerability_trace"]["steps"]) == 2
 
+    def test_accepts_stringified_compatibility_trace(self):
+        ctx = HunterContext(repo_path=str(FIXTURE_C_PROPAGATION))
+        record = next(t for t in build_hunter_tools(ctx) if t.name == "record_finding")
+
+        msg = record.invoke(
+            {
+                "file": "src/codec_a.c",
+                "line_number": 9,
+                "finding_type": "memory_safety",
+                "severity": "high",
+                "cwe": "CWE-787",
+                "description": "memcpy with unchecked length",
+                "trace": json.dumps(
+                    {
+                        "steps": [
+                            {"file": "src/codec_a.c", "line": 3, "note": "ENTRY: input"},
+                            {"file": "src/codec_a.c", "line": 9, "note": "SINK: memcpy"},
+                        ],
+                        "summary": "input flows to memcpy unchecked",
+                    }
+                ),
+            }
+        )
+
+        assert "Finding recorded" in msg
+        assert len(ctx.findings) == 1
+        assert ctx.findings[0]["vulnerability_trace"]["summary"] == (
+            "input flows to memcpy unchecked"
+        )
+
     def test_seeded_from_crash_flag(self):
         ctx = HunterContext(
             repo_path=str(FIXTURE_C_PROPAGATION),


### PR DESCRIPTION
## Summary

- forward a bounded campaign hint from the machine request into SourceHuntRunner
- accept compatibility traces emitted as JSON strings and normalize them before use
- reserve the final hunter turn for a tool-free synthesis so successful work is not lost at the step boundary

## Stack

- Depends on #206.
- The PR base is the #206 branch so this review contains only the extracted six-file Clearwing delta.
- Merge #206 before this PR; after #206 lands, retarget this PR to main if GitHub does not do so automatically.

## Validation

- Focused regression suites: 125 passed
- Ruff lint on all six changed files: passed
- Wheel and sdist build plus twine validation: passed
- Full non-strict suite: 3,328 passed, 2 skipped; 7 Docker integration tests failed because no Docker socket was available

The repository-wide gate is already red on the #206 base before this delta: 114 Ruff violations in unrelated code, 168 scoped mypy errors, and strict pytest collection rejects the unregistered integration marker. The extracted regression suites pass under strict configuration when selected directly.

## Conflict and architecture scan

- Simulated merges are clean with #200, #201, and #203 through #207, including the direct reporting overlap in #205.
- #202 has one content conflict in NativeHunter.arun because both branches edit termination control. The intended integration is to retain #202 steps_since_progress stop argument and this PR final-synthesis injection plus tool suppression; the behaviors are complementary.
- #190 has broader conflicts in the hunter and machine command and is already merge-dirty against main. It represents a much larger parallel SourceHunt lifecycle change and needs dedicated reconciliation if revived; this focused fix intentionally does not absorb that architecture.