### PR TITLE
chore: ignore local .claude settings directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ working-directory/
 
 # uv run inspect eval ...
 logs/
+
+# Local Claude Code settings
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore` so machine-local Claude Code settings (e.g. `.claude/settings.local.json`) are not tracked in the repository.